### PR TITLE
[WIP] BinaryFile.h: improve error message for unhandled GNU indirect function symbols

### DIFF
--- a/tools/revng-lift/BinaryFile.cpp
+++ b/tools/revng-lift/BinaryFile.cpp
@@ -38,6 +38,43 @@ using LabelList = BinaryFile::LabelList;
 
 static Logger<> EhFrameLog("ehframe");
 static Logger<> LabelsLog("labels");
+static Logger<> SymbolTypeLog("symbol-types");
+
+namespace SymbolType {
+
+static SymbolType::Values fromELF(unsigned char ELFSymbolType) {
+  switch (ELFSymbolType) {
+  case llvm::ELF::STT_GNU_IFUNC:
+    revng_log(SymbolTypeLog,
+              "symbol STT_GNU_IFUNC: GNU indirect functions not supported yet");
+    return SymbolType::Unknown;
+
+  case llvm::ELF::STT_TLS:
+    revng_log(SymbolTypeLog,
+              "symbol STT_TLS: thread-local storage not supported yet");
+    return SymbolType::Unknown;
+
+  case llvm::ELF::STT_NOTYPE:
+    return SymbolType::Unknown;
+
+  case llvm::ELF::STT_FUNC:
+    return SymbolType::Code;
+
+  case llvm::ELF::STT_OBJECT:
+    return SymbolType::Data;
+
+  case llvm::ELF::STT_SECTION:
+    return SymbolType::Section;
+
+  case llvm::ELF::STT_FILE:
+    return SymbolType::File;
+
+  default:
+    revng_abort("Unexpected symbol type");
+  }
+}
+
+} // namespace SymbolType
 
 const unsigned char R_MIPS_IMPLICIT_RELATIVE = 255;
 

--- a/tools/revng-lift/BinaryFile.h
+++ b/tools/revng-lift/BinaryFile.h
@@ -143,29 +143,6 @@ inline const char *getName(Values V) {
   revng_abort();
 }
 
-inline SymbolType::Values fromELF(unsigned char ELFSymbolType) {
-  switch (ELFSymbolType) {
-  case llvm::ELF::STT_NOTYPE:
-  case llvm::ELF::STT_TLS:
-    return SymbolType::Unknown;
-
-  case llvm::ELF::STT_FUNC:
-    return SymbolType::Code;
-
-  case llvm::ELF::STT_OBJECT:
-    return SymbolType::Data;
-
-  case llvm::ELF::STT_SECTION:
-    return SymbolType::Section;
-
-  case llvm::ELF::STT_FILE:
-    return SymbolType::File;
-
-  default:
-    revng_abort("Unexpected symbol type");
-  }
-}
-
 } // namespace SymbolType
 
 namespace LabelOrigin {


### PR DESCRIPTION
It is quite common for new users to compile programs with their system compilers and feeding them to revng. Most system compilers link C programs against glibc, which emits GNU indirect function symbols even when compiled with `-static`. Such symbols are not supported by revng yet, so the typical bug report is a crash with the unhelpful message: "Unexpected symbol type". This commits improves the error message to make this frequent troubleshooting easier.

In the error message we could probably also suggest to use our `x86_64-gentoo-linux-musl-gcc` compiler to statically compile binaries, but for now I didn't want to weigh it down to much. @aleclearmind what do you think about it?