### PR TITLE
RecursiveCoroutine: fix reference arguments

### DIFF
--- a/include/revng/ADT/RecursiveCoroutine-coroutine.h
+++ b/include/revng/ADT/RecursiveCoroutine-coroutine.h
@@ -6,6 +6,7 @@
 
 #include <experimental/coroutine>
 #include <optional>
+#include <utility>
 
 #include "revng/Support/Assert.h"
 
@@ -182,8 +183,8 @@ protected:
 };
 
 template<typename CoroutineT, typename... Args>
-auto rc_run(CoroutineT F, Args... Arguments) {
-  return F(Arguments...).run();
+auto rc_run(CoroutineT F, Args &&... args) {
+  return F(std::forward<Args>(args)...).run();
 }
 
 #define rc_return co_return

--- a/include/revng/ADT/RecursiveCoroutine-fallback.h
+++ b/include/revng/ADT/RecursiveCoroutine-fallback.h
@@ -4,12 +4,14 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include <utility>
+
 template<typename ReturnT = void>
 using RecursiveCoroutine = ReturnT;
 
 template<typename CoroutineT, typename... Args>
-auto rc_run(CoroutineT F, Args... Arguments) {
-  return F(Arguments...);
+auto rc_run(CoroutineT F, Args &&... args) {
+  return F(std::forward<Args>(args)...);
 }
 
 #define rc_return return

--- a/tests/unit/RecursiveCoroutine.cpp
+++ b/tests/unit/RecursiveCoroutine.cpp
@@ -136,4 +136,11 @@ int main(int, char *[]) {
   }
 
   std::cout << "Average: " << Average << std::endl;
+
+  int Result = 0;
+  rc_run(accumulateSums, 7, Result);
+  std::cout << "Result: " << Result << std::endl;
+  revng_check(Result == 28);
+
+  return 0;
 }

--- a/tests/unit/SimpleRecursiveCoroutine.h
+++ b/tests/unit/SimpleRecursiveCoroutine.h
@@ -36,3 +36,9 @@ inline RecursiveCoroutine<> my_coroutine(std::vector<MyState> &RCS, int x) {
   RCS.pop_back();
   rc_return;
 }
+
+inline RecursiveCoroutine<void> accumulateSums(int I, int &Result) {
+  Result += I;
+  if (I)
+    rc_recur accumulateSums(I - 1, Result);
+}


### PR DESCRIPTION
Before this commit, recursive coroutines did not work properly if they had out arguments with reference type.
The reason is that `rc_run` was inferring the type of its arguments from the arguments themselves, not from the prototype of the recursive coroutine.

Hence, code snippets like the following did not work properly, because `rc_run` was taking x by value, not by reference.

```c++
RecursiveCoroutine<void> accumulate_on_i(int &i) {
  // ...
}

int f() {
  int x = 0;
  rc_run(accumulate_on_i, x);
  return x;
}
```

This commit fixes the problem. Now the arguments of `rc_run` are properly forwarded to the recursive coroutine.