### PR TITLE
Upgrade to llvm-11

### DIFF
--- a/include/revng/BasicAnalyses/AdvancedValueInfo.h
+++ b/include/revng/BasicAnalyses/AdvancedValueInfo.h
@@ -797,7 +797,7 @@ public:
         }
       }
 
-      APInt Value(getTypeSize(DL, Current->getType()), 0);
+      APInt Value(Entry.value().getBitWidth(), 0);
       if (not Current->isNullValue())
         Value = cast<ConstantInt>(skipCasts(Current))->getValue();
 

--- a/include/revng/Support/IRHelpers.h
+++ b/include/revng/Support/IRHelpers.h
@@ -7,6 +7,7 @@
 #include <queue>
 #include <set>
 #include <sstream>
+#include <string>
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
@@ -383,7 +384,7 @@ inline std::string getName(const llvm::Function *F) {
     return "(nullptr)";
 
   if (F->hasName())
-    return F->getName();
+    return std::string(F->getName());
 
   std::stringstream SS;
   SS << "0x" << std::hex << intptr_t(F);
@@ -716,7 +717,7 @@ inline const llvm::Function *getCallee(const llvm::Instruction *I) {
 
   using namespace llvm;
   if (auto *Call = dyn_cast<CallInst>(I))
-    return llvm::dyn_cast<Function>(skipCasts(Call->getCalledValue()));
+    return llvm::dyn_cast<Function>(skipCasts(Call->getCalledOperand()));
   else
     return nullptr;
 }
@@ -726,7 +727,7 @@ inline llvm::Function *getCallee(llvm::Instruction *I) {
 
   using namespace llvm;
   if (auto *Call = dyn_cast<CallInst>(I))
-    return llvm::dyn_cast<Function>(skipCasts(Call->getCalledValue()));
+    return llvm::dyn_cast<Function>(skipCasts(Call->getCalledOperand()));
   else
     return nullptr;
 }

--- a/include/revng/Support/ProgramCounterHandler.h
+++ b/include/revng/Support/ProgramCounterHandler.h
@@ -266,7 +266,7 @@ private:
 
 protected:
   static llvm::StoreInst *
-  store(llvm::IRBuilder<> Builder, llvm::GlobalVariable *GV, uint64_t Value) {
+  store(llvm::IRBuilder<> &Builder, llvm::GlobalVariable *GV, uint64_t Value) {
     using namespace llvm;
     auto *Type = cast<IntegerType>(GV->getType()->getPointerElementType());
     return Builder.CreateStore(ConstantInt::get(Type, Value), GV);

--- a/include/revng/Support/revng.h
+++ b/include/revng/Support/revng.h
@@ -314,11 +314,6 @@ private:
   llvm::ArrayRef<const char> BasicBlockEndingPattern;
 };
 
-// TODO: move me somewhere more appropriate
-inline bool startsWith(std::string String, std::string Prefix) {
-  return String.substr(0, Prefix.size()) == Prefix;
-}
-
 /// \brief Simple helper function asserting a pointer is not a `nullptr`
 template<typename T>
 inline T *notNull(T *Pointer) {

--- a/lib/FunctionIsolation/EnforceABI.cpp
+++ b/lib/FunctionIsolation/EnforceABI.cpp
@@ -341,7 +341,7 @@ void EnforceABIImpl::run() {
         if (Call == nullptr or isMarker(Call))
           continue;
 
-        Value *CalledValue = Call->getCalledValue();
+        Value *CalledValue = Call->getCalledOperand();
         Function *Callee = cast_or_null<Function>(skipCasts(CalledValue));
 
         if (Callee != nullptr and Callee->isIntrinsic())
@@ -576,7 +576,7 @@ EnforceABIImpl::handleFunction(Function &F) {
 
 void EnforceABIImpl::handleHelperFunctionCall(CallInst *Call) {
   using namespace StackAnalysis;
-  Function *Helper = cast<Function>(skipCasts(Call->getCalledValue()));
+  Function *Helper = cast<Function>(skipCasts(Call->getCalledOperand()));
 
   auto UsedCSVs = GeneratedCodeBasicInfo::getCSVUsedByHelperCall(Call);
   UsedCSVs.sort();
@@ -650,7 +650,7 @@ void EnforceABIImpl::handleHelperFunctionCall(CallInst *Call) {
 }
 
 void EnforceABIImpl::handleRegularFunctionCall(CallInst *Call) {
-  Function *Callee = cast<Function>(skipCasts(Call->getCalledValue()));
+  Function *Callee = cast<Function>(skipCasts(Call->getCalledOperand()));
   bool IsDirect = (Callee != FunctionDispatcher);
   if (IsDirect)
     Callee = OldToNew.at(Callee);

--- a/lib/StackAnalysis/ABIIR.h
+++ b/lib/StackAnalysis/ABIIR.h
@@ -254,7 +254,6 @@ public:
   const_reverse_iterator rend() const { return Instructions.rend(); }
 
   llvm::BasicBlock *basicBlock() const { return BB; }
-  llvm::StringRef getName() const { return ::getName(BB); }
 
   void
   dump(const llvm::Module *M, const char *Prefix = "") const debug_function {

--- a/lib/UnitTestHelpers/DotGraphObject.cpp
+++ b/lib/UnitTestHelpers/DotGraphObject.cpp
@@ -167,7 +167,7 @@ void DotGraph::parseDotImpl(std::ifstream &F, llvm::StringRef EntryName) {
 void DotGraph::parseDotFromFile(llvm::StringRef FileName,
                                 llvm::StringRef EntryName) {
   std::ifstream DotFile;
-  DotFile.open(FileName);
+  DotFile.open(FileName.data());
 
   // Check that the file has been opened.
   if (DotFile.is_open()) {

--- a/tests/unit/FilteredGraphTraits.cpp
+++ b/tests/unit/FilteredGraphTraits.cpp
@@ -129,7 +129,7 @@ end:
   // #### Depth first visits ####
 
   std::vector<BasicBlock *> DefaultResults;
-  std::vector<std::string> DefaultResultsNames{
+  std::vector<llvm::StringRef> DefaultResultsNames{
     "initial_block", "starter", "end", "false", "_xit",
   };
   { // Baseline, on unfiltered graph
@@ -141,7 +141,7 @@ end:
   }
 
   { // Do-nothing filter
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block", "starter", "end", "false", "_xit",
     };
     std::vector<BasicBlock *> Results;
@@ -153,7 +153,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter all, leaving no edge
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block",
     };
     std::vector<BasicBlock *> Results;
@@ -165,7 +165,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter throwing away all the eges towards BB with name without 'a's
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "false",
@@ -181,7 +181,7 @@ end:
   }
   { // Filter throwing away all the eges towards BB with name without 'e's
     // All but _xit should reached, in this order
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "end",
@@ -199,7 +199,7 @@ end:
   // #### Breadth first visits ####
 
   { // Baseline, on unfiltered graph
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block", "starter", "end", "false", "_xit",
     };
     std::vector<BasicBlock *> Results;
@@ -210,7 +210,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Do-nothing filter
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block", "starter", "end", "false", "_xit",
     };
     std::vector<BasicBlock *> Results;
@@ -222,7 +222,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter all, leaving no edge
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block",
     };
     std::vector<BasicBlock *> Results;
@@ -239,7 +239,7 @@ end:
     for (auto &It : llvm::breadth_first(NPFG(F)))
       Results.push_back(It);
     // Only the initial_block, starter, and false should be left
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "false",
@@ -249,7 +249,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter throwing away all the eges towards BB with name without 'e's
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "end",
@@ -266,7 +266,7 @@ end:
 
   // #### Inverse depth first visits ####
   {
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
       "false",
       "starter",
@@ -280,7 +280,7 @@ end:
       revng_check(Results[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Do-nothing filter
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
       "false",
       "starter",
@@ -302,7 +302,7 @@ end:
       revng_check(SecondResults[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter all, leaving no edge
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
     };
     std::vector<BasicBlock *> FirstResults, SecondResults;
@@ -321,7 +321,7 @@ end:
       revng_check(SecondResults[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter throwing away all the eges towards BB with name without 'a's
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
     };
     std::vector<BasicBlock *> FirstResults, SecondResults;
@@ -340,7 +340,7 @@ end:
       revng_check(SecondResults[I]->getName() == ExpectedResultsNames[I]);
   }
   { // Filter throwing away all the eges towards BB with name without 'e's
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
       "false",
       "starter",
@@ -363,7 +363,7 @@ end:
   }
 
   // #### Dominator and PostDominator Trees ####
-  std::map<std::string, BasicBlock *> NamesToBlocks;
+  std::map<llvm::StringRef, BasicBlock *> NamesToBlocks;
   revng_check(DefaultResults.size() == DefaultResultsNames.size());
   for (size_t I = 0ULL; I < DefaultResults.size(); ++I)
     NamesToBlocks[DefaultResultsNames[I]] = DefaultResults[I];
@@ -478,10 +478,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block", "starter", "end", "false", "_xit",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, AlwaysTrueEdge<DotGraph *>>;
     for (auto &It : llvm::depth_first(EFG(&Input)))
@@ -498,10 +498,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, AlwaysFalseEdge<DotGraph *>>;
     for (auto &It : llvm::depth_first(EFG(&Input)))
@@ -518,12 +518,12 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "false",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, EdgeHasLetterInName<'a'>>;
     for (auto &It : llvm::depth_first(EFG(&Input)))
@@ -540,13 +540,13 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "end",
       "false",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, EdgeHasLetterInName<'e'>>;
     for (auto &It : llvm::depth_first(EFG(&Input)))
@@ -566,10 +566,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block", "starter", "end", "false", "_xit",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, AlwaysTrueEdge<DotGraph *>>;
     for (auto &It : llvm::breadth_first(EFG(&Input)))
@@ -586,10 +586,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "initial_block",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, AlwaysFalseEdge<DotGraph *>>;
     for (auto &It : llvm::breadth_first(EFG(&Input)))
@@ -606,12 +606,12 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "false",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, EdgeHasLetterInName<'a'>>;
     for (auto &It : llvm::breadth_first(EFG(&Input)))
@@ -628,13 +628,13 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames = {
+    std::vector<llvm::StringRef> ExpectedResultsNames = {
       "initial_block",
       "starter",
       "end",
       "false",
     };
-    std::vector<std::string> Results;
+    std::vector<llvm::StringRef> Results;
 
     using EFG = EdgeFilteredGraph<DotGraph *, EdgeHasLetterInName<'e'>>;
     for (auto &It : llvm::breadth_first(EFG(&Input)))
@@ -653,13 +653,13 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
       "starter",
       "initial_block",
       "false",
     };
-    std::vector<std::string> FirstResults, SecondResults;
+    std::vector<llvm::StringRef> FirstResults, SecondResults;
 
     using EFG = EdgeFilteredGraph<DotNode *, AlwaysTrueEdge<DotNode *>>;
     using InvEFG = llvm::Inverse<EFG>;
@@ -686,10 +686,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
     };
-    std::vector<std::string> FirstResults, SecondResults;
+    std::vector<llvm::StringRef> FirstResults, SecondResults;
 
     using EFG = EdgeFilteredGraph<DotNode *, AlwaysFalseEdge<DotNode *>>;
     using InvEFG = llvm::Inverse<EFG>;
@@ -697,13 +697,13 @@ end:
     DotNode *Exit = Input.getNodeByName("end");
 
     for (auto &It : llvm::depth_first(InvEFG(Exit)))
-      FirstResults.push_back(It->getName());
+      FirstResults.push_back(std::string(It->getName()));
     revng_check(FirstResults.size() == ExpectedResultsNames.size());
     for (size_t I = 0; I < FirstResults.size(); ++I)
       revng_check(FirstResults[I] == ExpectedResultsNames[I]);
 
     for (auto &It : llvm::inverse_depth_first(EFG(Exit)))
-      SecondResults.push_back(It->getName());
+      SecondResults.push_back(std::string(It->getName()));
     revng_check(SecondResults.size() == ExpectedResultsNames.size());
     for (size_t I = 0; I < SecondResults.size(); ++I)
       revng_check(SecondResults[I] == ExpectedResultsNames[I]);
@@ -716,10 +716,10 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
     };
-    std::vector<std::string> FirstResults, SecondResults;
+    std::vector<llvm::StringRef> FirstResults, SecondResults;
 
     using EFG = EdgeFilteredGraph<DotNode *, EdgeHasLetterInName<'a'>>;
     using InvEFG = llvm::Inverse<EFG>;
@@ -746,13 +746,13 @@ end:
     FileName += "001.dot";
     Input.parseDotFromFile(FileName, "initial_block");
 
-    std::vector<std::string> ExpectedResultsNames{
+    std::vector<llvm::StringRef> ExpectedResultsNames{
       "end",
       "starter",
       "initial_block",
       "false",
     };
-    std::vector<std::string> FirstResults, SecondResults;
+    std::vector<llvm::StringRef> FirstResults, SecondResults;
 
     using EFG = EdgeFilteredGraph<DotNode *, EdgeHasLetterInName<'e'>>;
     using InvEFG = llvm::Inverse<EFG>;

--- a/tools/revng-lift/AdvancedValueInfoPass.h
+++ b/tools/revng-lift/AdvancedValueInfoPass.h
@@ -121,7 +121,7 @@ AdvancedValueInfoPass::run(llvm::Function &F,
 
   for (User *U : Marker->users()) {
     auto *Call = dyn_cast<CallInst>(U);
-    if (Call == nullptr or skipCasts(Call->getCalledValue()) != Marker
+    if (Call == nullptr or skipCasts(Call->getCalledOperand()) != Marker
         or Call->getParent()->getParent() != &F)
       continue;
 

--- a/tools/revng-lift/DropHelperCallsPass.h
+++ b/tools/revng-lift/DropHelperCallsPass.h
@@ -133,7 +133,7 @@ DropHelperCallsPass::run(llvm::Function &F, llvm::FunctionAnalysisManager &) {
     for (Instruction &I : BB) {
 
       if (auto *Call = getCallToHelper(&I)) {
-        auto *Callee = cast<Function>(skipCasts(Call->getCalledValue()));
+        auto *Callee = cast<Function>(skipCasts(Call->getCalledOperand()));
 
         Builder.SetInsertPoint(Call);
 

--- a/tools/revng-lift/ExternalJumpsHandler.cpp
+++ b/tools/revng-lift/ExternalJumpsHandler.cpp
@@ -68,7 +68,7 @@ BasicBlock *ExternalJumpsHandler::createReturnFromExternal() {
 
       } else {
 
-        std::string AsmString = Arch.readRegisterAsm();
+        auto AsmString = std::string(Arch.readRegisterAsm());
         replace(AsmString, "REGISTER", Register.name());
         std::stringstream ConstraintStringStream;
         ConstraintStringStream << "*m,~{},~{dirflag},~{fpsr},~{flags}";
@@ -128,7 +128,7 @@ BasicBlock *ExternalJumpsHandler::createSerializeAndJumpOut() {
     if (CSV == nullptr)
       continue;
 
-    string AsmString = Arch.writeRegisterAsm();
+    auto AsmString = std::string(Arch.readRegisterAsm());
     replace(AsmString, "REGISTER", Register.name());
     std::stringstream ConstraintStringStream;
     ConstraintStringStream << "*m,~{" << Register.name().data()
@@ -170,7 +170,7 @@ llvm::BasicBlock *ExternalJumpsHandler::createSetjmp(BasicBlock *FirstReturn,
   IRBuilder<> Builder(SetjmpBB);
 
   // Call setjmp
-  llvm::Constant *SetjmpFunction = TheModule.getFunction("setjmp");
+  llvm::Function *SetjmpFunction = TheModule.getFunction("setjmp");
   auto *SetJmpTy = SetjmpFunction->getType()->getPointerElementType();
   auto *JmpBuf = CE::getPointerCast(TheModule.getGlobalVariable("jmp_buffer"),
                                     SetJmpTy->getFunctionParamType(0));
@@ -232,7 +232,7 @@ ExternalJumpsHandler::createExternalDispatcher(BasicBlock *IsExecutable,
                                                BasicBlock *IsNotExecutable) {
   buildExecutableSegmentsList();
 
-  Constant *IsExecutableFunction = TheModule.getFunction("is_executable");
+  Function *IsExecutableFunction = TheModule.getFunction("is_executable");
   BasicBlock *ExternalJumpHandler = BasicBlock::Create(Context,
                                                        "dispatcher.external",
                                                        &TheFunction);

--- a/tools/revng-lift/InstructionTranslator.cpp
+++ b/tools/revng-lift/InstructionTranslator.cpp
@@ -868,7 +868,7 @@ IT::translateOpcode(PTCOpcode Opcode,
 
       Pointer = Builder.CreateIntToPtr(InArguments[0],
                                        MemoryType->getPointerTo());
-      auto *Load = Builder.CreateAlignedLoad(Pointer, Alignment);
+      auto *Load = Builder.CreateAlignedLoad(Pointer, MaybeAlign(Alignment));
       Value *Loaded = Load;
 
       if (BSwapFunction != nullptr)
@@ -889,7 +889,7 @@ IT::translateOpcode(PTCOpcode Opcode,
       if (BSwapFunction != nullptr)
         Value = Builder.CreateCall(BSwapFunction, Value);
 
-      Builder.CreateAlignedStore(Value, Pointer, Alignment);
+      Builder.CreateAlignedStore(Value, Pointer, MaybeAlign(Alignment));
 
       return v{};
     } else {

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -1242,7 +1242,7 @@ void JumpTargetManager::aliasAnalysis() {
   for (const GlobalVariable *CSV : CSVs) {
     CSVAliasInfo &AliasInfo = CSVAliasInfoMap[CSV];
 
-    std::string Name = CSV->getName();
+    std::string Name = std::string(CSV->getName());
     MDNode *CSVScope = MDB.createAliasScope(Name, CSVDomain);
     AliasInfo.AliasScope = CSVScope;
     AllCSVScopes.push_back(CSVScope);
@@ -1709,7 +1709,7 @@ void JumpTargetManager::harvestWithAVI() {
   StructType *MetaAddressStruct = MetaAddress::getStruct(M);
   for (User *U : AVIMarker->users()) {
     auto *Call = dyn_cast<CallInst>(U);
-    if (Call == nullptr or skipCasts(Call->getCalledValue()) != AVIMarker)
+    if (Call == nullptr or skipCasts(Call->getCalledOperand()) != AVIMarker)
       continue;
 
     // Get the ID from the marker, and then the original instruction and marker

--- a/tools/revng-lift/VariableManager.cpp
+++ b/tools/revng-lift/VariableManager.cpp
@@ -184,7 +184,7 @@ VariableManager::VariableManager(Module &TheModule,
       if (Param->isPointerTy())
         Structs.insert(dyn_cast<StructType>(Param->getPointerElementType()));
 
-    if (startsWith(HelperFunction.getName(), HelperPrefix)
+    if (HelperFunction.getName().startswith(HelperPrefix)
         && HelperFunction.getFunctionType()->getNumParams() > 1) {
 
       for (Type *Candidate : HelperType->params()) {
@@ -633,7 +633,7 @@ Value *VariableManager::getOrCreate(unsigned TemporaryId, bool Reading) {
     // Basically we use fixed_reg to detect "env"
     if (Temporary->fixed_reg == 0) {
       Value *Result = getByCPUStateOffset(EnvOffset + Temporary->mem_offset,
-                                          StringRef(Temporary->name));
+                                          Temporary->name);
       revng_assert(Result != nullptr);
       return Result;
     } else {
@@ -691,7 +691,10 @@ Value *VariableManager::getOrCreate(unsigned TemporaryId, bool Reading) {
 Value *VariableManager::computeEnvAddress(Type *TargetType,
                                           Instruction *InsertBefore,
                                           unsigned Offset) {
-  auto *LoadEnv = new LoadInst(Env, "", InsertBefore);
+
+  auto *EnvPtrTy = cast<PointerType>(Env->getType());
+  auto *PointeeTy = EnvPtrTy->getElementType();
+  auto *LoadEnv = new LoadInst(PointeeTy, Env, "", InsertBefore);
   Type *EnvType = Env->getType()->getPointerElementType();
   Value *Integer = LoadEnv;
   if (Offset != 0)


### PR DESCRIPTION
This patch upgrades revng to compile with llvm-11.

Tests are still failing though.

On my machine I got:
```

The following tests FAILED:
         16 - test-lifted-tests_analysis-cfg-lifted_tests_analysis__switch-addls__arm (Failed)
         17 - test-lifted-tests_analysis-functionsboundaries-lifted_tests_analysis__switch-addls__arm (Failed)
         18 - test-lifted-tests_analysis-cfg-lifted_tests_analysis__switch-ldrls__arm (Failed)
         19 - test-lifted-tests_analysis-functionsboundaries-lifted_tests_analysis__switch-ldrls__arm (Failed)
         20 - test-lifted-tests_analysis-cfg-lifted_tests_analysis__switch-disjoint-ranges__arm (Failed)
         21 - test-lifted-tests_analysis-functionsboundaries-lifted_tests_analysis__switch-disjoint-ranges__arm (Failed)
         31 - test-lifted-tests_analysis-cfg-lifted_tests_analysis__memset__arm (Failed)
         32 - test-lifted-tests_analysis-functionsboundaries-lifted_tests_analysis__memset__arm (Failed)
         33 - test-lifted-tests_analysis-cfg-lifted_tests_analysis__switch-jump-table__mips (Failed)
         34 - test-lifted-tests_analysis-functionsboundaries-lifted_tests_analysis__switch-jump-table__mips (Failed)
         54 - test-translated-tests_runtime-translated_tests_runtime__calc__dynamic_native-literal (Failed)
         55 - test-translated-tests_runtime-translated_tests_runtime__calc__dynamic_native-sum (Failed)
         56 - test-translated-tests_runtime-translated_tests_runtime__calc__dynamic_native-multiplication (Failed)
         57 - test-translated-tests_runtime-translated_tests_runtime__calc__arm-literal (Failed)
         58 - test-translated-tests_runtime-translated_tests_runtime__calc__arm-sum (Failed)
         59 - test-translated-tests_runtime-translated_tests_runtime__calc__arm-multiplication (Failed)
         75 - test-translated-tests_runtime-translated_tests_runtime__function-call__dynamic_native-default (Failed)
         76 - test-translated-tests_runtime-translated_tests_runtime__function-call__arm-default (Failed)
         82 - test-translated-tests_runtime-translated_tests_runtime__floating-point__dynamic_native-default (Failed)
         83 - test-translated-tests_runtime-translated_tests_runtime__floating-point__arm-default (Failed)
         89 - test-translated-tests_runtime-translated_tests_runtime__syscall__dynamic_native-default (Failed)
         90 - test-translated-tests_runtime-translated_tests_runtime__syscall__arm-default (Failed)
         96 - test-translated-tests_runtime-translated_tests_runtime__global__dynamic_native-default (Failed)
         97 - test-translated-tests_runtime-translated_tests_runtime__global__arm-default (Failed)
        103 - test-translated-tests_runtime-translated_tests_runtime__printf__dynamic_native-one (Failed)
        104 - test-translated-tests_runtime-translated_tests_runtime__printf__dynamic_native-two (Failed)
        105 - test-translated-tests_runtime-translated_tests_runtime__printf__dynamic_native-three (Failed)
        106 - test-translated-tests_runtime-translated_tests_runtime__printf__arm-one (Failed)
        107 - test-translated-tests_runtime-translated_tests_runtime__printf__arm-two (Failed)
        108 - test-translated-tests_runtime-translated_tests_runtime__printf__arm-three (Failed)
```

The `*-lifted-*` tests all fail because of misidentified jump targets.

The `*-translated-*` tests all fail because of `Erroneous call to function dispatcher`, some of them printing `Unknown PC` as well before crashing.

Looks like something in the rebase of LVI patches on top of llvm-11 (here https://github.com/revng/llvm-project/pull/2) went wrong, but I can't figure out right now. The point is that, while I was rebasing our LVI patches on llvm-11, some part of them were obsoleted, so I had to take some pieces, drop some others, and cleanup the rest. Something might have gone wrong in the process, or some of the rebased patches might not work properly with new addition to LVI from upstream. We need to figure out what's going on.