### PR TITLE
Add RecursiveCoroutine headers and tests

### DIFF
--- a/include/revng/ADT/RecursiveCoroutine-coroutine.h
+++ b/include/revng/ADT/RecursiveCoroutine-coroutine.h
@@ -1,0 +1,191 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <experimental/coroutine>
+#include <optional>
+
+#include "revng/Support/Assert.h"
+
+struct PromiseBase {
+
+  auto initial_suspend() const { return std::experimental::suspend_always(); }
+  auto final_suspend() const noexcept {
+    return std::experimental::suspend_always();
+  }
+
+  [[noreturn]] void unhandled_exception() const { std::terminate(); }
+
+  PromiseBase *Callee = nullptr;
+};
+
+template<typename ReturnT = void>
+struct [[nodiscard("RecursiveCoroutine is discarded without running "
+                   "it")]] RecursiveCoroutine {
+public:
+  struct promise_type;
+
+public:
+  using coro_handle = std::experimental::coroutine_handle<promise_type>;
+
+public:
+  RecursiveCoroutine(coro_handle H) : OwnedHandle(H) {}
+  RecursiveCoroutine() : RecursiveCoroutine(coro_handle{}) {}
+
+  // Not copyable, because we don't want OwnedHandle to be destroyed twice
+  RecursiveCoroutine &operator=(const RecursiveCoroutine &);
+  RecursiveCoroutine(const RecursiveCoroutine &);
+
+  // Movable, but we clean up the OwnedHandle, because we don't want it to be
+  // destroyed twice in the destructor
+  RecursiveCoroutine &operator=(RecursiveCoroutine &&Other) {
+    this->OwnedHandle = Other.OwnedHandle;
+    Other.OwnedHandle = {};
+    return *this;
+  }
+  RecursiveCoroutine(RecursiveCoroutine && Other) { *this = std::move(Other); }
+
+  ~RecursiveCoroutine() {
+    revng_assert(OwnedHandle and OwnedHandle.done());
+    OwnedHandle.destroy();
+    OwnedHandle = {};
+  }
+
+  bool await_ready() const { return false; }
+
+  // TODO: I wanted to do something like the following
+  //
+  // template<typename CallerReturnT>
+  // void await_suspend(std::coroutine_handle<RecursiveCoroutine<CallerReturnT>>
+  //                    CallerHandle)
+  //
+  // but I had to fight the template parameter type inference engine and I gave
+  // up. This is also likely a good spot to constraint CallerCoroHandleT with
+  // C++20 concepts, but not today.
+  template<typename CallerCoroHandleT>
+  void await_suspend(CallerCoroHandleT CallerHandle) {
+    revng_assert(CallerHandle and not CallerHandle.done());
+    revng_assert(OwnedHandle and not OwnedHandle.done());
+    CallerHandle.promise().Callee = &OwnedHandle.promise();
+  }
+
+  ReturnT await_resume() {
+    revng_assert(OwnedHandle and OwnedHandle.done());
+    if constexpr (std::is_same_v<ReturnT, void>) {
+      return;
+    } else {
+      return OwnedHandle.promise().get();
+    }
+  }
+
+  ReturnT run() {
+    revng_assert(OwnedHandle);
+
+    // If the result is already available, use it!
+    if (OwnedHandle.done())
+      return OwnedHandle.promise().get();
+
+    using recursive_handle = std::experimental::coroutine_handle<PromiseBase>;
+    std::vector<PromiseBase *> Stack;
+
+    Stack.push_back(&OwnedHandle.promise());
+
+    while (not Stack.empty()) {
+      PromiseBase &CurrentPromise = *Stack.back();
+      auto CurrentHandle = recursive_handle::from_promise(CurrentPromise);
+      revng_assert(CurrentHandle);
+
+      // Resume the coroutine that's on top of the Stack.
+      // This will either suspend at the final suspension point of the current
+      // coroutine on top of the stack, or after setting a handle to a new
+      // recursive coroutine ready for execution in the promise object of the
+      // current coroutine on top of the stack.
+      CurrentHandle.resume();
+
+      if (CurrentHandle.done()) {
+        // The coroutine that we have just resumed has terminated its execution
+        // and is suspended at its final suspension point. It has not pushed
+        // anything else on top of the stack, so we can pop this.
+        Stack.pop_back();
+
+      } else {
+
+        // The coroutine that we have just resumed has suspended its execution
+        // and we can find a non-owning handle to the callee inside its promise
+        // object.
+
+        revng_assert(CurrentHandle and CurrentHandle.promise().Callee);
+        PromiseBase *CalleePromise = CurrentHandle.promise().Callee;
+        revng_assert(CalleePromise);
+
+        // Push the callee handle on top of the stack for resumption.
+        Stack.push_back(CalleePromise);
+      }
+    }
+
+    revng_assert(OwnedHandle and OwnedHandle.done());
+
+    return OwnedHandle.promise().get();
+  }
+
+private:
+  coro_handle OwnedHandle;
+};
+
+template<>
+struct RecursiveCoroutine<void>::promise_type : public PromiseBase {
+
+  RecursiveCoroutine<void> get_return_object() {
+    return RecursiveCoroutine<void>(coro_handle::from_promise(*this));
+  }
+
+  [[noreturn]] static RecursiveCoroutine<void>
+  get_return_object_on_allocation_failure() {
+    std::terminate();
+    // TODO: if we need this not to be a hard crash we could do the following
+    // return RecursiveCoroutine<void>();
+  }
+
+  void return_void() const { return; }
+  void get() const {}
+};
+
+template<typename ReturnT>
+struct RecursiveCoroutine<ReturnT>::promise_type : public PromiseBase {
+
+  RecursiveCoroutine<ReturnT> get_return_object() {
+    return RecursiveCoroutine<ReturnT>(coro_handle::from_promise(*this));
+  }
+
+  [[noreturn]] static RecursiveCoroutine<ReturnT>
+  get_return_object_on_allocation_failure() {
+    std::terminate();
+    // TODO: if we need this not to be a hard crash we could do the following
+    // return RecursiveCoroutine<ReturnT>();
+  }
+
+  void return_value(ReturnT R) {
+    revng_assert(not CurrValue.has_value());
+    CurrValue = std::move(R);
+    return;
+  }
+
+  ReturnT get() const {
+    revng_assert(CurrValue.has_value());
+    return *CurrValue;
+  }
+
+protected:
+  std::optional<ReturnT> CurrValue = std::nullopt;
+};
+
+template<typename CoroutineT, typename... Args>
+auto rc_run(CoroutineT F, Args... Arguments) {
+  return F(Arguments...).run();
+}
+
+#define rc_return co_return
+
+#define rc_recur co_await

