### PR TITLE
[NewMFP] Move monotone framework implementation to revng

### DIFF
--- a/include/revng/ADT/ReversePostOrderTraversal.h
+++ b/include/revng/ADT/ReversePostOrderTraversal.h
@@ -1,0 +1,39 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/PostOrderIterator.h"
+
+namespace llvm {
+
+template <class GraphT, class GT = llvm::GraphTraits<GraphT>,
+          class SetType = std::set<typename llvm::GraphTraits<GraphT>::NodeRef>>
+class ReversePostOrderTraversalExt {
+  using NodeRef = typename GT::NodeRef;
+  using NodeVec = std::vector<NodeRef>;
+
+  NodeVec Blocks; // Block list in normal RPO order
+
+  void Initialize(GraphT G, SetType &WhiteList) {
+    std::copy(po_ext_begin(G, WhiteList), po_ext_end(G, WhiteList),
+              std::back_inserter(Blocks));
+  }
+
+public:
+  using rpo_iterator = typename NodeVec::reverse_iterator;
+  using const_rpo_iterator = typename NodeVec::const_reverse_iterator;
+
+  ReversePostOrderTraversalExt(GraphT G, SetType &WhiteList) {
+    Initialize(G, WhiteList);
+  }
+
+  // Because we want a reverse post order, use reverse iterators from the vector
+  rpo_iterator begin() { return Blocks.rbegin(); }
+  const_rpo_iterator begin() const { return Blocks.crbegin(); }
+  rpo_iterator end() { return Blocks.rend(); }
+  const_rpo_iterator end() const { return Blocks.crend(); }
+};
+
+} // namespace llvm

