### PR TITLE
[WIP] RecursiveCoroutine: enable direct continuation

### DIFF
--- a/include/revng/ADT/RecursiveCoroutine-fallback.h
+++ b/include/revng/ADT/RecursiveCoroutine-fallback.h
@@ -4,15 +4,8 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
-#include <utility>
-
 template<typename ReturnT = void>
 using RecursiveCoroutine = ReturnT;
-
-template<typename CoroutineT, typename... Args>
-auto rc_run(CoroutineT F, Args &&... args) {
-  return F(std::forward<Args>(args)...);
-}
 
 #define rc_return return
 

--- a/include/revng/ADT/RecursiveCoroutine.h
+++ b/include/revng/ADT/RecursiveCoroutine.h
@@ -4,6 +4,8 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include <utility>
+
 #if defined(DISABLE_RECURSIVE_COROUTINES)
 
 #include "RecursiveCoroutine-fallback.h"

--- a/tests/unit/RecursiveCoroutine.cpp
+++ b/tests/unit/RecursiveCoroutine.cpp
@@ -27,7 +27,7 @@ int main(int, char *[]) {
   //
   std::vector<MyState> MyStateRCS;
   MyStateRCS.emplace_back();
-  rc_run(my_coroutine, MyStateRCS, 0);
+  my_coroutine(MyStateRCS, 0);
 
   //
   // Visit a simple graph
@@ -50,7 +50,7 @@ int main(int, char *[]) {
   // element
   ThisRCS.emplace_back(SimpleGraph.root());
   // run the coroutine
-  rc_run(findMaxDepth, ThisRCS);
+  findMaxDepth(ThisRCS);
 
 #endif
 
@@ -91,7 +91,7 @@ int main(int, char *[]) {
     // element
     RCS.emplace_back(G.root());
     // run the coroutine
-    rc_run(findMaxDepth, RCS);
+    findMaxDepth(RCS);
 
 #endif
     auto End = high_resolution_clock::now();
@@ -123,7 +123,7 @@ int main(int, char *[]) {
 
 #else
 
-    X = rc_run(findMaxDepthRet, G.root(), Stack);
+    X = findMaxDepthRet(G.root(), Stack);
 
 #endif
     auto End = high_resolution_clock::now();
@@ -138,7 +138,7 @@ int main(int, char *[]) {
   std::cout << "Average: " << Average << std::endl;
 
   int Result = 0;
-  rc_run(accumulateSums, 7, Result);
+  accumulateSums(7, Result);
   std::cout << "Result: " << Result << std::endl;
   revng_check(Result == 28);
 


### PR DESCRIPTION
Before this commit, the execution logic of RecursiveCoroutine used an underlying std::stack allocated on the heap to hold all the coroutine_handles. It also manually managed passing return values from callees to callers.

This commit drops this unnecessary auxiliary stack.
When a RecursiveCoroutine co_awaits another one, the handle of the awaiter is injected into the awaitee, so that when the awaitee is done it can directly execute the remaining part of the awaiter as a continuation.

With these changes, the inliner should by much happier and we should get even better performance, but I haven't measured it yet. I'll ask alvise to try this out on his use case, which at the moment uses these heavily, so we should be able to se a difference.