### PR TITLE
Fix issues detected by ASAN

### DIFF
--- a/include/revng/Support/Generator.h
+++ b/include/revng/Support/Generator.h
@@ -150,14 +150,16 @@ public:
   }
 
   generator(const generator &other) = delete;
+  generator &operator=(const generator &other) = delete;
 
   ~generator() {
     if (m_coroutine) {
+      revng_assert(m_coroutine.done());
       m_coroutine.destroy();
     }
   }
 
-  generator &operator=(generator other) noexcept {
+  generator &operator=(generator &&other) noexcept {
     swap(other);
     return *this;
   }

--- a/tools/revng-lift/InstructionTranslator.cpp
+++ b/tools/revng-lift/InstructionTranslator.cpp
@@ -508,6 +508,8 @@ void IT::finalizeNewPCMarkers(std::string &CoveragePath) {
   Output << std::hex;
   size_t FixedArgCount = NewPCMarker->arg_size();
 
+  llvm::SmallVector<CallInst *, 4> CallsToRemove;
+
   for (User *U : NewPCMarker->users()) {
     auto *Call = cast<CallInst>(U);
 
@@ -534,9 +536,13 @@ void IT::finalizeNewPCMarkers(std::string &CoveragePath) {
       NewCall->copyMetadata(*Call);
 
       revng_assert(Call->use_empty());
-      Call->eraseFromParent();
+      CallsToRemove.push_back(Call);
     }
   }
+
+  for (auto *Call : CallsToRemove)
+    Call->eraseFromParent();
+
   Output << std::dec;
 }
 


### PR DESCRIPTION
This PR fixes a some issues that emerged by running revng with ASAN. Specifically:

- cppcoro did not delete the default copy assignment which might be used unsafely
- cppcoro now move assignment now takes an rvalue reference
- cppcoro now asserts that the coroutines are done when destroying them
- fixed a use after free in InstructionTranslator