### PR TITLE
Various fixes needed by Caliban

### DIFF
--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -361,6 +361,7 @@ public:
   static const bool is_generic_graph = true;
   using NodesContainer = llvm::SmallVector<std::unique_ptr<NodeT>, SmallSize>;
   using Node = NodeT;
+  static constexpr bool hasEntryNode = HasEntryNode;
 
 private:
   using nodes_iterator_impl = typename NodesContainer::iterator;

--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -10,6 +10,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include "revng/ADT/KeyTraits.h"
+#include "revng/ADT/SortedVector.h"
 #include "revng/Support/Debug.h"
 
 struct Empty {};
@@ -21,7 +23,7 @@ template<typename T, typename BaseType>
 class Parent : public BaseType {
 public:
   template<typename... Args>
-  explicit Parent(Args &&... args) :
+  explicit Parent(Args &&...args) :
     BaseType(std::forward<Args>(args)...), TheParent(nullptr) {}
 
   Parent(const Parent &) = default;
@@ -142,7 +144,7 @@ public:
 
 public:
   template<typename... Args>
-  explicit ForwardNode(Args &&... args) : Base(std::forward<Args>(args)...) {}
+  explicit ForwardNode(Args &&...args) : Base(std::forward<Args>(args)...) {}
 
   ForwardNode(const ForwardNode &) = default;
   ForwardNode(ForwardNode &&) = default;
@@ -277,7 +279,7 @@ public:
 
 public:
   template<typename... Args>
-  explicit BidirectionalNode(Args &&... args) :
+  explicit BidirectionalNode(Args &&...args) :
     Base(std::forward<Args>(args)...) {}
 
   BidirectionalNode(const BidirectionalNode &) = default;
@@ -391,7 +393,7 @@ public:
 
 public:
   template<class... Args>
-  NodeT *addNode(Args &&... A) {
+  NodeT *addNode(Args &&...A) {
     Nodes.push_back(std::make_unique<NodeT>(std::forward<Args>(A)...));
     if constexpr (NodeT::has_parent)
       Nodes.back()->setParent(this);

--- a/include/revng/ADT/SerializableGraph.h
+++ b/include/revng/ADT/SerializableGraph.h
@@ -1,0 +1,81 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/ADT/GenericGraph.h"
+
+template<typename NodeType>
+struct SerializableNode {
+  using BDir = BidirectionalNode<NodeType>;
+  using KKeyType = decltype(KeyedObjectTraits<BDir>::key(*((BDir *) NULL)));
+  NodeType N;
+  SortedVector<KKeyType> Successors;
+
+  bool operator!=(const SerializableNode<NodeType> &O) const {
+    return N != O.N;
+  }
+};
+
+template<typename NodeType>
+struct KeyedObjectTraits<SerializableNode<NodeType>> {
+  using BDir = BidirectionalNode<NodeType>;
+  using KKeyType = decltype(KeyedObjectTraits<BDir>::key(*((BDir *) NULL)));
+
+  static KKeyType key(const SerializableNode<NodeType> &FD) {
+    return KeyedObjectTraits<BDir>::key(BDir(FD.N));
+  }
+  static SerializableNode<NodeType> fromKey(KKeyType Key) {
+    return SerializableNode<NodeType>({ Key, {} });
+  }
+};
+
+template<typename NodeType>
+struct SerializableGraph {
+  using BDir = BidirectionalNode<NodeType>;
+  using SNode = SerializableNode<NodeType>;
+  using KKeyType = decltype(KeyedObjectTraits<BDir>::key(*((BDir *) NULL)));
+
+  SortedVector<SNode> Nodes;
+
+  bool operator!=(const SerializableGraph<NodeType> &O) const {
+    return Nodes != O.Nodes;
+  }
+
+  static SerializableGraph toSerializable(const GenericGraph<BDir> &G) {
+    SerializableGraph Out;
+    {
+      auto Inserter = Out.Nodes.batch_insert();
+      for (const auto &N : G.nodes())
+        Inserter.insert(SNode{ getKey(*N), {} });
+    }
+
+    for (const auto &N : G.nodes()) {
+      auto Inserter = Out.Nodes.at(getKey(*N)).Successors.batch_insert();
+      for (const auto &J : N->successors())
+        Inserter.insert(getKey(*J));
+    }
+    return Out;
+  };
+
+  GenericGraph<BDir> fromSerializable() const {
+    GenericGraph<BDir> Ret;
+
+    std::map<KKeyType, BDir *> Map;
+
+    for (const auto &N : Nodes)
+      Map[getKey(N.N)] = Ret.addNode(N.N);
+
+    for (const auto &N : Nodes)
+      for (const auto &S : N.Successors)
+        Map[getKey(N.N)]->addSuccessor(Map[S]);
+
+    return Ret;
+  }
+
+private:
+  static KKeyType getKey(const NodeType &N) {
+    return KeyedObjectTraits<BDir>::key(BDir(N));
+  }
+};

--- a/include/revng/ADT/SerializableGraph.h
+++ b/include/revng/ADT/SerializableGraph.h
@@ -4,6 +4,8 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include "llvm/ADT/GraphTraits.h"
+
 #include "revng/ADT/GenericGraph.h"
 
 template<typename NodeType>
@@ -38,6 +40,7 @@ struct SerializableGraph {
   using KKeyType = decltype(KeyedObjectTraits<BDir>::key(*((BDir *) NULL)));
 
   SortedVector<SNode> Nodes;
+  KKeyType EntryNode;
 
   bool operator!=(const SerializableGraph<NodeType> &O) const {
     return Nodes != O.Nodes;
@@ -56,6 +59,11 @@ struct SerializableGraph {
       for (const auto &J : N->successors())
         Inserter.insert(getKey(*J));
     }
+
+    if constexpr (GenericGraph<BDir>::hasEntryNode) {
+      if (G.getEntryNode() != nullptr)
+        Out.EntryNode = getKey(*G.getEntryNode());
+    }
     return Out;
   };
 
@@ -71,6 +79,9 @@ struct SerializableGraph {
       for (const auto &S : N.Successors)
         Map[getKey(N.N)]->addSuccessor(Map[S]);
 
+    if constexpr (GenericGraph<BDir>::hasEntryNode) {
+      Ret.setEntryNode(Map[EntryNode]);
+    }
     return Ret;
   }
 

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -489,8 +489,45 @@ std::string pathAsString(const KeyIntVector &Path) {
 //
 // FOR_EACH macro implemenation
 //
-#define GET_MACRO(_0, _1, _2, _3, _4, _5, NAME, ...) NAME
-#define NUMARGS(...) GET_MACRO(_0, __VA_ARGS__, 5, 4, 3, 2, 1)
+#define GET_MACRO(_0,   \
+                  _1,   \
+                  _2,   \
+                  _3,   \
+                  _4,   \
+                  _5,   \
+                  _6,   \
+                  _7,   \
+                  _8,   \
+                  _9,   \
+                  _10,  \
+                  _11,  \
+                  _12,  \
+                  _13,  \
+                  _14,  \
+                  _15,  \
+                  _16,  \
+                  NAME, \
+                  ...)  \
+  NAME
+#define NUMARGS(...)     \
+  GET_MACRO(_0,          \
+            __VA_ARGS__, \
+            16,          \
+            15,          \
+            14,          \
+            13,          \
+            12,          \
+            11,          \
+            10,          \
+            9,           \
+            8,           \
+            7,           \
+            6,           \
+            5,           \
+            4,           \
+            3,           \
+            2,           \
+            1)
 
 #define FE_0(ACTION, TOTAL, ARG)
 
@@ -512,9 +549,71 @@ std::string pathAsString(const KeyIntVector &Path) {
   ACTION(ARG, (TOTAL) -4, X)             \
   FE_4(ACTION, TOTAL, ARG, __VA_ARGS__)
 
+#define FE_6(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -5, X)             \
+  FE_5(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_7(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -6, X)             \
+  FE_6(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_8(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -7, X)             \
+  FE_7(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_9(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -8, X)             \
+  FE_8(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_10(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -9, X)              \
+  FE_9(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_11(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -10, X)             \
+  FE_10(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_12(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -11, X)             \
+  FE_11(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_13(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -12, X)             \
+  FE_12(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_14(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -13, X)             \
+  FE_13(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_15(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -14, X)             \
+  FE_14(ACTION, TOTAL, ARG, __VA_ARGS__)
+
+#define FE_16(ACTION, TOTAL, ARG, X, ...) \
+  ACTION(ARG, (TOTAL) -15, X)             \
+  FE_15(ACTION, TOTAL, ARG, __VA_ARGS__)
+
 /// Calls ACTION(ARG, INDEX, VA_ARG) for each VA_ARG in ...
-#define FOR_EACH(ACTION, ARG, ...)                               \
-  GET_MACRO(_0, __VA_ARGS__, FE_5, FE_4, FE_3, FE_2, FE_1, FE_0) \
+#define FOR_EACH(ACTION, ARG, ...) \
+  GET_MACRO(_0,                    \
+            __VA_ARGS__,           \
+            FE_16,                 \
+            FE_15,                 \
+            FE_14,                 \
+            FE_13,                 \
+            FE_12,                 \
+            FE_11,                 \
+            FE_10,                 \
+            FE_9,                  \
+            FE_8,                  \
+            FE_7,                  \
+            FE_6,                  \
+            FE_5,                  \
+            FE_4,                  \
+            FE_3,                  \
+            FE_2,                  \
+            FE_1,                  \
+            FE_0)                  \
   (ACTION, (NUMARGS(__VA_ARGS__) - 1), ARG, __VA_ARGS__)
 
 //

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -13,6 +13,7 @@
 #include "llvm/Support/YAMLTraits.h"
 
 #include "revng/ADT/KeyTraits.h"
+#include "revng/ADT/KeyedObjectContainer.h"
 #include "revng/ADT/KeyedObjectTraits.h"
 #include "revng/Support/Assert.h"
 

--- a/include/revng/Model/TupleTreeDiff.h
+++ b/include/revng/Model/TupleTreeDiff.h
@@ -10,6 +10,7 @@
 #include "llvm/Support/WithColor.h"
 
 #include "revng/ADT/KeyedObjectContainer.h"
+#include "revng/ADT/ZipMapIterator.h"
 #include "revng/Model/TupleTree.h"
 
 template<typename>

--- a/include/revng/Support/MetaAddress/YAMLTraits.h
+++ b/include/revng/Support/MetaAddress/YAMLTraits.h
@@ -23,5 +23,5 @@ struct llvm::yaml::ScalarTraits<MetaAddress> {
     return StringRef();
   }
 
-  static QuotingType mustQuote(StringRef) { return QuotingType::None; }
+  static QuotingType mustQuote(StringRef) { return QuotingType::Double; }
 };


### PR DESCRIPTION
This MR:

* extends the support for the `FOR_EACH` macro used in `INTROSPECTION_NS` to allow serialization of structs with more than 5 entries. It now supports up to 16 entries.
* enables quotes around MetaAddress during serialization, because ':' is a valid YAML separator, which causes wrong deserialization when a vector of MetaAddress is serialized as a list.
* add a missing include in `TupleTreeDiff.h`, `TupleTree.h`
* applied clang-format to GenericGraph
* add SerializableGraph