### PR TITLE
Enable generation and installation of .clang-format file from check-revng-conventions script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,18 +150,27 @@ set(VERSION 0.0.0)
 configure_file(runtime/support.c "${CMAKE_BINARY_DIR}/share/revng/support.c" COPYONLY)
 configure_file(runtime/support.h "${CMAKE_BINARY_DIR}/share/revng/support.h" COPYONLY)
 configure_file(include/revng/Runtime/commonconstants.h "${CMAKE_BINARY_DIR}/share/revng/commonconstants.h" COPYONLY)
+
+install(FILES
+  "${CMAKE_BINARY_DIR}/share/revng/support.c"
+  "${CMAKE_BINARY_DIR}/share/revng/support.h"
+  "${CMAKE_BINARY_DIR}/share/revng/commonconstants.h"
+  DESTINATION share/revng)
+
 configure_file(runtime/early-linked.c "${CMAKE_BINARY_DIR}/share/revng/early-linked.c" COPYONLY)
+
 configure_file(scripts/revng "${CMAKE_BINARY_DIR}/bin/revng")
 configure_file(scripts/revng-merge-dynamic "${CMAKE_BINARY_DIR}/bin/revng-merge-dynamic" COPYONLY)
 install(PROGRAMS
   "${CMAKE_BINARY_DIR}/bin/revng"
-  scripts/revng-merge-dynamic
-  scripts/check-revng-conventions
+  "${CMAKE_BINARY_DIR}/bin/revng-merge-dynamic"
   DESTINATION bin)
-install(FILES runtime/support.c DESTINATION share/revng)
-install(FILES runtime/support.h DESTINATION share/revng)
-install(FILES include/revng/Runtime/commonconstants.h DESTINATION share/revng)
-install(FILES scripts/clang-format-style-file DESTINATION share/revng)
+
+configure_file(scripts/check-revng-conventions "${CMAKE_BINARY_DIR}/bin/check-revng-conventions" COPYONLY)
+install(PROGRAMS "${CMAKE_BINARY_DIR}/bin/check-revng-conventions" DESTINATION bin)
+
+configure_file(scripts/clang-format-style-file "${CMAKE_BINARY_DIR}/share/revng/clang-format-style-file" COPYONLY)
+install(FILES "${CMAKE_BINARY_DIR}/share/revng/clang-format-style-file" DESTINATION share/revng)
 
 # Remove -rdynamic
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,22 @@ install(PROGRAMS "${CMAKE_BINARY_DIR}/bin/check-revng-conventions" DESTINATION b
 configure_file(scripts/clang-format-style-file "${CMAKE_BINARY_DIR}/share/revng/clang-format-style-file" COPYONLY)
 install(FILES "${CMAKE_BINARY_DIR}/share/revng/clang-format-style-file" DESTINATION share/revng)
 
+# Custom command to create .clang-format file from check-revng-conventions
+add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/share/revng/.clang-format"
+  DEPENDS
+    "${CMAKE_BINARY_DIR}/bin/check-revng-conventions"
+    "${CMAKE_BINARY_DIR}/share/revng/clang-format-style-file"
+  COMMAND "${CMAKE_BINARY_DIR}/bin/check-revng-conventions"
+  ARGS
+    --print-clang-format-config
+    >
+    "${CMAKE_BINARY_DIR}/share/revng/.clang-format"
+)
+
+add_custom_target(clang-format-dot-file ALL DEPENDS "${CMAKE_BINARY_DIR}/share/revng/.clang-format" )
+
+install(FILES "${CMAKE_BINARY_DIR}/share/revng/.clang-format" DESTINATION share/revng)
+
 # Remove -rdynamic
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -95,6 +95,11 @@ while [[ $# > 0 ]]; do
             print_usage
             exit 1
             ;;
+        -*)
+            echo "Error: unrecognized option $key" > /dev/stderr
+            print_usage
+            exit 1
+            ;;
         *)
             break
             ;;

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -70,7 +70,6 @@ USE_CLANG_FORMAT_FILE="0"
 
 PRINT_CLANG_FORMAT_CONFIG="0"
 