--- a/include/revng/ADT/RecursiveCoroutine-fallback.h
+++ b/include/revng/ADT/RecursiveCoroutine-fallback.h
@@ -1,0 +1,17 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+template<typename ReturnT = void>
+using RecursiveCoroutine = ReturnT;
+
+template<typename CoroutineT, typename... Args>
+auto rc_run(CoroutineT F, Args... Arguments) {
+  return F(Arguments...);
+}
+
+#define rc_return return
+
+#define rc_recur

--- a/include/revng/ADT/RecursiveCoroutine.h
+++ b/include/revng/ADT/RecursiveCoroutine.h
@@ -1,0 +1,15 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#if defined(DISABLE_RECURSIVE_COROUTINES)
+
+#include "RecursiveCoroutine-fallback.h"
+
+#else
+
+#include "RecursiveCoroutine-coroutine.h"
+
+#endif

--- a/tests/unit/DepthFirstVisit.h
+++ b/tests/unit/DepthFirstVisit.h
@@ -1,0 +1,264 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <deque>
+#include <iterator>
+#include <queue>
+#include <set>
+
+#include "llvm/ADT/iterator_range.h"
+
+#include "revng/ADT/RecursiveCoroutine.h"
+#include "revng/Support/Assert.h"
+
+class Node {
+private:
+  size_t Index;
+  const char *Name;
+  std::vector<Node *> Children;
+  std::vector<Node *> Parents;
+
+public:
+  Node(size_t Index, const char *Name) : Index(Index), Name(Name) {}
+  size_t index() const { return Index; }
+  const char *name() const { return Name; }
+  const std::vector<Node *> &children() const { return Children; }
+  void addChild(Node *NewChild) {
+    Children.push_back(NewChild);
+    NewChild->Parents.push_back(this);
+  }
+
+  Node *getRandomParent() const {
+    return Parents[static_cast<unsigned long int>(random()) % Parents.size()];
+  }
+};
+
+class Graph {
+private:
+  std::deque<Node> Nodes;
+  Node *Root;
+
+public:
+  Graph() : Nodes(), Root(newNode()) {}
+
+  size_t size() const { return Nodes.size(); }
+
+  Node *root() { return Root; }
+  Node *newNode(const char *Name = nullptr) {
+    Nodes.emplace_back(Nodes.size(), Name);
+    return &Nodes.back();
+  }
+  Node *getRandom() {
+    return &Nodes[static_cast<unsigned long>(random()) % Nodes.size()];
+  }
+};
+
+inline Graph createSimpleGraph() {
+  Graph SimpleGraph;
+  Node *Root = SimpleGraph.root();
+  auto *Left = SimpleGraph.newNode("Left");
+  auto *Right = SimpleGraph.newNode("Right");
+  auto *Post = SimpleGraph.newNode("Post");
+  auto *PostPost = SimpleGraph.newNode("PostPost");
+  Root->addChild(Left);
+  Root->addChild(Right);
+  Right->addChild(Post);
+  Left->addChild(Post);
+  Post->addChild(PostPost);
+  return SimpleGraph;
+}
+
+inline Graph createRandomGraph() {
+  Graph Result;
+  srandom(1);
+
+  enum Action { NewChildren, LinkToRandom, LinkToUncle, Stop };
+
+  auto GetRandomAction = []() {
+    const long int NewChildrenLikelyhood = 20;
+    const long int LinkToRandomLikelyhood = 5;
+    const long int LinkToUncleLikelyhood = 5;
+    const long int StopLikelyhood = 5;
+    const long int Total = NewChildrenLikelyhood + LinkToRandomLikelyhood
+                           + StopLikelyhood + LinkToUncleLikelyhood;
+    const long int Random = random() % Total;
+    if (Random < NewChildrenLikelyhood)
+      return NewChildren;
+    else if (Random < NewChildrenLikelyhood + LinkToRandomLikelyhood)
+      return LinkToRandom;
+    else if (Random < NewChildrenLikelyhood + LinkToRandomLikelyhood
+                        + LinkToUncleLikelyhood)
+      return LinkToRandom;
+    else
+      return Stop;
+  };
+
+  std::queue<Node *> ToProcess;
+  ToProcess.push(Result.root());
+
+  while (!ToProcess.empty() and Result.size() < 300) {
+    Node *Current = ToProcess.front();
+    ToProcess.pop();
+
+    Action CurrentAction = GetRandomAction();
+    while (CurrentAction != Stop) {
+      switch (CurrentAction) {
+      case NewChildren: {
+        Node *NewNode = Result.newNode();
+        ToProcess.push(NewNode);
+        Current->addChild(NewNode);
+        break;
+      }
+      case LinkToRandom:
+        Current->addChild(Result.getRandom());
+        break;
+      case LinkToUncle:
+        Current->getRandomParent()->addChild(Current);
+        break;
+      case Stop:
+        revng_abort();
+      }
+
+      CurrentAction = GetRandomAction();
+    }
+  }
+
+  return Result;
+}
+
+extern size_t MaxDepth;
+extern size_t Iterations;
+
+struct Entry {
+  using iterator = std::vector<Node *>::const_iterator;
+  Node *CurNode = nullptr;
+  bool FirstVisit = true;
+  iterator ChildNext;
+  iterator ChildEnd;
+};
+
+inline void iterativeFindMaxDepth(std::vector<Entry> &Stack) {
+  while (not Stack.empty()) {
+    revng_assert(nullptr != Stack.back().CurNode);
+
+    // The first time we visit a node, we increment the Iterations, we detect if
+    // we're closing a loop with something else already on the stack, and we
+    // increment MaxDepth.
+
+    Entry &CurrentEntry = Stack.back();
+
+    if (CurrentEntry.FirstVisit) {
+      CurrentEntry.FirstVisit = false;
+
+      ++Iterations;
+
+      bool Skip = false;
+      for (const Entry &E : llvm::make_range(Stack.begin(), --Stack.end())) {
+        if (E.CurNode == CurrentEntry.CurNode) {
+          Skip = true;
+          break;
+        }
+      }
+
+      if (Skip) {
+        Stack.pop_back();
+        continue;
+      }
+
+      MaxDepth = std::max(MaxDepth, Stack.size());
+
+      continue;
+    }
+
+    if (CurrentEntry.ChildNext != CurrentEntry.ChildEnd) {
+      // Visit the next children
+      Node *Child = *CurrentEntry.ChildNext;
+      auto &Children = Child->children();
+      ++CurrentEntry.ChildNext;
+      Stack.push_back(Entry{ Child, true, Children.begin(), Children.end() });
+    } else {
+      // We're done visiting all the children of the node, pop it
+      Stack.pop_back();
+    }
+  }
+}
+
+inline RecursiveCoroutine<> findMaxDepth(std::vector<Node *> &RCS) {
+  revng_check(not RCS.empty() and nullptr != RCS.back());
+  Node *Current = RCS.back();
+  ++Iterations;
+
+  revng_assert(RCS.size() != 0);
+  for (const Node *N : llvm::make_range(RCS.begin(), --RCS.end())) {
+    if (N == Current) {
+      RCS.pop_back();
+      rc_return;
+    }
+  }
+
+  MaxDepth = std::max(MaxDepth, RCS.size());
+
+  size_t ChildIndex = 0;
+  for (Node *Child : Current->children()) {
+    RCS.emplace_back(Child);
+    rc_recur findMaxDepth(RCS);
+    ++ChildIndex;
+  }
+
+  RCS.pop_back();
+  rc_return;
+}
+
+inline RecursiveCoroutine<size_t>
+findMaxDepthRet(Node *Current, std::set<Node *> &Stack) {
+  size_t MaxChildDepth = 0ULL;
+  for (Node *Child : Current->children()) {
+    auto [_, New] = Stack.insert(Child);
+    if (New)
+      MaxChildDepth = std::max(MaxChildDepth,
+                               rc_recur findMaxDepthRet(Child, Stack));
+  }
+
+  size_t CurrDepth = MaxChildDepth + 1;
+  Stack.erase(Current);
+  rc_return CurrDepth;
+}
+
+inline size_t iterativeFindMaxRet(Node *Root, std::set<Node *> &Stack) {
+
+  using iterator = std::vector<Node *>::const_iterator;
+  std::vector<std::tuple<Node *, iterator, size_t>> IterativeStack;
+  size_t Max = 0ULL;
+
+  IterativeStack.push_back({ Root, Root->children().begin(), 0ULL });
+
+  while (not IterativeStack.empty()) {
+    auto &[Current, ChildIt, MaxChildDepth] = IterativeStack.back();
+
+    if (ChildIt != Current->children().end()) {
+
+      Node *Child = *ChildIt;
+      ++ChildIt;
+
+      if (Stack.insert(Child).second)
+        IterativeStack.push_back({ Child, Child->children().begin(), 0ULL });
+
+    } else {
+
+      size_t CurDepth = MaxChildDepth + 1;
+      Stack.erase(Current);
+      Max = std::max(Max, CurDepth);
+      IterativeStack.pop_back();
+
+      if (not IterativeStack.empty()) {
+        auto &OldMax = std::get<2>(IterativeStack.back());
+        OldMax = std::max(OldMax, CurDepth);
+      }
+    }
+  }
+
+  return Max;
+}