--- a/include/revng/MFP/MFP.h
+++ b/include/revng/MFP/MFP.h
@@ -1,0 +1,145 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <compare>
+#include <cstddef>
+#include <map>
+#include <queue>
+#include <type_traits>
+
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "revng/ADT/GenericGraph.h"
+#include "revng/ADT/ReversePostOrderTraversal.h"
+
+namespace MFP {
+
+template<typename T, typename U>
+concept same_as = std::is_same_v<T, U>;
+
+template<typename LatticeElement>
+struct MFPResult {
+  LatticeElement InValue;
+  LatticeElement OutValue;
+};
+
+/// GT is an instance of llvm::GraphTraits e.g. llvm::GraphTraits<GraphType>
+template<typename GT>
+auto successors(typename GT::NodeRef From) {
+  return llvm::make_range(GT::child_begin(From), GT::child_end(From));
+}
+
+template<typename MFI>
+concept MonotoneFrameworkInstance = requires(typename MFI::LatticeElement E1,
+                                             typename MFI::LatticeElement E2,
+                                             typename MFI::Label L) {
+  /// To compute the reverse post order traversal of the graph starting from
+  /// the extremal nodes, we need that the nodes also represent a subgraph
+  typename llvm::GraphTraits<typename MFI::Label>::NodeRef;
+
+  same_as<typename MFI::Label,
+          typename llvm::GraphTraits<typename MFI::GraphType>::NodeRef>;
+  // Disable clang-format, because it does not handle concepts very well yet
+  // clang-format off
+  { MFI::combineValues(E1, E2) } ->same_as<typename MFI::LatticeElement>;
+  { MFI::isLessOrEqual(E1, E2) } ->same_as<bool>;
+  { MFI::applyTransferFunction(L, E2) } ->same_as<typename MFI::LatticeElement>;
+  // clang-format on
+};
+
+/// Compute the maximum fixed points of an instance of monotone framework
+/// GT an instance of llvm::GraphTraits
+template<MonotoneFrameworkInstance MFI,
+         typename GT = llvm::GraphTraits<typename MFI::GraphType>>
+std::map<typename MFI::Label, MFPResult<typename MFI::LatticeElement>>
+getMaximalFixedPoint(const typename MFI::GraphType &Flow,
+                     typename MFI::LatticeElement InitialValue,
+                     typename MFI::LatticeElement ExtremalValue,
+                     const std::vector<typename MFI::Label> &ExtremalLabels) {
+  typedef typename MFI::Label Label;
+  typedef typename MFI::LatticeElement LatticeElement;
+  std::map<Label, LatticeElement> PartialAnalysis;
+  std::map<Label, MFPResult<LatticeElement>> AnalysisResult;
+
+  struct WorklistItem {
+    size_t Priority;
+    Label Item;
+
+    std::strong_ordering operator<=>(const WorklistItem &) const = default;
+  };
+  std::set<WorklistItem> Worklist;
+
+  llvm::SmallSet<Label, 8> Visited{};
+  std::map<Label, size_t> LabelPriority;
+
+  // Step 1 initialize the worklist and extremal labels
+  for (Label ExtremalLabel : ExtremalLabels) {
+    PartialAnalysis[ExtremalLabel] = ExtremalValue;
+  }
+
+  // Handle the special case that the graph has a single entry node
+  if (GT::getEntryNode(Flow) != nullptr) {
+    llvm::ReversePostOrderTraversalExt RPOTE(GT::getEntryNode(Flow), Visited);
+    for (Label Node : RPOTE) {
+      LabelPriority[Node] = LabelPriority.size();
+      Worklist.insert({ LabelPriority.at(Node), Node });
+      // initialize the analysis value for non extremal nodes
+      if (PartialAnalysis.find(Node) == PartialAnalysis.end()) {
+        PartialAnalysis[Node] = InitialValue;
+      }
+    }
+  }
+  // Start visits for nodes that we still haven't visited
+  // prioritizing extremal nodes
+  std::vector<Label> Nodes(ExtremalLabels);
+  for (Label Node : llvm::nodes(Flow)) {
+    Nodes.push_back(Node);
+  }
+  for (Label Start : Nodes) {
+    if (Visited.count(Start) == 0) {
+      // Fill the worklist with nodes in reverse post order
+      // lauching a visit from each remaining node
+      llvm::ReversePostOrderTraversalExt RPOTE(Start, Visited);
+      for (Label Node : RPOTE) {
+        LabelPriority[Node] = LabelPriority.size();
+        Worklist.insert({ LabelPriority.at(Node), Node });
+        // initialize the analysis value for non extremal nodes
+        if (PartialAnalysis.find(Node) == PartialAnalysis.end()) {
+          PartialAnalysis[Node] = InitialValue;
+        }
+      }
+    }
+  }
+
+  // Step 2 iteration
+  while (!Worklist.empty()) {
+    WorklistItem First = *Worklist.begin();
+    Label Start = First.Item;
+    Worklist.erase(First);
+    for (Label End : successors<GT>(Start)) {
+      auto &PartialStart = PartialAnalysis.at(Start);
+      LatticeElement
+        UpdatedEndAnalysis = MFI::applyTransferFunction(Start, PartialStart);
+      auto &PartialEnd = PartialAnalysis.at(End);
+      if (!MFI::isLessOrEqual(UpdatedEndAnalysis, PartialEnd)) {
+        PartialEnd = MFI::combineValues(PartialEnd, UpdatedEndAnalysis);
+        Worklist.insert({ LabelPriority.at(End), End });
+      }
+    }
+  }
+
+  // Step 3 presenting the results
+  for (auto &[Node, Analysis] : PartialAnalysis) {
+    AnalysisResult[Node] = { Analysis,
+                             MFI::applyTransferFunction(Node, Analysis) };
+  }
+  return AnalysisResult;
+}
+
+} // namespace MFP

--- a/include/revng/MFP/MFP.h
+++ b/include/revng/MFP/MFP.h
@@ -63,8 +63,8 @@ getMaximalFixedPoint(const MFI &Instance, const typename MFI::GraphType &Flow,
                      typename MFI::LatticeElement InitialValue,
                      typename MFI::LatticeElement ExtremalValue,
                      const std::vector<typename MFI::Label> &ExtremalLabels) {
-  typedef typename MFI::Label Label;
-  typedef typename MFI::LatticeElement LatticeElement;
+  using Label = typename MFI::Label;
+  using LatticeElement = typename MFI::LatticeElement;
   std::map<Label, LatticeElement> PartialAnalysis;
   std::map<Label, MFPResult<LatticeElement>> AnalysisResult;
 


### PR DESCRIPTION
This commit moves the implementation of the monotone framework
from revng-c to revng

The core part of the maximal fixed point algorithm for the monotone framework is in:
```
include/revng/MFP/MFP.h
```

The last file is a dependency of the MFP implementation that visits the nodes in reverse post order traversal order
```
include/revng/ADT/ReversePostOrderTraversal.h
```

Finally I am adding a parameter `const MFI &I` to `getMaximumFixedPoint` to let us use contextual readonly data, which we cannot easily do if we only allow static methods. 

----

A separate pull request on revng-c will remote these files from the revng-c repo and fix any code that depends on them