-
 while [[ $# > 0 ]]; do
     key="$1"
     case $key in
@@ -106,14 +105,6 @@ while [[ $# > 0 ]]; do
     esac
 done
 
-if [[ $# -eq 0 ]]; then
-    FILES="$(git ls-files | grep -E '\.(c|cc|cpp|h|hpp)$')"
-else
-    FILES="$@"
-fi
-
-GREP="git grep -n --color=always"
-
 CLANG_FORMAT_STYLE_FILE="$SCRIPT_PATH/clang-format-style-file"
 if ! test -e "$CLANG_FORMAT_STYLE_FILE"; then
     CLANG_FORMAT_STYLE_FILE="$SCRIPT_PATH/../share/revng/clang-format-style-file"
@@ -128,6 +119,22 @@ CLANG_FORMAT_STYLE=$(cat "$CLANG_FORMAT_STYLE_FILE")
 if test "$USE_CLANG_FORMAT_FILE" -gt 0; then
     CLANG_FORMAT_STYLE=file
 fi
+
+# If the user passed the --print-clang-format-config, dump the config and exit
+# with success.
+if test "$PRINT_CLANG_FORMAT_CONFIG" -gt 0; then
+        clang-format --dry-run -style="$CLANG_FORMAT_STYLE" --dump-config
+        exit 0
+fi
+
+
+if [[ $# -eq 0 ]]; then
+    FILES="$(git ls-files | grep -E '\.(c|cc|cpp|h|hpp)$')"
+else
+    FILES="$@"
+fi
+
+GREP="git grep -n --color=always"
 
 # Run clang-format on FILES
 function run_clang_format() {
@@ -192,14 +199,6 @@ function run_revng_checks() {
     done
 
 }
-
-# If the user passed the --print-clang-format-config, dump the config and exit
-# with success.
-if test "$PRINT_CLANG_FORMAT_CONFIG" -gt 0; then
-        clang-format --dry-run -style="$CLANG_FORMAT_STYLE" --dump-config
-        exit 0
-fi
-
 
 # First, run the checks and output warnings in a human readable format.
 run_clang_format

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -4,13 +4,51 @@
 # This file is distributed under the MIT License. See LICENSE.md for details.
 #
 
+set -e
+
+function print_usage() {
+            cat > /dev/stderr << END_USAGE_TEXT
+SYNOPSIS
+   $0 [--help] [--force-format] [FILE...]
+
+DESCRIPTION
+   Checks that the files specified in FILE... respect the rev.ng coding
+   conventions, and prints all the violations.
+
+   If the FILE... arguments are missing, checks that all the C++ source files in
+   the project that have already been added to the git repository project
+   respect the rev.ng coding conventions.
+
+
+OPTIONS
+   --help
+       Prints this help and exit
+
+   --force-format
+       In addition to checking the rev.ng coding conventions on the specified
+       files, uses clang-format to try to enforce the coding conventions
+       automatically.
+       If this fails, exit with failure, otherwise exit with success.
+       WARNING: using this option will overwrite your files, make sure to backup
+       important stuff.
+
+    FILE
+      List of filenames of the files for which you want to check the rev.ng
+      coding conventions.
+
+RETURN VALUES
+   On success exit code is 0.
+   On failure, i.e. if there is at least one file that is not respecting the
+   coding conventions, exit code is 1.
+END_USAGE_TEXT
+}
+
 SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 FORCE_FORMAT="0"
 
 USE_CLANG_FORMAT_FILE="0"
 
-set -e
 
 while [[ $# > 0 ]]; do
     key="$1"
@@ -23,12 +61,14 @@ while [[ $# > 0 ]]; do
             USE_CLANG_FORMAT_FILE="1"
             shift # past argument
             ;;
+        --help)
+            print_usage
+            exit 0
+            ;;
         --*)
-            echo "Unexpected option $key" > /dev/stderr
-            echo > /dev/stderr
-            echo "Usage: $0 [--force-format] [FILE...]" > /dev/stderr
+            echo "Error: unrecognized option $key" > /dev/stderr
+            print_usage
             exit 1
-            shift
             ;;
         *)
             break

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -50,6 +50,11 @@ OPTIONS
 
       See clang-format documentation for more details.
 
+    --print-clang-format-config
+      Print the clang-format configuration to stdout, ignoring all the other
+      arguments except for --use-local-clang-format-file.
+      The conventions are not checked.
+
 RETURN VALUES
    On success exit code is 0.
    On failure, i.e. if there is at least one file that is not respecting the
@@ -63,10 +68,16 @@ FORCE_FORMAT="0"
 
 USE_CLANG_FORMAT_FILE="0"
 
+PRINT_CLANG_FORMAT_CONFIG="0"
+
 
 while [[ $# > 0 ]]; do
     key="$1"
     case $key in
+        --print-clang-format-config)
+            PRINT_CLANG_FORMAT_CONFIG="1"
+            shift # past argument
+            ;;
         --force-format)
             FORCE_FORMAT="1"
             shift # past argument
@@ -176,6 +187,14 @@ function run_revng_checks() {
     done
 
 }
+
+# If the user passed the --print-clang-format-config, dump the config and exit
+# with success.
+if test "$PRINT_CLANG_FORMAT_CONFIG" -gt 0; then
+        clang-format --dry-run -style="$CLANG_FORMAT_STYLE" --dump-config
+        exit 0
+fi
+
 
 # First, run the checks and output warnings in a human readable format.
 run_clang_format

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -9,7 +9,8 @@ set -e
 function print_usage() {
             cat > /dev/stderr << END_USAGE_TEXT
 SYNOPSIS
-   $0 [--help] [--force-format] [FILE...]
+   $0 [--help] [--force-format] [--use-local-clang-format-file] [FILE...]
+
 
 DESCRIPTION
    Checks that the files specified in FILE... respect the rev.ng coding
@@ -35,6 +36,19 @@ OPTIONS
     FILE
       List of filenames of the files for which you want to check the rev.ng
       coding conventions.
+
+    --use-local-clang-format-file
+      By default, clang-format is executed with a hard-coded configuration that
+      should apply to all the projects under the rev.ng umbrella.
+      When this option is passed, the hard-coded configuration is ignored, and
+      clang-format looks for configuration in a .clang-format file in the
+      current directory or in its parent directories.
+
+      This allows to use different clang-format configuration on per-project
+      basis, in cases where the hard-coded configuration does not fit (e.g Qt
+      projects where Qt coding conventions are a better fit).
+
+      See clang-format documentation for more details.
 
 RETURN VALUES
    On success exit code is 0.

--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -9,14 +9,14 @@ set -e
 function print_usage() {
             cat > /dev/stderr << END_USAGE_TEXT
 SYNOPSIS
-   $0 [--help] [--force-format] [--use-local-clang-format-file] [FILE...]
+   $0 [<options>] [FILES...]
 
 
 DESCRIPTION
-   Checks that the files specified in FILE... respect the rev.ng coding
+   Checks that the files specified in FILES... respect the rev.ng coding
    conventions, and prints all the violations.
 
-   If the FILE... arguments are missing, checks that all the C++ source files in
+   If the FILES... arguments are missing, checks that all the C++ source files in
    the project that have already been added to the git repository project
    respect the rev.ng coding conventions.
 
@@ -32,10 +32,6 @@ OPTIONS
        If this fails, exit with failure, otherwise exit with success.
        WARNING: using this option will overwrite your files, make sure to backup
        important stuff.
-
-    FILE
-      List of filenames of the files for which you want to check the rev.ng
-      coding conventions.
 
     --use-local-clang-format-file
       By default, clang-format is executed with a hard-coded configuration that
@@ -54,6 +50,10 @@ OPTIONS
       Print the clang-format configuration to stdout, ignoring all the other
       arguments except for --use-local-clang-format-file.
       The conventions are not checked.
+
+    FILES
+      List of filenames of the files for which you want to check the rev.ng
+      coding conventions.
 
 RETURN VALUES
    On success exit code is 0.


### PR DESCRIPTION
This patchest introduces the following changes
- Adds the `--help` flag to the `check-revng-conventions` script
- Improves the error reporting of the `check-revng-conventions` script, printing a manual similar to a man page (we could think of making a real man page sooner or later)
- Enables to run the `check-revng-conventions` script outside of a git directory (this enables running it from the build directory)
- Adds the `--print-clang-format-config` flag to the `check-revng-conventions` script, to dump to stdout a file that can be used as a valid `.clang-format` style file for `clang-format`
- Uses this newly introduced option to create and install a common `.clang-format` file that can be used by all projects adopting the rev.ng coding conventions. The typical envisioned usage is that the developers of each project that depends on `revng` and adopts its coding conventions can create a `.clang-format` symlink in the source directory of the project, referencing the `.clang-format` file generated and installed in this way. This enables IDEs and other dev tools to pick the style file easily while at the same time keeping it up-to-date automatically when `revng` is updated.