--- a/tests/unit/SimpleRecursiveCoroutine.h
+++ b/tests/unit/SimpleRecursiveCoroutine.h
@@ -1,0 +1,38 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <iostream>
+#include <vector>
+
+#include "revng/ADT/RecursiveCoroutine.h"
+
+struct MyState {
+  int Depth;
+};
+
+inline RecursiveCoroutine<int> get10() {
+  rc_return 10;
+}
+
+inline RecursiveCoroutine<> my_coroutine(std::vector<MyState> &RCS, int x) {
+  int X = 1;
+  std::cerr << "Pre " << x << ':';
+  RCS.back().Depth = x;
+
+  for (const MyState &S : RCS) {
+    std::cerr << ' ' << S.Depth;
+  }
+  std::cerr << std::endl;
+
+  if (x < (rc_recur get10())) {
+    RCS.emplace_back();
+    rc_recur my_coroutine(RCS, x + 1);
+  }
+
+  std::cerr << "Post " << x << ' ' << X << std::endl;
+  RCS.pop_back();
+  rc_return;
+}

--- a/tests/unit/UnitTests.cmake
+++ b/tests/unit/UnitTests.cmake
@@ -215,3 +215,43 @@ target_link_libraries(test_genericgraph
   ${LLVM_LIBRARIES})
 add_test(NAME test_genericgraph COMMAND ./bin/test_genericgraph)
 set_tests_properties(test_genericgraph PROPERTIES LABELS "unit")
