### PR TITLE
GCBI: remove assertion on Dispatcher != nullptr

### DIFF
--- a/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
+++ b/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
@@ -100,8 +100,6 @@ bool GeneratedCodeBasicInfo::runOnModule(Module &M) {
     }
   }
 
-  revng_assert(Dispatcher != nullptr);
-
   if (auto *NamedMD = M.getNamedMetadata("revng.csv")) {
     auto *Tuple = cast<MDTuple>(NamedMD->getOperand(0));
     for (const MDOperand &Operand : Tuple->operands()) {


### PR DESCRIPTION
This assertion was executed in the `runOnModule` method of the GCBI pass, but it is too strict.

Asserting that `Dispatcher != nullptr` during the execution of the pass prevents the pass from successfully running on a Module without aDispatcher.
This is unfortunate, because some passes that depend on GCBI in revng-c actually do that. They do so because they are not really interested in the Dispatcher at all. They only use GCBI to access information on the Stack Pointer.

In fact, the check for `Dispatcher != nullptr` is already performed also in the `dispatcher()` method which is the sane thing to do. This commit removes the assertion from the `runOnModule` method and leaves it in the `dispatcher` method.
This allows to run the pass successfully even on a Module without the Dispatcher, while not changing the contract of this pass (i.e. that when you call the `dispatcher` method you get a nonnull pointer).