### PR TITLE
Latest fixes for inlining helpers

### DIFF
--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -427,14 +427,31 @@ private:
   NodesContainer Nodes;
 };
 
+template<typename T>
+concept IsForwardNode = requires {
+  T::is_forward_node;
+};
+
+template<typename T>
+concept IsBidirectionalNode = requires {
+  T::is_bidirectional_node;
+  typename llvm::Inverse<T *>;
+};
+
+template<typename T>
+concept IsGenericGraph = requires {
+  T::is_generic_graph;
+  typename T::Node;
+};
+
 //
 // GraphTraits implementation for GenericGraph
 //
 namespace llvm {
 
 /// Implement GraphTraits<ForwardNode>
-template<typename T>
-struct GraphTraits<T *, std::enable_if_t<T::is_forward_node>> {
+template<IsForwardNode T>
+struct GraphTraits<T *> {
 public:
   using NodeRef = T *;
   using ChildIteratorType = std::conditional_t<std::is_const_v<T>,
@@ -471,9 +488,8 @@ public:
 };
 
 /// Implement GraphTraits<GenericGraph>
-template<typename T>
-struct GraphTraits<T *, std::enable_if_t<T::is_generic_graph>>
-  : public GraphTraits<typename T::Node *> {
+template<IsGenericGraph T>
+struct GraphTraits<T *> : public GraphTraits<typename T::Node *> {
 
   using NodeRef = std::conditional_t<std::is_const_v<T>,
                                      const typename T::Node *,
@@ -492,9 +508,8 @@ struct GraphTraits<T *, std::enable_if_t<T::is_generic_graph>>
 };
 
 /// Implement GraphTraits<Inverse<BidirectionalNode>>
-template<typename T>
-struct GraphTraits<llvm::Inverse<T *>,
-                   std::enable_if_t<T::is_bidirectional_node>> {
+template<IsBidirectionalNode T>
+struct GraphTraits<llvm::Inverse<T *>> {
 public:
   using NodeRef = T *;
   using ChildIteratorType = std::conditional_t<std::is_const_v<T>,

--- a/include/revng/ADT/KeyTraits.h
+++ b/include/revng/ADT/KeyTraits.h
@@ -14,7 +14,7 @@
 using KeyInt = uint64_t;
 using KeyIntVector = std::vector<KeyInt>;
 
-template<typename T, typename = void>
+template<typename T>
 struct KeyTraits {
   // static constexpr size_t IntsCount = ...;
   // using IntsArray = std::array<KeyInt, IntsCount>;
@@ -29,8 +29,8 @@ struct KeyTraits {
 };
 
 /// Trivial specialization for integral types
-template<typename T>
-struct KeyTraits<T, enable_if_is_integral_t<T>> {
+template<Integral T>
+struct KeyTraits<T> {
   static constexpr size_t IntsCount = 1;
   using IntsArray = std::array<KeyInt, IntsCount>;
 
@@ -39,12 +39,12 @@ struct KeyTraits<T, enable_if_is_integral_t<T>> {
   static IntsArray toInts(const T &I) { return { static_cast<KeyInt>(I) }; }
 };
 
-template<typename T, typename K = void>
-using enable_if_is_enum_t = std::enable_if_t<std::is_enum_v<T>, K>;
+template<typename T>
+concept Enum = std::is_enum_v<T>;
 
 /// Trivial specialization for integral types
-template<typename T>
-struct KeyTraits<T, enable_if_is_enum_t<T>> {
+template<Enum T>
+struct KeyTraits<T> {
   static constexpr size_t IntsCount = 1;
   using IntsArray = std::array<KeyInt, IntsCount>;
 
@@ -58,8 +58,8 @@ struct KeyTraits<T, enable_if_is_enum_t<T>> {
 //
 // Derive KeyTraits from tuple-like of objects featuring KeyTraits
 //
-template<typename T>
-struct KeyTraits<T, std::enable_if_t<std::tuple_size<T>::value >= 0>> {
+template<HasTupleSize T>
+struct KeyTraits<T> {
 private:
   template<size_t I = 0>
   static constexpr size_t computeIntsCount() {

--- a/include/revng/ADT/KeyedObjectContainer.h
+++ b/include/revng/ADT/KeyedObjectContainer.h
@@ -25,7 +25,7 @@ template<typename T, class Compare = KOTCompare<T>>
 class SortedVector;
 
 //
-// is_KeyedObjectContainer
+// IsKeyedObjectContainer
 //
 namespace detail {
 
@@ -33,33 +33,27 @@ template<typename T>
 using no_cv_t = std::remove_cv_t<T>;
 
 template<typename T, template<typename...> class Ref>
-constexpr bool is_no_cv_specialization_v = is_specialization_v<no_cv_t<T>, Ref>;
+concept is_no_cv_specialization_v = is_specialization_v<no_cv_t<T>, Ref>;
 
 template<typename T>
-constexpr bool is_mutableset_v = is_no_cv_specialization_v<T, MutableSet>;
+concept IsMutableSet = is_no_cv_specialization_v<T, MutableSet>;
 
 template<typename T>
-constexpr bool is_sortedvector_v = is_no_cv_specialization_v<T, SortedVector>;
+concept IsSortedVector = is_no_cv_specialization_v<T, SortedVector>;
 
 template<typename T>
-constexpr bool is_KOC_v = is_mutableset_v<T> or is_sortedvector_v<T>;
-
-template<typename T, typename K = void>
-using enable_if_is_KOC_t = std::enable_if_t<is_KOC_v<T>, K>;
+concept IsKOC = IsMutableSet<T> or IsSortedVector<T>;
 
 } // namespace detail
 
 template<typename T>
-constexpr bool is_KeyedObjectContainer_v = detail::is_KOC_v<T>;
+concept IsKeyedObjectContainer = detail::IsKOC<T>;
 
-template<typename T, typename K = void>
-using enable_if_is_KeyedObjectContainer_t = detail::enable_if_is_KOC_t<T, K>;
+static_assert(IsKeyedObjectContainer<MutableSet<int>>);
+static_assert(IsKeyedObjectContainer<SortedVector<int>>);
 
-static_assert(is_KeyedObjectContainer_v<MutableSet<int>>);
-static_assert(is_KeyedObjectContainer_v<SortedVector<int>>);
-
-template<typename T>
-struct llvm::yaml::SequenceTraits<T, enable_if_is_KeyedObjectContainer_t<T>> {
+template<IsKeyedObjectContainer T>
+struct llvm::yaml::SequenceTraits<T> {
   static size_t size(IO &io, T &Seq) { return Seq.size(); }
 
   class Inserter {
@@ -111,171 +105,71 @@ struct llvm::yaml::SequenceTraits<T, enable_if_is_KeyedObjectContainer_t<T>> {
 };
 
 //
-// has_tuple_size
+// Iterable
 //
-template<typename, typename = void>
-struct has_tuple_size : std::false_type {};
-
 template<typename T>
-struct has_tuple_size<T, std::void_t<decltype(std::tuple_size<T>{})>>
-  : std::true_type {};
+concept Iterable = requires {
+  // * begin/end
+  // * operator!=
+  std::begin(std::declval<T &>()) != std::end(std::declval<T &>());
+  // * operator++
+  ++std::declval<decltype(std::begin(std::declval<T &>())) &>();
+  // * operator*
+  void(*std::begin(std::declval<T &>()));
+};
 
-template<typename T>
-constexpr bool has_tuple_size_v = has_tuple_size<T>::value;
-
-static_assert(has_tuple_size_v<std::tuple<>>);
-static_assert(!has_tuple_size_v<std::vector<int>>);
-static_assert(!has_tuple_size_v<int>);
-
-template<size_t I, typename T, typename K = void>
-using enable_if_tuple_end_t = std::enable_if_t<I == std::tuple_size_v<T>, K>;
-
-template<size_t I, typename T, typename K = void>
-using enable_if_not_tuple_end_t = std::enable_if_t<I != std::tuple_size_v<T>,
-                                                   K>;
-
-template<typename T, typename R = void>
-using enable_if_has_tuple_size_t = std::enable_if_t<has_tuple_size_v<T>, R>;
+static_assert(Iterable<std::vector<int>>);
+static_assert(not Iterable<int>);
 
 //
-// is_iterable
+// StringLike
 //
-namespace tupletree::detail {
-
-using std::begin;
-using std::end;
-
-// Require the following:
-// * begin/end
-// * operator!=
-// * operator++
-// * operator*
 template<typename T>
-decltype(begin(std::declval<T &>()) != end(std::declval<T &>()),
-         ++std::declval<decltype(begin(std::declval<T &>())) &>(),
-         void(*begin(std::declval<T &>())),
-         std::true_type{})
-is_iterable_impl(int);
+concept HasCStr = std::is_same_v<decltype(std::declval<T>().c_str()),
+                                 const char *>;
+
+static_assert(HasCStr<llvm::SmallString<4>>);
+static_assert(not HasCStr<int>);
 
 template<typename T>
-std::false_type is_iterable_impl(...);
+concept StringLike = std::is_convertible_v<std::string, T> or HasCStr<T>;
 
-} // namespace tupletree::detail
-
-template<typename T>
-using is_iterable = decltype(tupletree::detail::is_iterable_impl<T>(0));
-
-template<typename T>
-constexpr bool is_iterable_v = is_iterable<T>::value;
-
-static_assert(is_iterable_v<std::vector<int>>);
-static_assert(!is_iterable_v<int>);
+static_assert(StringLike<llvm::SmallString<4>>);
+static_assert(StringLike<std::string>);
+static_assert(not StringLike<llvm::ArrayRef<int>>);
+static_assert(StringLike<llvm::StringRef>);
 
 //
-// is_string_like
-//
-namespace tupletree::detail {
-template<typename T>
-typename std::is_same<decltype(std::declval<T>().c_str()), const char *>::type
-has_c_str(int);
-
-template<typename>
-std::false_type has_c_str(...);
-
-} // namespace tupletree::detail
-
-template<typename T>
-using has_c_str = typename decltype(tupletree::detail::has_c_str<T>(0))::type;
-
-template<typename T>
-constexpr bool has_c_str_v = has_c_str<T>::value;
-
-static_assert(has_c_str_v<llvm::SmallString<4>>);
-static_assert(!has_c_str_v<int>);
-
-template<typename T>
-constexpr bool
-  is_string_like_v = (std::is_convertible_v<std::string, T> or has_c_str_v<T>);
-
-static_assert(is_string_like_v<llvm::SmallString<4>>);
-static_assert(is_string_like_v<std::string>);
-static_assert(not is_string_like_v<llvm::ArrayRef<int>>);
-static_assert(is_string_like_v<llvm::StringRef>);
-
-//
-// is_container
+// IsContainer
 //
 
 template<typename T>
-constexpr bool is_container_v = is_iterable_v<T> and not is_string_like_v<T>;
-
-namespace detail {
-template<typename T>
-constexpr bool is_cot_v = is_container_v<T> or has_tuple_size_v<T>;
-} // namespace detail
+concept IsContainer = Iterable<T> and not StringLike<T>;
 
 template<typename T>
-constexpr bool is_container_or_tuple_v = detail::is_cot_v<T>;
+concept NotContainerNorTuple = not IsContainer<T> and not HasTupleSize<T>;
 
-namespace detail {
-template<typename T, typename K = void>
-using ei_not_cot_t = std::enable_if_t<!is_container_or_tuple_v<T>, K>;
-} // namespace detail
-
-template<typename T, typename K = void>
-using enable_if_is_not_container_or_tuple_t = detail::ei_not_cot_t<T, K>;
-
-static_assert(is_container_v<std::vector<int>>);
-static_assert(is_container_v<std::set<int>>);
-static_assert(is_container_v<std::map<int, int>>);
-static_assert(is_container_v<llvm::SmallVector<int, 4>>);
-static_assert(!is_container_v<std::string>);
-static_assert(!is_container_v<llvm::SmallString<4>>);
-static_assert(!is_container_v<llvm::StringRef>);
-
-template<typename T, typename K = void>
-using enable_if_is_container_t = std::enable_if_t<is_container_v<T>, K>;
-
-template<typename T, typename K = void>
-using enable_if_is_not_container_t = std::enable_if_t<!is_container_v<T>, K>;
+static_assert(IsContainer<std::vector<int>>);
+static_assert(IsContainer<std::set<int>>);
+static_assert(IsContainer<std::map<int, int>>);
+static_assert(IsContainer<llvm::SmallVector<int, 4>>);
+static_assert(!IsContainer<std::string>);
+static_assert(!IsContainer<llvm::SmallString<4>>);
+static_assert(!IsContainer<llvm::StringRef>);
 
 //
-// is_sorted_container
+// SortedContainer and UnsortedContainer
 //
 // TODO: this is not very nice
 namespace detail {
 
 template<typename T>
-constexpr bool is_set_v = is_specialization_v<T, std::set>;
-
-template<typename T>
-constexpr bool is_sc_v = is_set_v<T> or is_KeyedObjectContainer_v<T>;
+concept IsSet = is_specialization_v<T, std::set>;
 
 } // namespace detail
 
 template<typename T>
-constexpr bool is_sorted_container_v = detail::is_sc_v<T>;
-
-namespace detail {
-template<typename T>
-constexpr bool is_uc_v = is_container_v<T> and not is_sorted_container_v<T>;
-}
+concept SortedContainer = detail::IsSet<T> or IsKeyedObjectContainer<T>;
 
 template<typename T>
-constexpr bool is_unsorted_container_v = detail::is_uc_v<T>;
-
-namespace detail {
-
-template<typename T, typename K = void>
-using ei_isc_t = std::enable_if_t<is_sorted_container_v<T>, K>;
-
-template<typename T, typename K = void>
-using ei_iuc_t = std::enable_if_t<is_unsorted_container_v<T>, K>;
-
-} // namespace detail
-
-template<typename T, typename K = void>
-using enable_if_is_sorted_container_t = detail::ei_isc_t<T, K>;
-
-template<typename T, typename K = void>
-using enable_if_is_unsorted_container_t = detail::ei_iuc_t<T, K>;
+concept UnsortedContainer = IsContainer<T> and not SortedContainer<T>;

--- a/include/revng/ADT/KeyedObjectContainer.h
+++ b/include/revng/ADT/KeyedObjectContainer.h
@@ -10,6 +10,7 @@
 
 #include "revng/ADT/KeyedObjectTraits.h"
 #include "revng/ADT/STLExtras.h"
+#include "revng/ADT/UpcastablePointer.h"
 #include "revng/Support/Assert.h"
 
 template<typename T>
@@ -146,8 +147,12 @@ static_assert(StringLike<llvm::StringRef>);
 template<typename T>
 concept IsContainer = Iterable<T> and not StringLike<T>;
 
+// clang-format off
 template<typename T>
-concept NotContainerNorTuple = not IsContainer<T> and not HasTupleSize<T>;
+concept NotTupleTreeCompatible = (not IsContainer<T>
+                                  and not HasTupleSize<T>
+                                  and not IsUpcastablePointer<T>);
+// clang-format on
 
 static_assert(IsContainer<std::vector<int>>);
 static_assert(IsContainer<std::set<int>>);

--- a/include/revng/ADT/KeyedObjectTraits.h
+++ b/include/revng/ADT/KeyedObjectTraits.h
@@ -22,6 +22,5 @@ struct IdentityKeyedObjectTraits {
 };
 
 /// Trivial specialization for integral types
-template<typename T>
-struct KeyedObjectTraits<T, enable_if_is_integral_t<T>>
-  : public IdentityKeyedObjectTraits<T> {};
+template<Integral T>
+struct KeyedObjectTraits<T> : public IdentityKeyedObjectTraits<T> {};

--- a/include/revng/ADT/LazySmallBitVector.h
+++ b/include/revng/ADT/LazySmallBitVector.h
@@ -30,34 +30,23 @@ inline unsigned requiredBits(T Value) {
 }
 
 template<typename T, typename A, typename B>
-constexpr bool is_either() {
-  return std::is_same<T, A>::value || std::is_same<T, B>::value;
-}
+concept is_either = std::is_same_v<T, A> or std::is_same_v<T, B>;
 
-template<typename T, typename A, typename B>
-using enable_if_either = typename std::enable_if<is_either<T, A, B>(), T>::type;
-
-template<typename T>
-using enable_if_int = enable_if_either<T, unsigned, int>;
-
-template<typename T>
-using enable_if_long = enable_if_either<T, unsigned long, long>;
-
-template<typename T>
-using enable_if_long_long = enable_if_either<T, unsigned long long, long long>;
-
-template<typename T>
-inline unsigned findFirstBit(enable_if_int<T> Value) {
+template<typename IntT>
+requires is_either<IntT, unsigned, int> inline unsigned
+findFirstBit(IntT Value) {
   return ffs(Value);
 }
 
-template<typename T>
-inline unsigned findFirstBit(enable_if_long<T> Value) {
+template<typename LongT>
+requires is_either<LongT, unsigned long, long> inline unsigned
+findFirstBit(LongT Value) {
   return ffsl(Value);
 }
 
-template<typename T>
-inline unsigned findFirstBit(enable_if_long_long<T> Value) {
+template<typename LongLongT>
+requires is_either<LongLongT, unsigned long long, long long> inline unsigned
+findFirstBit(LongLongT Value) {
   return ffsll(Value);
 }
 

--- a/include/revng/ADT/STLExtras.h
+++ b/include/revng/ADT/STLExtras.h
@@ -13,16 +13,8 @@
 //
 // is_integral
 //
-template<typename T, typename K = void>
-using enable_if_is_integral_t = std::enable_if_t<std::is_integral_v<T>, K>;
-
-//
-// enable_if_type
-//
-template<class T, class R = void>
-struct enable_if_type {
-  using type = R;
-};
+template<typename T>
+concept Integral = std::is_integral_v<T>;
 
 //
 // is_specialization
@@ -35,3 +27,28 @@ struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
 template<typename Test, template<typename...> class Ref>
 constexpr bool is_specialization_v = is_specialization<Test, Ref>::value;
+
+//
+// HasTupleSize
+//
+
+template<typename T>
+concept HasTupleSize = requires {
+  std::tuple_size<T>::value;
+};
+
+// clang-format off
+template<typename T, std::size_t I>
+concept IsTupleEnd
+  = std::is_same_v<std::true_type,
+                   std::integral_constant<bool, std::tuple_size_v<T> == I>>;
+
+template<typename T, std::size_t I>
+concept IsNotTupleEnd
+  = std::is_same_v<std::true_type,
+                   std::integral_constant<bool, std::tuple_size_v<T> != I>>;
+// clang-format on
+
+static_assert(HasTupleSize<std::tuple<>>);
+static_assert(!HasTupleSize<std::vector<int>>);
+static_assert(!HasTupleSize<int>);

--- a/include/revng/ADT/STLExtras.h
+++ b/include/revng/ADT/STLExtras.h
@@ -8,8 +8,6 @@
 
 #include "llvm/ADT/STLExtras.h"
 
-#include "revng/ADT/KeyedObjectTraits.h"
-
 //
 // is_integral
 //

--- a/include/revng/ADT/UpcastablePointer.h
+++ b/include/revng/ADT/UpcastablePointer.h
@@ -1,0 +1,158 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <memory>
+#include <type_traits>
+
+#include "llvm/Support/Casting.h"
+
+#include "revng/ADT/STLExtras.h"
+#include "revng/Support/Assert.h"
+
+template<typename T, typename U>
+concept same_as = std::is_same_v<T, U>;
+
+template<typename T>
+concept is_pointer = std::is_pointer_v<T>;
+
+template<typename T>
+struct concrete_types_traits;
+
+template<typename T>
+using concrete_types_traits_t = typename concrete_types_traits<T>::type;
+
+template<typename T>
+concept HasConcretTypeTraits = requires {
+  typename concrete_types_traits_t<T>;
+};
+
+// clang-format off
+template<typename T>
+concept HasLLVMRTTI = requires(T *a) {
+  { a->classof(a) } -> same_as<bool>;
+};
+// clang-format on
+
+template<typename T>
+concept Upcastable = HasLLVMRTTI<T> and HasConcretTypeTraits<T>;
+
+template<typename T>
+using pointee = typename std::pointer_traits<T>::element_type;
+
+template<typename T>
+concept PointerLike = requires(T a) {
+  { *a };
+};
+
+static_assert(PointerLike<int *>);
+static_assert(not PointerLike<int>);
+
+template<typename T>
+concept UpcastablePointerLike = PointerLike<T> and Upcastable<pointee<T>>;
+
+template<typename T>
+concept NotVoid = !same_as<void, T>;
+
+template<NotVoid ReturnT, typename L, UpcastablePointerLike P, size_t I = 0>
+ReturnT upcast(P &Upcastable, const L &Callable, const ReturnT &IfNull) {
+  using pointee = std::remove_reference_t<decltype(*Upcastable)>;
+  using concrete_types = concrete_types_traits_t<pointee>;
+  auto *Pointer = &*Upcastable;
+  if (Pointer == nullptr)
+    return IfNull;
+
+  if constexpr (I < std::tuple_size_v<concrete_types>) {
+    using type = std::tuple_element_t<I, concrete_types>;
+    if (auto *Upcasted = llvm::dyn_cast<type>(Pointer)) {
+      return Callable(*Upcasted);
+    } else {
+      return upcast<ReturnT, L, P, I + 1>(Upcastable, Callable, IfNull);
+    }
+  } else {
+    revng_abort();
+  }
+}
+
+template<typename L, UpcastablePointerLike P>
+void upcast(P &Upcastable, const L &Callable) {
+  auto Wrapper = [&](auto &Upcasted) {
+    Callable(Upcasted);
+    return true;
+  };
+  upcast(Upcastable, Wrapper, false);
+}
+
+/// A unique_ptr copiable thanks to LLVM RTTI
+template<Upcastable T>
+class UpcastablePointer {
+private:
+  template<Upcastable P>
+  static P *clone(P *Pointer) {
+    auto Dispatcher = [](auto &Upcasted) -> P * {
+      using type = std::remove_reference_t<decltype(Upcasted)>;
+      return new type(Upcasted);
+    };
+    return upcast(Pointer, Dispatcher, static_cast<P *>(nullptr));
+  }
+
+  template<Upcastable P>
+  static void destroy(P *Pointer) {
+    upcast(Pointer, [](auto &Upcasted) { delete &Upcasted; });
+  }
+
+private:
+  using concrete_types = concrete_types_traits_t<T>;
+  static constexpr void (*deleter)(T *) = &destroy<T>;
+  using inner_pointer = std::unique_ptr<T, decltype(deleter)>;
+
+public:
+  using pointer = typename inner_pointer::pointer;
+  using element_type = typename inner_pointer::element_type;
+
+public:
+  constexpr UpcastablePointer() noexcept : Pointer(nullptr, deleter) {}
+  constexpr UpcastablePointer(std::nullptr_t P) noexcept :
+    Pointer(P, deleter) {}
+  explicit UpcastablePointer(pointer P) noexcept : Pointer(P, deleter) {}
+  UpcastablePointer(UpcastablePointer &&P) noexcept :
+    Pointer(std::move(P.Pointer)) {
+    revng_assert(Pointer.get_deleter() == deleter);
+  }
+
+public:
+  UpcastablePointer(const UpcastablePointer &Other) :
+    Pointer(nullptr, deleter) {
+    *this = Other;
+    revng_assert(Pointer.get_deleter() == deleter);
+  }
+
+  UpcastablePointer &operator=(const UpcastablePointer &Other) {
+    Pointer.reset(clone(Other.Pointer.get()));
+    revng_assert(Pointer.get_deleter() == deleter);
+    return *this;
+  }
+
+  UpcastablePointer &operator=(UpcastablePointer &&Other) {
+    Pointer.reset(Other.Pointer.release());
+    revng_assert(Pointer.get_deleter() == deleter);
+    return *this;
+  }
+
+  auto get() const noexcept { return Pointer.get(); }
+  auto &operator*() const { return *Pointer; }
+  auto *operator->() const noexcept { return Pointer.operator->(); }
+
+  void reset(pointer Other = pointer()) noexcept {
+    Pointer.reset(Other);
+    revng_assert(Pointer.get_deleter() == deleter);
+  }
+
+private:
+  inner_pointer Pointer;
+};
+
+template<typename T>
+concept IsUpcastablePointer = is_specialization_v<T, UpcastablePointer>;

--- a/include/revng/ADT/UpcastablePointer/YAMLTraits.h
+++ b/include/revng/ADT/UpcastablePointer/YAMLTraits.h
@@ -1,0 +1,53 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/Support/YAMLTraits.h"
+
+#include "revng/ADT/UpcastablePointer.h"
+
+template<typename O, size_t I = 0>
+void initializeOwningPointer(llvm::yaml::IO &io, O &Obj) {
+  using concrete_types = concrete_types_traits_t<typename O::element_type>;
+
+  if constexpr (I < std::tuple_size_v<concrete_types>) {
+    using type = typename std::tuple_element_t<I, concrete_types>;
+    if (io.mapTag(type::Tag)) {
+      Obj.reset(new type);
+    } else {
+      initializeOwningPointer<O, I + 1>(io, Obj);
+    }
+  } else {
+    revng_abort();
+  }
+}
+
+template<typename O, size_t I = 0>
+void dispatchMappingTraits(llvm::yaml::IO &io, O &Obj) {
+  using concrete_types = concrete_types_traits_t<typename O::element_type>;
+
+  if constexpr (I < std::tuple_size_v<concrete_types>) {
+    using type = typename std::tuple_element_t<I, concrete_types>;
+    auto Pointer = Obj.get();
+    if (llvm::isa<type>(Pointer)) {
+      io.mapTag(type::Tag, true);
+      llvm::yaml::MappingTraits<type>::mapping(io, *llvm::cast<type>(Pointer));
+    } else {
+      dispatchMappingTraits<O, I + 1>(io, Obj);
+    }
+  } else {
+    revng_abort();
+  }
+}
+
+template<UpcastablePointerLike T>
+struct PolymorphicMappingTraits {
+  static void mapping(llvm::yaml::IO &io, T &Obj) {
+    if (!io.outputting())
+      initializeOwningPointer(io, Obj);
+
+    dispatchMappingTraits(io, Obj);
+  }
+};

--- a/include/revng/FunctionIsolation/InlineHelpers.h
+++ b/include/revng/FunctionIsolation/InlineHelpers.h
@@ -1,0 +1,19 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/Pass.h"
+
+#include "revng/BasicAnalyses/GeneratedCodeBasicInfo.h"
+
+class InlineHelpersPass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  InlineHelpersPass() : FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+};

--- a/include/revng/FunctionIsolation/RemoveExceptionalCalls.h
+++ b/include/revng/FunctionIsolation/RemoveExceptionalCalls.h
@@ -1,0 +1,21 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/Pass.h"
+
+class RemoveExceptionalCalls : public llvm::ModulePass {
+public:
+  static char ID;
+
+public:
+  RemoveExceptionalCalls() : llvm::ModulePass(ID) {}
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+  }
+
+  bool runOnModule(llvm::Module &F) override;
+};

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -844,7 +844,7 @@ struct KeyedObjectTraits<model::Function> {
   };
 };
 
-static_assert(is_KeyedObjectContainer_v<MutableSet<model::Function>>);
+static_assert(IsKeyedObjectContainer<MutableSet<model::Function>>);
 
 //
 // Binary

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -9,6 +9,8 @@
 #include "revng/ADT/KeyedObjectContainer.h"
 #include "revng/ADT/MutableSet.h"
 #include "revng/ADT/SortedVector.h"
+#include "revng/ADT/UpcastablePointer.h"
+#include "revng/ADT/UpcastablePointer/YAMLTraits.h"
 #include "revng/Model/TupleTree.h"
 #include "revng/Support/MetaAddress.h"
 #include "revng/Support/MetaAddress/KeyTraits.h"
@@ -20,6 +22,7 @@ namespace model {
 class Function;
 class Binary;
 class FunctionEdge;
+class CallEdge;
 class FunctionABIRegister;
 class BasicBlock;
 } // namespace model
@@ -674,6 +677,26 @@ inline bool hasDestination(Values V) {
   }
 }
 
+inline bool isCall(Values V) {
+  switch (V) {
+  case FunctionCall:
+  case IndirectCall:
+  case IndirectTailCall:
+    return true;
+
+  case Invalid:
+  case DirectBranch:
+  case FakeFunctionCall:
+  case FakeFunctionReturn:
+  case Return:
+  case BrokenReturn:
+  case LongJmp:
+  case Killer:
+  case Unreachable:
+    return false;
+  }
+}
+
 } // namespace model::FunctionEdgeType
 
 namespace llvm::yaml {
@@ -723,9 +746,10 @@ public:
   /// Edge target. If invalid, it's an indirect edge
   MetaAddress Destination;
   FunctionEdgeType::Values Type;
-  SortedVector<model::FunctionABIRegister> Registers;
 
 public:
+  FunctionEdge() :
+    Destination(MetaAddress::invalid()), Type(FunctionEdgeType::Invalid) {}
   FunctionEdge(MetaAddress Destination, FunctionEdgeType::Values Type) :
     Destination(Destination), Type(Type) {}
 
@@ -738,17 +762,62 @@ public:
     return ThisTie < OtherTie;
   }
 
+public:
+  static constexpr const char *Tag = "!FunctionEdge";
+  static bool classof(const FunctionEdge *A) {
+    return not FunctionEdgeType::isCall(A->Type);
+  }
+
   bool verify() const debug_function;
 };
-INTROSPECTION_NS(model, FunctionEdge, Destination, Type, Registers);
+INTROSPECTION_NS(model, FunctionEdge, Destination, Type);
+
+class model::CallEdge : public model::FunctionEdge {
+public:
+  using Key = std::pair<MetaAddress, model::FunctionEdgeType::Values>;
+
+public:
+  SortedVector<model::FunctionABIRegister> Registers;
+
+public:
+  CallEdge() :
+    FunctionEdge(MetaAddress::invalid(), FunctionEdgeType::FunctionCall) {}
+  CallEdge(MetaAddress Destination, FunctionEdgeType::Values Type) :
+    FunctionEdge(Destination, Type) {
+    revng_assert(FunctionEdgeType::isCall(Type));
+  }
+
+public:
+  static constexpr const char *Tag = "!CallEdge";
+  static bool classof(const FunctionEdge *A) {
+    return FunctionEdgeType::isCall(A->Type);
+  }
+
+public:
+  bool verify() const debug_function;
+};
+INTROSPECTION_NS(model, CallEdge, Destination, Type, Registers);
+
+template<>
+struct concrete_types_traits<model::FunctionEdge> {
+  using type = std::tuple<model::CallEdge, model::FunctionEdge>;
+};
+
+template<>
+class llvm::yaml::MappingTraits<UpcastablePointer<model::FunctionEdge>>
+  : public PolymorphicMappingTraits<UpcastablePointer<model::FunctionEdge>> {};
 
 template<>
 struct llvm::yaml::MappingTraits<model::FunctionEdge>
   : public TupleLikeMappingTraits<model::FunctionEdge> {};
 
 template<>
+struct llvm::yaml::MappingTraits<model::CallEdge>
+  : public TupleLikeMappingTraits<model::CallEdge> {};
+
+template<>
 struct llvm::yaml::ScalarTraits<model::FunctionEdge::Key>
-  : CompositeScalar<model::FunctionEdge::Key, '-'> {};
+  : public CompositeScalar<model::FunctionEdge::Key, '-'> {};
 
 template<>
 struct KeyedObjectTraits<model::FunctionEdge> {
@@ -759,6 +828,23 @@ struct KeyedObjectTraits<model::FunctionEdge> {
 
   static model::FunctionEdge fromKey(const Key &Obj) {
     return model::FunctionEdge{ Obj.first, Obj.second };
+  }
+};
+
+template<>
+struct KeyedObjectTraits<UpcastablePointer<model::FunctionEdge>> {
+  using Key = model::FunctionEdge::Key;
+  static Key key(const UpcastablePointer<model::FunctionEdge> &Obj) {
+    return { Obj->Destination, Obj->Type };
+  }
+
+  static UpcastablePointer<model::FunctionEdge> fromKey(const Key &Obj) {
+    using ResultType = UpcastablePointer<model::FunctionEdge>;
+    if (model::FunctionEdgeType::isCall(Obj.second)) {
+      return ResultType(new model::CallEdge(Obj.first, Obj.second));
+    } else {
+      return ResultType(new model::FunctionEdge(Obj.first, Obj.second));
+    }
   }
 };
 
@@ -792,7 +878,7 @@ public:
   MetaAddress Start;
   MetaAddress End;
   std::string Name;
-  SortedVector<FunctionEdge> Successors;
+  SortedVector<UpcastablePointer<model::FunctionEdge>> Successors;
 
 public:
   BasicBlock(const MetaAddress &Start) : Start(Start) {}

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -19,39 +19,32 @@
 #include "revng/Support/Debug.h"
 #include "revng/Support/YAMLTraits.h"
 
-//
-// has_yaml
-//
-namespace tupletree::detail {
-
-using namespace llvm::yaml;
+// clang-format off
+template<typename T>
+concept Yamlizable
+  = llvm::yaml::has_DocumentListTraits<T>::value
+    or llvm::yaml::has_MappingTraits<T, llvm::yaml::EmptyContext>::value
+    or llvm::yaml::has_SequenceTraits<T>::value
+    or llvm::yaml::has_BlockScalarTraits<T>::value
+    or llvm::yaml::has_CustomMappingTraits<T>::value
+    or llvm::yaml::has_PolymorphicTraits<T>::value
+    or llvm::yaml::has_ScalarTraits<T>::value
+    or llvm::yaml::has_ScalarEnumerationTraits<T>::value;
+// clang-format on
 
 template<typename T>
-constexpr bool has_yaml_v = has_DocumentListTraits<T>::value
-                            or has_MappingTraits<T, EmptyContext>::value
-                            or has_SequenceTraits<T>::value
-                            or has_BlockScalarTraits<T>::value
-                            or has_CustomMappingTraits<T>::value
-                            or has_PolymorphicTraits<T>::value
-                            or has_ScalarTraits<T>::value
-                            or has_ScalarEnumerationTraits<T>::value;
+concept NotYamlizable = not Yamlizable<T>;
+
+namespace detail {
 
 struct NoYaml {};
 
-} // namespace tupletree::detail
+static_assert(NotYamlizable<NoYaml>);
 
-template<typename T>
-constexpr bool has_yaml_v = tupletree::detail::has_yaml_v<T>;
+} // end namespace detail
 
-static_assert(!has_yaml_v<tupletree::detail::NoYaml>);
-static_assert(has_yaml_v<int>);
-static_assert(has_yaml_v<std::vector<int>>);
-
-template<typename T, typename K = void>
-using enable_if_has_yaml_t = std::enable_if_t<has_yaml_v<T>, K>;
-
-template<typename T, typename K = void>
-using enable_if_has_not_yaml_t = std::enable_if_t<not has_yaml_v<T>, K>;
+static_assert(Yamlizable<int>);
+static_assert(Yamlizable<std::vector<int>>);
 
 //
 // slice
@@ -117,11 +110,11 @@ struct TupleLikeMappingTraits {
 namespace tupletree::detail {
 
 template<size_t I = 0, typename Visitor, typename T>
-enable_if_tuple_end_t<I, T> visitTuple(Visitor &V, T &Obj) {
+requires IsTupleEnd<T, I> void visitTuple(Visitor &V, T &Obj) {
 }
 
 template<size_t I = 0, typename Visitor, typename T>
-enable_if_not_tuple_end_t<I, T> visitTuple(Visitor &V, T &Obj) {
+requires IsNotTupleEnd<T, I> void visitTuple(Visitor &V, T &Obj) {
   // Visit the field
   visit(V, get<I>(Obj));
 
@@ -132,16 +125,16 @@ enable_if_not_tuple_end_t<I, T> visitTuple(Visitor &V, T &Obj) {
 } // namespace tupletree::detail
 
 // Tuple-like
-template<typename Visitor, typename T>
-enable_if_has_tuple_size_t<T, void> visit(Visitor &V, T &Obj) {
+template<typename Visitor, HasTupleSize T>
+void visit(Visitor &V, T &Obj) {
   V.preVisit(Obj);
   tupletree::detail::visitTuple(V, Obj);
   V.postVisit(Obj);
 }
 
 // Container-like
-template<typename Visitor, typename T>
-enable_if_is_container_t<T> visit(Visitor &V, T &Obj) {
+template<typename Visitor, IsContainer T>
+void visit(Visitor &V, T &Obj) {
   V.preVisit(Obj);
   using value_type = typename T::value_type;
   for (value_type &Element : Obj) {
@@ -151,9 +144,8 @@ enable_if_is_container_t<T> visit(Visitor &V, T &Obj) {
 }
 
 // All the others
-template<typename Visitor, typename T>
-std::enable_if_t<not(is_container_v<T> or has_tuple_size_v<T>)>
-visit(Visitor &V, T &Element) {
+template<NotContainerNorTuple Visitor, typename T>
+void visit(Visitor &V, T &Element) {
   V.preVisit(Element);
   V.postVisit(Element);
 }
@@ -171,12 +163,12 @@ struct DefaultTupleTreeVisitor {
 // tupleIndexByName
 //
 template<typename T, size_t I = 0>
-enable_if_tuple_end_t<I, T, size_t> tupleIndexByName(llvm::StringRef Name) {
+requires IsTupleEnd<T, I> size_t tupleIndexByName(llvm::StringRef Name) {
   return -1;
 }
 
 template<typename T, size_t I = 0>
-enable_if_not_tuple_end_t<I, T, size_t> tupleIndexByName(llvm::StringRef Name) {
+requires IsNotTupleEnd<T, I> size_t tupleIndexByName(llvm::StringRef Name) {
   llvm::StringRef ThisName = TupleLikeTraits<T>::template fieldName<I>();
   if (Name == ThisName)
     return I;
@@ -190,13 +182,12 @@ enable_if_not_tuple_end_t<I, T, size_t> tupleIndexByName(llvm::StringRef Name) {
 namespace tupletree::detail {
 
 template<typename ResultT, size_t I = 0, typename RootT, typename KeyT>
-enable_if_tuple_end_t<I, RootT, ResultT *> getByKeyTuple(RootT &M, KeyT Key) {
+requires IsTupleEnd<RootT, I> ResultT *getByKeyTuple(RootT &M, KeyT Key) {
   return nullptr;
 }
 
 template<typename ResultT, size_t I = 0, typename RootT, typename KeyT>
-enable_if_not_tuple_end_t<I, RootT, ResultT *>
-getByKeyTuple(RootT &M, KeyT Key) {
+requires IsNotTupleEnd<RootT, I> ResultT *getByKeyTuple(RootT &M, KeyT Key) {
   if (I == Key) {
     using tuple_element = typename std::tuple_element<I, RootT>::type;
     revng_assert((std::is_same_v<tuple_element, ResultT>) );
@@ -208,13 +199,13 @@ getByKeyTuple(RootT &M, KeyT Key) {
 
 } // namespace tupletree::detail
 
-template<typename ResultT, typename RootT, typename KeyT>
-enable_if_has_tuple_size_t<RootT, ResultT *> getByKey(RootT &M, KeyT Key) {
+template<typename ResultT, HasTupleSize RootT, typename KeyT>
+ResultT getByKey(RootT &M, KeyT Key) {
   return tupletree::detail::getByKeyTuple<ResultT>(M, Key);
 }
 
-template<typename ResultT, typename RootT, typename KeyT>
-enable_if_is_container_t<RootT, ResultT *> getByKey(RootT &M, KeyT Key) {
+template<typename ResultT, IsContainer RootT, typename KeyT>
+ResultT *getByKey(RootT &M, KeyT Key) {
   for (auto &Element : M) {
     using KOT = KeyedObjectTraits<std::remove_reference_t<decltype(Element)>>;
     if (KOT::key(Element) == Key)
@@ -226,19 +217,16 @@ enable_if_is_container_t<RootT, ResultT *> getByKey(RootT &M, KeyT Key) {
 //
 // callOnPathSteps (no instance)
 //
-template<typename RootT, typename Visitor>
-enable_if_has_tuple_size_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path);
+template<HasTupleSize RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path);
 
-template<typename RootT, typename Visitor>
-enable_if_is_not_container_or_tuple_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
+template<NotContainerNorTuple RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
   return false;
 }
 
-template<typename RootT, typename Visitor>
-enable_if_is_container_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
+template<IsContainer RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
   using value_type = typename RootT::value_type;
   using KOT = KeyedObjectTraits<value_type>;
   using key_type = decltype(KOT::key(std::declval<value_type>()));
@@ -258,13 +246,13 @@ callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
 namespace tupletree::detail {
 
 template<typename RootT, size_t I = 0, typename Visitor>
-enable_if_tuple_end_t<I, RootT, bool>
+requires IsTupleEnd<RootT, I> bool
 callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
   return true;
 }
 
 template<typename RootT, size_t I = 0, typename Visitor>
-enable_if_not_tuple_end_t<I, RootT, bool>
+requires IsNotTupleEnd<RootT, I> bool
 callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
   if (Path[0] == I) {
     using next_type = typename std::tuple_element<I, RootT>::type;
@@ -281,9 +269,8 @@ callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
 
 } // namespace tupletree::detail
 
-template<typename RootT, typename Visitor>
-enable_if_has_tuple_size_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
+template<HasTupleSize RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
   return tupletree::detail::callOnPathStepsTuple<RootT>(V, Path);
 }
 
@@ -294,19 +281,18 @@ callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path) {
 namespace tupletree::detail {
 
 template<size_t I = 0, typename RootT, typename Visitor>
-enable_if_tuple_end_t<I, RootT, bool>
+requires IsTupleEnd<RootT, I> bool
 callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
   return true;
 }
 
-template<typename RootT, typename Visitor>
-enable_if_is_not_container_or_tuple_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
+template<NotContainerNorTuple RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
   return false;
 }
 
 template<size_t I = 0, typename RootT, typename Visitor>
-enable_if_not_tuple_end_t<I, RootT, bool>
+requires IsNotTupleEnd<RootT, I> bool
 callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
   if (Path[0] == I) {
     using next_type = typename std::tuple_element<I, RootT>::type;
@@ -324,15 +310,13 @@ callOnPathStepsTuple(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
 
 } // namespace tupletree::detail
 
-template<typename RootT, typename Visitor>
-enable_if_has_tuple_size_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
+template<HasTupleSize RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
   return tupletree::detail::callOnPathStepsTuple(V, Path, M);
 }
 
-template<typename RootT, typename Visitor>
-enable_if_is_container_t<RootT, bool>
-callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
+template<IsContainer RootT, typename Visitor>
+bool callOnPathSteps(Visitor &V, llvm::ArrayRef<KeyInt> Path, RootT &M) {
   using value_type = typename RootT::value_type;
   using KOT = KeyedObjectTraits<value_type>;
   using key_type = decltype(KOT::key(std::declval<value_type>()));
@@ -615,22 +599,19 @@ private:
                          llvm::StringRef Rest,
                          PathMatcher &Result);
 
-  template<typename T>
-  static enable_if_has_tuple_size_t<T, bool>
-  visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result);
+  template<HasTupleSize T>
+  static bool visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result);
 
-  template<typename T>
-  static enable_if_is_container_t<T, bool>
-  visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result);
+  template<IsContainer T>
+  static bool visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result);
 
-  template<typename T>
-  static enable_if_is_not_container_or_tuple_t<T, bool>
-  visitTupleTreeNode(llvm::StringRef Path, PathMatcher &Result);
+  template<NotContainerNorTuple T>
+  static bool visitTupleTreeNode(llvm::StringRef Path, PathMatcher &Result);
 };
 
-template<typename T>
-enable_if_has_tuple_size_t<T, bool>
-PathMatcher::visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result) {
+template<HasTupleSize T>
+bool PathMatcher::visitTupleTreeNode(llvm::StringRef String,
+                                     PathMatcher &Result) {
   if (String.size() == 0)
     return true;
 
@@ -638,9 +619,9 @@ PathMatcher::visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result) {
   return visitTuple<T>(Before, After, Result);
 }
 
-template<typename T>
-enable_if_is_container_t<T, bool>
-PathMatcher::visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result) {
+template<IsContainer T>
+bool PathMatcher::visitTupleTreeNode(llvm::StringRef String,
+                                     PathMatcher &Result) {
   if (String.size() == 0)
     return true;
 
@@ -662,9 +643,9 @@ PathMatcher::visitTupleTreeNode(llvm::StringRef String, PathMatcher &Result) {
   return visitTupleTreeNode<Value>(After, Result);
 }
 
-template<typename T>
-enable_if_is_not_container_or_tuple_t<T, bool>
-PathMatcher::visitTupleTreeNode(llvm::StringRef Path, PathMatcher &Result) {
+template<NotContainerNorTuple T>
+bool PathMatcher::visitTupleTreeNode(llvm::StringRef Path,
+                                     PathMatcher &Result) {
   return Path.size() == 0;
 }
 

--- a/include/revng/Model/TupleTreeDiff.h
+++ b/include/revng/Model/TupleTreeDiff.h
@@ -161,7 +161,7 @@ private:
     }
   }
 
-  template<NotContainerNorTuple T>
+  template<NotTupleTreeCompatible T>
   void diffImpl(T &LHS, T &RHS) {
     if (LHS != RHS)
       Result.change(Stack, &LHS, &RHS);
@@ -233,7 +233,7 @@ struct DumpDiffVisitor {
     dump<typename T::value_type>();
   }
 
-  template<NotContainerNorTuple T>
+  template<NotTupleTreeCompatible T>
   void visit() {
     revng_assert(Old != nullptr and New != nullptr);
     dump<T>();

--- a/include/revng/Model/TupleTreeDiff.h
+++ b/include/revng/Model/TupleTreeDiff.h
@@ -20,31 +20,18 @@ template<typename T, typename A>
 struct is_std_vector<std::vector<T, A>> : std::true_type {};
 
 template<typename T>
-constexpr bool has_push_back_v = is_std_vector<T>::value;
-
-template<typename T, typename K = void>
-using enable_if_has_push_back_t = std::enable_if_t<has_push_back_v<T>, K>;
+concept HasPushBack = is_std_vector<T>::value;
 
 template<typename T>
-constexpr bool has_insert_or_assign_v = not has_push_back_v<T>;
+concept HasInsertOrAssign = not HasPushBack<T>;
 
-namespace detail {
-template<typename T, typename K = void>
-using ei_hioa_t = std::enable_if_t<has_insert_or_assign_v<T>, K>;
-}
-
-template<typename T, typename K = void>
-using enable_if_has_insert_or_assign_t = detail::ei_hioa_t<T, K>;
-
-template<typename C>
-enable_if_has_insert_or_assign_t<C>
-addToContainer(C &Container, const typename C::value_type &Value) {
+template<HasInsertOrAssign C>
+void addToContainer(C &Container, const typename C::value_type &Value) {
   Container.insert_or_assign(Value);
 }
 
-template<typename C>
-enable_if_has_push_back_t<C>
-addToContainer(C &Container, const typename C::value_type &Value) {
+template<HasPushBack C>
+void addToContainer(C &Container, const typename C::value_type &Value) {
   Container.push_back(Value);
 }
 
@@ -98,10 +85,10 @@ struct Diff {
 
 private:
   template<size_t I = 0, typename T>
-  enable_if_tuple_end_t<I, T> diffTuple(T &LHS, T &RHS) {}
+  requires IsTupleEnd<T, I> void diffTuple(T &LHS, T &RHS) {}
 
   template<size_t I = 0, typename T>
-  enable_if_not_tuple_end_t<I, T> diffTuple(T &LHS, T &RHS) {
+  requires IsNotTupleEnd<T, I> void diffTuple(T &LHS, T &RHS) {
     using child_type = typename std::tuple_element<I, T>::type;
 
     Stack.push_back(I);
@@ -112,13 +99,13 @@ private:
     diffTuple<I + 1>(LHS, RHS);
   }
 
-  template<typename T>
-  enable_if_has_tuple_size_t<T> diffImpl(T &LHS, T &RHS) {
+  template<HasTupleSize T>
+  void diffImpl(T &LHS, T &RHS) {
     diffTuple(LHS, RHS);
   }
 
-  template<typename T>
-  enable_if_is_sorted_container_t<T> diffImpl(T &LHS, T &RHS) {
+  template<SortedContainer T>
+  void diffImpl(T &LHS, T &RHS) {
     using value_type = typename T::value_type;
     using KOT = KeyedObjectTraits<value_type>;
     using key_type = decltype(KOT::key(std::declval<value_type>()));
@@ -144,8 +131,8 @@ private:
     }
   }
 
-  template<typename T>
-  enable_if_is_unsorted_container_t<T> diffImpl(T &LHS, T &RHS) {
+  template<UnsortedContainer T>
+  void diffImpl(T &LHS, T &RHS) {
     using value_type = typename T::value_type;
     using KOT = KeyedObjectTraits<value_type>;
     using key_type = decltype(KOT::key(std::declval<value_type>()));
@@ -174,9 +161,8 @@ private:
     }
   }
 
-  template<typename T>
-  std::enable_if_t<not(is_container_v<T> or has_tuple_size_v<T>)>
-  diffImpl(T &LHS, T &RHS) {
+  template<NotContainerNorTuple T>
+  void diffImpl(T &LHS, T &RHS) {
     if (LHS != RHS)
       Result.change(Stack, &LHS, &RHS);
   }
@@ -194,16 +180,16 @@ TupleTreeDiff<M> diff(M &LHS, M &RHS) {
 //
 namespace tupletreediff::detail {
 
-template<typename T, typename S>
-enable_if_has_yaml_t<T> stream(T *M, S &Stream) {
+template<Yamlizable T, typename S>
+void stream(T *M, S &Stream) {
   using namespace llvm::yaml;
   Output Out(Stream);
   EmptyContext Ctx;
   yamlize(Out, *M, true, Ctx);
 }
 
-template<typename T, typename S>
-enable_if_has_not_yaml_t<T> stream(T *M, S &Stream) {
+template<NotYamlizable T, typename S>
+void stream(T *M, S &Stream) {
   Stream << *M;
 }
 
@@ -241,14 +227,14 @@ struct DumpDiffVisitor {
   template<typename T, typename KeyT>
   void visitContainerElement(KeyT Key) {}
 
-  template<typename T>
-  enable_if_is_container_t<T> visit() {
+  template<IsContainer T>
+  void visit() {
     revng_assert((Old != nullptr) != (New != nullptr));
     dump<typename T::value_type>();
   }
 
-  template<typename T>
-  enable_if_is_not_container_t<T> visit() {
+  template<NotContainerNorTuple T>
+  void visit() {
     revng_assert(Old != nullptr and New != nullptr);
     dump<T>();
   }
@@ -296,6 +282,15 @@ inline void TupleTreeDiff<T>::dump() const {
 //
 namespace tupletreediff::detail {
 
+// clang-format off
+template<typename T>
+concept IterableAndNotStdString
+  = Iterable<T> and not std::is_same_v<std::string, T>;
+// clang-format on
+
+template<typename T>
+concept NotIterableOrStdString = not IterableAndNotStdString<T>;
+
 template<typename T>
 struct ApplyDiffVisitor {
   using Change = typename TupleTreeDiff<T>::Change;
@@ -311,9 +306,8 @@ struct ApplyDiffVisitor {
     visit(Element);
   }
 
-  template<typename S>
-  std::enable_if_t<is_iterable_v<S> and !std::is_same_v<std::string, S>>
-  visit(S &M) {
+  template<IterableAndNotStdString S>
+  void visit(S &M) {
     revng_assert((C->Old == nullptr) != (C->New == nullptr));
 
     using value_type = typename S::value_type;
@@ -337,9 +331,8 @@ struct ApplyDiffVisitor {
     }
   }
 
-  template<typename S>
-  std::enable_if_t<!(is_iterable_v<S> and !std::is_same_v<std::string, S>)>
-  visit(S &M) {
+  template<NotIterableOrStdString S>
+  void visit(S &M) {
     revng_assert(C->Old != nullptr and C->New != nullptr);
     auto *Old = reinterpret_cast<S *>(C->Old);
     auto *New = reinterpret_cast<S *>(C->New);

--- a/include/revng/Support/MonotoneFramework.h
+++ b/include/revng/Support/MonotoneFramework.h
@@ -37,7 +37,7 @@ enum VisitType {
 
 /// \brief Work list for the monotone framework supporting various visit
 ///        strategies
-template<typename Iterated, VisitType Visit, typename = void>
+template<typename Iterated, VisitType Visit>
 class MonotoneFrameworkWorkList {};
 
 // Breadth first implementation
@@ -57,14 +57,12 @@ public:
 };
 
 template<VisitType V>
-using enable_if_post_order = std::enable_if<V == PostOrder
-                                            or V == ReversePostOrder>;
+concept IsPostOrderLike = V == PostOrder or V == ReversePostOrder;
 
 // (Reverse) post order implementation
 template<typename Iterated, VisitType Visit>
-class MonotoneFrameworkWorkList<Iterated,
-                                Visit,
-                                typename enable_if_post_order<Visit>::type> {
+requires IsPostOrderLike<Visit> class MonotoneFrameworkWorkList<Iterated,
+                                                                Visit> {
 private:
   /// \brief Class for an entry in the work list
   ///

--- a/include/revng/Support/YAMLTraits.h
+++ b/include/revng/Support/YAMLTraits.h
@@ -6,21 +6,6 @@
 
 #include "llvm/Support/YAMLTraits.h"
 
-namespace detail {
-
-using namespace llvm::yaml;
-
-template<typename T>
-using has_MappingTraits = has_MappingTraits<T, EmptyContext>;
-
-template<typename T, typename K = void>
-using ei_hmt = std::enable_if_t<has_MappingTraits<T>::value, K>;
-
-} // namespace detail
-
-template<typename T, typename K = void>
-using enable_if_has_MappingTraits = detail::ei_hmt<T, K>;
-
 template<typename T>
 inline llvm::StringRef getNameFromYAMLEnumScalar(T V) {
   using namespace llvm::yaml;

--- a/lib/FunctionIsolation/CMakeLists.txt
+++ b/lib/FunctionIsolation/CMakeLists.txt
@@ -8,6 +8,7 @@ revng_add_analyses_library_internal(revngFunctionIsolation
   InvokeIsolatedFunctions.cpp
   IsolateFunctions.cpp
   PromoteCSVs.cpp
+  RemoveExceptionalCalls.cpp
   StructInitializers.cpp)
 
 target_link_libraries(revngFunctionIsolation

--- a/lib/FunctionIsolation/CMakeLists.txt
+++ b/lib/FunctionIsolation/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 revng_add_analyses_library_internal(revngFunctionIsolation
   EnforceABI.cpp
+  InlineHelpers.cpp
   InvokeIsolatedFunctions.cpp
   IsolateFunctions.cpp
   PromoteCSVs.cpp

--- a/lib/FunctionIsolation/InlineHelpers.cpp
+++ b/lib/FunctionIsolation/InlineHelpers.cpp
@@ -1,0 +1,93 @@
+/// \file InlineHelpers.cpp
+/// \brief
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <iterator>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+#include "revng/ADT/Queue.h"
+#include "revng/BasicAnalyses/GeneratedCodeBasicInfo.h"
+#include "revng/FunctionIsolation/InlineHelpers.h"
+#include "revng/Support/IRHelpers.h"
+#include "revng/Support/OpaqueFunctionsPool.h"
+
+using namespace llvm;
+
+// TODO: make sure we do not inline loops
+
+char InlineHelpersPass::ID = 0;
+
+using Register = RegisterPass<InlineHelpersPass>;
+static Register X("inline-helpers", "Inline Helpers Pass", true, true);
+
+static bool shouldInline(Function *F) {
+  if (F == nullptr)
+    return false;
+
+  return F->getSection() == "revng_inline";
+}
+
+static CallInst *getCallToInline(Instruction *I) {
+  if (auto *Call = dyn_cast<CallInst>(I)) {
+    if (shouldInline(Call->getCalledFunction())) {
+      return Call;
+    }
+  }
+
+  return nullptr;
+}
+
+static void doInline(CallInst *Call) {
+  InlineFunctionInfo IFI;
+  auto Result = InlineFunction(Call, IFI, nullptr, false);
+  revng_assert(Result);
+}
+
+static bool doInline(Function *F) {
+  SmallVector<CallInst *, 8> ToInline;
+
+  for (BasicBlock &BB : *F)
+    for (Instruction &I : BB)
+      if (auto *Call = getCallToInline(&I))
+        ToInline.push_back(Call);
+
+  for (CallInst *Call : ToInline) {
+    doInline(Call);
+  }
+
+  return ToInline.size() > 0;
+}
+
+class InlineHelpers {
+private:
+  LLVMContext &C;
+
+public:
+  InlineHelpers(Module *M) : C(M->getContext()) {}
+
+  void run(Function *F);
+
+private:
+  void wrapCallsToHelpers(Function *F);
+};
+
+void InlineHelpers::run(Function *F) {
+  // Fixed-point inlining
+  while (doInline(F))
+    ;
+}
+
+bool InlineHelpersPass::runOnFunction(Function &F) {
+  if (not FunctionTags::Lifted.isTagOf(&F))
+    return false;
+
+  InlineHelpers IH(F.getParent());
+  IH.run(&F);
+  return true;
+}

--- a/lib/FunctionIsolation/IsolateFunctions.cpp
+++ b/lib/FunctionIsolation/IsolateFunctions.cpp
@@ -625,10 +625,10 @@ void IFI::handleBasicBlock(const model::BasicBlock &Block,
   // if any
 
   SuccessorsContainer ExpectedSuccessors;
-  for (const model::FunctionEdge &E : Block.Successors) {
+  for (const auto &E : Block.Successors) {
     // Ignore self-loops
-    if (E.Destination != Block.Start) {
-      ExpectedSuccessors[E] = 0;
+    if (E->Destination != Block.Start) {
+      ExpectedSuccessors[*E] = 0;
     }
   }
 
@@ -646,7 +646,7 @@ void IFI::handleBasicBlock(const model::BasicBlock &Block,
     {
       raw_string_ostream StringStream(Buffer);
       yaml::Output YAMLOutput(StringStream);
-      for (model::FunctionEdge Edge : Block.Successors) {
+      for (auto Edge : Block.Successors) {
         YAMLOutput << Edge;
       }
     }

--- a/lib/FunctionIsolation/PromoteCSVs.cpp
+++ b/lib/FunctionIsolation/PromoteCSVs.cpp
@@ -91,7 +91,7 @@ PromoteCSVs::PromoteCSVs(Module *M, const GeneratedCodeBasicInfo &GCBI) :
       if (FunctionTags::OpaqueCSVValue.isTagOf(F))
         CSVInitializers.record(CSV->getName(), F);
 
-  copy(CSVs, std::inserter(this->CSVs, this->CSVs.begin()));
+  copy(GCBI.csvs(), std::inserter(this->CSVs, this->CSVs.begin()));
 }
 
 // TODO: assign alias information

--- a/lib/FunctionIsolation/RemoveExceptionalCalls.cpp
+++ b/lib/FunctionIsolation/RemoveExceptionalCalls.cpp
@@ -1,0 +1,59 @@
+/// \file RemoveExceptionalCalls.cpp
+/// \brief
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+#include "revng/FunctionIsolation/RemoveExceptionalCalls.h"
+#include "revng/Support/FunctionTags.h"
+#include "revng/Support/IRHelpers.h"
+
+using namespace llvm;
+
+char RemoveExceptionalCalls::ID = 0;
+
+using Register = RegisterPass<RemoveExceptionalCalls>;
+static Register
+  X("remove-exceptional-functions", "Remove Exceptional Functions");
+
+bool RemoveExceptionalCalls::runOnModule(llvm::Module &M) {
+  LLVMContext &C = M.getContext();
+
+  // Collect all calls to exceptional functions in lifted functions
+  std::set<CallBase *> ToErase;
+  for (Function &F : FunctionTags::Exceptional.functions(&M))
+    for (CallBase *Call : callers(&F))
+      if (FunctionTags::Lifted.isTagOf(Call->getParent()->getParent()))
+        ToErase.insert(Call);
+
+  std::set<Function *> ToCleanup;
+  for (CallBase *Call : ToErase) {
+    BasicBlock *BB = Call->getParent();
+
+    // Register function for cleanup
+    ToCleanup.insert(BB->getParent());
+
+    // Split containing basic block
+    BB->splitBasicBlock(Call);
+
+    // Drop terminator of the old basic block
+    BB->getTerminator()->eraseFromParent();
+
+    // Terminate with an unreachable
+    new UnreachableInst(C, BB);
+
+    // Drop function call
+    Call->eraseFromParent();
+  }
+
+  // Garbage collect dead blocks
+  for (Function *F : ToCleanup)
+    EliminateUnreachableBlocks(*F, nullptr, false);
+
+  return true;
+}

--- a/lib/FunctionIsolation/RemoveExceptionalCalls.cpp
+++ b/lib/FunctionIsolation/RemoveExceptionalCalls.cpp
@@ -48,6 +48,8 @@ bool RemoveExceptionalCalls::runOnModule(llvm::Module &M) {
     new UnreachableInst(C, BB);
 
     // Drop function call
+    auto *Undef = UndefValue::get(Call->getType());
+    Call->replaceAllUsesWith(Undef);
     Call->eraseFromParent();
   }
 

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -79,9 +79,9 @@ bool Binary::verify() const {
 
     // Ensure all the direct function calls target an existing function
     for (const BasicBlock &Block : F.CFG) {
-      for (const FunctionEdge &Edge : Block.Successors) {
-        if (Edge.Type == FunctionEdgeType::FunctionCall
-            and Functions.count(Edge.Destination) == 0) {
+      for (const auto &Edge : Block.Successors) {
+        if (Edge->Type == FunctionEdgeType::FunctionCall
+            and Functions.count(Edge->Destination) == 0) {
           return false;
         }
       }
@@ -98,8 +98,8 @@ static FunctionCFG getGraph(const Function &F) {
   for (const BasicBlock &Block : F.CFG) {
     auto *Source = Graph.get(Block.Start);
 
-    for (const FunctionEdge &Edge : Block.Successors) {
-      switch (Edge.Type) {
+    for (const auto &Edge : Block.Successors) {
+      switch (Edge->Type) {
       case DirectBranch:
       case FakeFunctionCall:
       case FakeFunctionReturn:
@@ -108,7 +108,7 @@ static FunctionCFG getGraph(const Function &F) {
       case IndirectTailCall:
       case LongJmp:
       case Unreachable:
-        Source->addSuccessor(Graph.get(Edge.Destination));
+        Source->addSuccessor(Graph.get(Edge->Destination));
         break;
 
       case FunctionCall:
@@ -140,8 +140,8 @@ void Function::dumpCFG() const {
 bool Function::verify() const {
   // Verify blocks
   for (const BasicBlock &Block : CFG)
-    for (const FunctionEdge &Edge : Block.Successors)
-      if (not Edge.verify())
+    for (const auto &Edge : Block.Successors)
+      if (not Edge->verify())
         return false;
 
   // Populate graph

--- a/tests/analysis/AnalysisTests.cmake
+++ b/tests/analysis/AnalysisTests.cmake
@@ -80,6 +80,7 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --invoke-isolated-functions
       --inline-helpers
       --promote-csvs
+      --remove-exceptional-functions
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()

--- a/tests/analysis/AnalysisTests.cmake
+++ b/tests/analysis/AnalysisTests.cmake
@@ -78,6 +78,8 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --enforce-abi
       --promote-csvs
       --invoke-isolated-functions
+      --inline-helpers
+      --promote-csvs
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()

--- a/tests/runtime/RuntimeTests.cmake
+++ b/tests/runtime/RuntimeTests.cmake
@@ -59,6 +59,7 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --invoke-isolated-functions
       --inline-helpers
       --promote-csvs
+      --remove-exceptional-functions
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()
@@ -78,6 +79,7 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --invoke-isolated-functions
       --inline-helpers
       --promote-csvs
+      --remove-exceptional-functions
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()

--- a/tests/runtime/RuntimeTests.cmake
+++ b/tests/runtime/RuntimeTests.cmake
@@ -57,6 +57,8 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --enforce-abi
       --promote-csvs
       --invoke-isolated-functions
+      --inline-helpers
+      --promote-csvs
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()
@@ -74,6 +76,8 @@ macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
       --enforce-abi
       --promote-csvs
       --invoke-isolated-functions
+      --inline-helpers
+      --promote-csvs
       -o "${OUTPUT}")
     set(DEPEND_ON revng-all-binaries)
   endif()

--- a/tests/unit/UnitTests.cmake
+++ b/tests/unit/UnitTests.cmake
@@ -268,6 +268,24 @@ add_test(NAME test_instantiatepasses COMMAND ./bin/test_instantiatepasses)
 set_tests_properties(test_instantiatepasses PROPERTIES LABELS "unit")
 
 #
+# test_upcastablepointer
+#
+
+revng_add_private_executable(test_upcastablepointer "${SRC}/UpcastablePointer.cpp")
+target_compile_definitions(test_upcastablepointer
+  PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_include_directories(test_upcastablepointer
+  PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_upcastablepointer
+  revngSupport
+  revngUnitTestHelpers
+  revngModel
+  Boost::unit_test_framework
+  ${LLVM_LIBRARIES})
+add_test(NAME test_upcastablepointer COMMAND ./bin/test_upcastablepointer)
+set_tests_properties(test_upcastablepointer PROPERTIES LABELS "unit")
+
+#
 # test_recursive_coroutines
 #
 

--- a/tests/unit/UpcastablePointer.cpp
+++ b/tests/unit/UpcastablePointer.cpp
@@ -1,0 +1,52 @@
+/// \file UpcastablePointer.cpp
+/// \brief
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/ADT/UpcastablePointer.h"
+
+// clang-format off
+template<typename T>
+concept UniquePtrLike = requires(T a, typename T::pointer b) {
+  std::is_pointer_v<typename T::pointer>;
+  typename T::element_type;
+  { a.get() } -> same_as<typename T::pointer>;
+  { a.reset(b) } -> same_as<void>;
+  { T() };
+  { T(b) };
+};
+// clang-format on
+
+class TestClass {
+public:
+  static bool classof(TestClass *) { return true; }
+};
+
+template<>
+struct concrete_types_traits<TestClass> {
+  using type = std::tuple<TestClass>;
+};
+
+// Test UniquePtrLike
+static_assert(UniquePtrLike<std::unique_ptr<int>>);
+static_assert(not UniquePtrLike<TestClass>);
+static_assert(UniquePtrLike<UpcastablePointer<TestClass>>);
+
+static_assert(Upcastable<TestClass>);
+
+// Test UpcastablePointerLike
+static_assert(UpcastablePointerLike<TestClass *>);
+static_assert(UpcastablePointerLike<std::unique_ptr<TestClass>>);
+static_assert(UpcastablePointerLike<UpcastablePointer<TestClass>>);
+
+static_assert(std::is_default_constructible_v<UpcastablePointer<TestClass>>);
+static_assert(std::is_copy_assignable_v<UpcastablePointer<TestClass>>);
+static_assert(std::is_copy_constructible_v<UpcastablePointer<TestClass>>);
+static_assert(std::is_move_assignable_v<UpcastablePointer<TestClass>>);
+static_assert(std::is_move_constructible_v<UpcastablePointer<TestClass>>);
+
+int main() {
+  return 0;
+}

--- a/tests/unit/ZipMapIterator.cpp
+++ b/tests/unit/ZipMapIterator.cpp
@@ -28,8 +28,8 @@ using namespace llvm;
 template<typename T, typename = void>
 struct KeyContainer {};
 
-template<typename T>
-struct KeyContainer<T, enable_if_is_map_like_t<T>> {
+template<MapLike T>
+struct KeyContainer<T> {
   using key_type = typename T::key_type;
 
   static void insert(T &Container, typename T::key_type Key) {
@@ -43,8 +43,8 @@ struct KeyContainer<T, enable_if_is_map_like_t<T>> {
   static void sort(T &) {}
 };
 
-template<typename T>
-struct KeyContainer<T, enable_if_is_sorted_container_t<T>> {
+template<SortedContainer T>
+struct KeyContainer<T> {
   using key_type = const typename T::key_type;
 
   static void insert(T &Container, key_type Key) { Container.insert(Key); }
@@ -54,9 +54,8 @@ struct KeyContainer<T, enable_if_is_sorted_container_t<T>> {
   static void sort(T &) {}
 };
 
-template<typename T>
-struct KeyContainer<T,
-                    typename std::enable_if_t<is_vector_of_pairs<T>::value>> {
+template<VectorOfPairs T>
+struct KeyContainer<T> {
   using key_type = typename T::value_type::first_type;
   using value_type = std::conditional_t<std::is_const<T>::value,
                                         const typename T::value_type,

--- a/tools/revng-lift/CodeGenerator.cpp
+++ b/tools/revng-lift/CodeGenerator.cpp
@@ -385,8 +385,17 @@ std::string SegmentInfo::generateName() {
 }
 
 static BasicBlock *replaceFunction(Function *ToReplace) {
+  // Save tags and attributes before calling dropAllReferences, because that
+  // clears both, and we want to keep them.
+  FunctionTags::TagsSet Tags = FunctionTags::TagsSet::from(ToReplace);
+  AttributeList Attributes = ToReplace->getAttributes();
+
   ToReplace->setLinkage(GlobalValue::InternalLinkage);
   ToReplace->dropAllReferences();
+
+  // Reassign the old tags and attributes.
+  Tags.addTo(ToReplace);
+  ToReplace->setAttributes(Attributes);
 
   return BasicBlock::Create(ToReplace->getParent()->getContext(),
                             "",


### PR DESCRIPTION
With these fixes the only issues left in revng-c are the `ExtractValueInst` patterns we found out today, that I'm going to handle soon.

In the meantime, feel free to fixup these commits wherever you think they fit better.

As soon as I'm done with the `ExtractValueInst` thingy we should be good and we should be able finally merge the whole inline-helpers effort.