+
+
+#
+# test_recursive_coroutines
+#
+
+revng_add_private_executable(test_recursive_coroutines "${SRC}/recur.cpp")
+target_compile_definitions(test_recursive_coroutines
+  PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_include_directories(test_recursive_coroutines
+  PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_recursive_coroutines
+  revngSupport
+  ${LLVM_LIBRARIES})
+add_test(NAME test_recursive_coroutines COMMAND ./bin/test_recursive_coroutines)
+set_tests_properties(test_recursive_coroutines PROPERTIES LABELS "unit")
+
+revng_add_private_executable(test_recursive_coroutines_fallback "${SRC}/recur.cpp")
+target_compile_definitions(test_recursive_coroutines_fallback
+  PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_include_directories(test_recursive_coroutines_fallback
+  PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_recursive_coroutines_fallback
+  revngSupport
+  ${LLVM_LIBRARIES})
+add_test(NAME test_recursive_coroutines_fallback COMMAND ./bin/test_recursive_coroutines_fallback)
+set_tests_properties(test_recursive_coroutines_fallback PROPERTIES LABELS "unit")
+set_target_properties(test_recursive_coroutines_fallback PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DDISABLE_RECURSIVE_COROUTINES" )
+
+revng_add_private_executable(test_recursive_coroutines_iterative "${SRC}/recur.cpp")
+target_compile_definitions(test_recursive_coroutines_iterative
+  PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_include_directories(test_recursive_coroutines_iterative
+  PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_recursive_coroutines_iterative
+  revngSupport
+  ${LLVM_LIBRARIES})
+add_test(NAME test_recursive_coroutines_iterative COMMAND ./bin/test_recursive_coroutines_iterative)
+set_tests_properties(test_recursive_coroutines_iterative PROPERTIES LABELS "unit")
+set_target_properties(test_recursive_coroutines_iterative PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DITERATIVE" )

--- a/tests/unit/recur.cpp
+++ b/tests/unit/recur.cpp
@@ -1,0 +1,139 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <chrono>
+#include <experimental/coroutine>
+#include <functional>
+#include <iostream>
+#include <vector>
+
+// TODO: increase height up to explosion
+// TODO: compare performance and peak memory
+
+#include "revng/ADT/RecursiveCoroutine.h"
+#include "revng/Support/Assert.h"
+
+#include "DepthFirstVisit.h"
+#include "SimpleRecursiveCoroutine.h"
+
+size_t MaxDepth = 0;
+size_t Iterations = 0;
+
+int main(int, char *[]) {
+
+  //
+  // Run a simple recursive coroutine
+  //
+  std::vector<MyState> MyStateRCS;
+  MyStateRCS.emplace_back();
+  rc_run(my_coroutine, MyStateRCS, 0);
+
+  //
+  // Visit a simple graph
+  //
+  Graph SimpleGraph = createSimpleGraph();
+#ifdef ITERATIVE
+
+  std::vector<Entry> ThisRCS;
+
+  auto *Root = SimpleGraph.root();
+  auto &Children = Root->children();
+
+  ThisRCS.emplace_back(Entry{ Root, true, Children.begin(), Children.end() });
+  iterativeFindMaxDepth(ThisRCS);
+
+#else
+
+  std::vector<Node *> ThisRCS;
+  // findMaxDepth expects the RCS to already contain the state for the first
+  // element
+  ThisRCS.emplace_back(SimpleGraph.root());
+  // run the coroutine
+  rc_run(findMaxDepth, ThisRCS);
+
+#endif
+
+  std::cerr << "MaxDepth: " << MaxDepth << std::endl;
+  std::cerr << "Iterations: " << Iterations << std::endl;
+  revng_check(MaxDepth == 4);
+  revng_check(Iterations == 7);
+
+  //
+  // Visit a complex graph
+  //
+  Graph G = createRandomGraph();
+
+  using namespace std::chrono;
+  using us = long long;
+  const us Repeat = 1;
+  us Average = 0;
+
+  for (size_t I = 0; I < Repeat; I++) {
+    Iterations = 0;
+    MaxDepth = 0;
+
+    auto Start = high_resolution_clock::now();
+#ifdef ITERATIVE
+
+    std::vector<Entry> Stack;
+
+    auto *Root = G.root();
+    auto &Children = Root->children();
+
+    Stack.emplace_back(Entry{ Root, true, Children.begin(), Children.end() });
+    iterativeFindMaxDepth(Stack);
+
+#else
+
+    std::vector<Node *> RCS;
+    // findMaxDepth expects the RCS to already contain the state for the first
+    // element
+    RCS.emplace_back(G.root());
+    // run the coroutine
+    rc_run(findMaxDepth, RCS);
+
+#endif
+    auto End = high_resolution_clock::now();
+
+    if (I != 0) {
+      Average += (duration_cast<microseconds>(End - Start).count() / Repeat);
+    }
+
+    std::cerr << "MaxDepth: " << MaxDepth << std::endl;
+    std::cerr << "Iterations: " << Iterations << std::endl;
+    revng_check(MaxDepth == 31);
+    revng_check(Iterations == 1227752);
+  }
+
+  std::cout << "Average: " << Average << std::endl;
+  Average = 0LL;
+
+  for (size_t I = 0; I < Repeat; I++) {
+    Iterations = 0;
+    MaxDepth = 0;
+
+    size_t X = 0ULL;
+    std::set<Node *> Stack;
+
+    auto Start = high_resolution_clock::now();
+#ifdef ITERATIVE
+
+    X = iterativeFindMaxRet(G.root(), Stack);
+
+#else
+
+    X = rc_run(findMaxDepthRet, G.root(), Stack);
+
+#endif
+    auto End = high_resolution_clock::now();
+
+    if (I != 0) {
+      Average += (duration_cast<microseconds>(End - Start).count() / Repeat);
+    }
+
+    revng_check(X == 34);
+  }
+
+  std::cout << "Average: " << Average << std::endl;
+}


### PR DESCRIPTION
RecursiveCoroutines are a facility intended to be used as-drop in replacement of recursive functions.

They provide the following features.
- They can be written almost as regular recursive functions, with 4 caveats.
  1. A recursive coroutine that returns a type `T`, needs to be declared to return a `RecursiveCoroutine<T>`.
  2. Inside the body of a recursive coroutine, when recursively calling another recursive coroutine, the recursive call needs to be prepended by the new keywork `rc_recur`.
  3. Inside the body of a recursive coroutine, the `return` statement needs to be substituted with `rc_return`.
  4. When launching a recursive coroutine `A` from a function that is not a recursive coroutine, `A` needs to be called with the provided dedicated template wrapper `rc_run`. The syntax is the following `rc_run(A, arg0, arg1, ...)`. This is necessary to enable swapping off recursive coroutine and fall back to regular recursion for debug. See below for how to do it.
- Unlike regular recursive functions, they don't use the system stack for recursion. They use a custom heap-allocated stack to manage recursion. This makes them more robust for implementing recursive functions that manipulate user-defined input, because they are much less likely to trigger stack overflow.
- They can be turned off compiling with `-DDISABLE_RECURSIVE_COROUTINES`, falling back to regular recursion, for debug purposes.
- They support both direct and indirect recursion, i.e. a recursive coroutine A can recursively call itself, or it can recursively call another recursive coroutine B, which in turns recursively calls A.