### PR TITLE
Improve interactions between `TupleTreeReference`, `UpcastablePointer` and `KeyedObjectTraits`

### DIFF
--- a/include/revng/ADT/KeyedObjectTraits.h
+++ b/include/revng/ADT/KeyedObjectTraits.h
@@ -7,7 +7,7 @@
 #include "revng/ADT/STLExtras.h"
 #include "revng/Support/Concepts.h"
 
-template<typename T, typename = void>
+template<typename T>
 struct KeyedObjectTraits {
   // static * key(const T &);
   // static T fromKey(* Key);

--- a/include/revng/ADT/TupleTreePath.h
+++ b/include/revng/ADT/TupleTreePath.h
@@ -151,9 +151,7 @@ public:
   const TupleTreeKeyWrapper &operator[](size_t Index) const {
     return Storage[Index];
   }
-  bool operator==(const TupleTreePath &Other) const {
-    return Storage == Other.Storage;
-  }
+  bool operator==(const TupleTreePath &Other) const = default;
 
   // TODO: should return ArrayRef<const TupleTreeKeyWrapper>
   llvm::ArrayRef<TupleTreeKeyWrapper> toArrayRef() const { return { Storage }; }

--- a/include/revng/ADT/TupleTreePath.h
+++ b/include/revng/ADT/TupleTreePath.h
@@ -25,17 +25,23 @@ protected:
 public:
   TupleTreeKeyWrapper() : Pointer(nullptr) {}
 
-  TupleTreeKeyWrapper(const TupleTreeKeyWrapper &Other) { Other.clone(this); }
-  TupleTreeKeyWrapper(TupleTreeKeyWrapper &&Other) { Other.clone(this); }
   TupleTreeKeyWrapper &operator=(const TupleTreeKeyWrapper &Other) {
-    Other.clone(this);
+    if (&Other != this) {
+      Other.clone(this);
+    }
     return *this;
   }
 
+  TupleTreeKeyWrapper(const TupleTreeKeyWrapper &Other) { *this = Other; }
+
   TupleTreeKeyWrapper &operator=(TupleTreeKeyWrapper &&Other) {
-    Other.clone(this);
+    if (&Other != this) {
+      Other.clone(this);
+    }
     return *this;
   }
+
+  TupleTreeKeyWrapper(TupleTreeKeyWrapper &&Other) { *this = Other; }
 
   virtual ~TupleTreeKeyWrapper(){};
   virtual bool operator==(const TupleTreeKeyWrapper &) const {
@@ -114,20 +120,24 @@ private:
 
 public:
   TupleTreePath() = default;
-  TupleTreePath(TupleTreePath &&Other) = default;
-  TupleTreePath &operator=(TupleTreePath &&Other) = default;
 
-  TupleTreePath(const TupleTreePath &Other) { *this = Other; }
+  TupleTreePath &operator=(TupleTreePath &&) = default;
+  TupleTreePath(TupleTreePath &&) = default;
 
   TupleTreePath &operator=(const TupleTreePath &Other) {
-    Storage.resize(Other.size());
-    for (auto [ThisElement, OtherElement] : llvm::zip(Storage, Other.Storage)) {
-      static_assert(std::is_reference_v<decltype(ThisElement)>);
-      OtherElement.clone(&ThisElement);
+    if (&Other != this) {
+      Storage.resize(Other.size());
+      for (auto [ThisElement, OtherElement] :
+           llvm::zip(Storage, Other.Storage)) {
+        static_assert(std::is_reference_v<decltype(ThisElement)>);
+        OtherElement.clone(&ThisElement);
+      }
     }
 
     return *this;
   }
+
+  TupleTreePath(const TupleTreePath &Other) { *this = Other; }
 
 public:
   template<typename T, typename... Args>

--- a/include/revng/ADT/UpcastablePointer.h
+++ b/include/revng/ADT/UpcastablePointer.h
@@ -126,28 +126,32 @@ public:
   constexpr UpcastablePointer(std::nullptr_t P) noexcept :
     Pointer(P, deleter) {}
   explicit UpcastablePointer(pointer P) noexcept : Pointer(P, deleter) {}
-  UpcastablePointer(UpcastablePointer &&P) noexcept :
-    Pointer(std::move(P.Pointer)) {
-    revng_assert(Pointer.get_deleter() == deleter);
-  }
 
 public:
-  UpcastablePointer(const UpcastablePointer &Other) :
-    Pointer(nullptr, deleter) {
-    *this = Other;
-    revng_assert(Pointer.get_deleter() == deleter);
+  UpcastablePointer &operator=(const UpcastablePointer &Other) {
+    if (&Other != this) {
+      Pointer.reset(clone(Other.Pointer.get()));
+      revng_assert(Pointer.get_deleter() == deleter);
+    }
+    return *this;
   }
 
-  UpcastablePointer &operator=(const UpcastablePointer &Other) {
-    Pointer.reset(clone(Other.Pointer.get()));
-    revng_assert(Pointer.get_deleter() == deleter);
-    return *this;
+  UpcastablePointer(const UpcastablePointer &Other) :
+    UpcastablePointer(nullptr) {
+    *this = Other;
   }
 
   UpcastablePointer &operator=(UpcastablePointer &&Other) {
-    Pointer.reset(Other.Pointer.release());
-    revng_assert(Pointer.get_deleter() == deleter);
+    if (&Other != this) {
+      Pointer.reset(Other.Pointer.release());
+      revng_assert(Pointer.get_deleter() == deleter);
+    }
     return *this;
+  }
+
+  UpcastablePointer(UpcastablePointer &&Other) noexcept :
+    UpcastablePointer(nullptr) {
+    *this = std::move(Other);
   }
 
   bool operator==(const UpcastablePointer &Other) const {

--- a/include/revng/ADT/UpcastablePointer.h
+++ b/include/revng/ADT/UpcastablePointer.h
@@ -179,3 +179,6 @@ private:
 
 template<typename T>
 concept IsUpcastablePointer = is_specialization_v<T, UpcastablePointer>;
+
+template<typename T>
+concept IsNotUpcastablePointer = not IsUpcastablePointer<T>;

--- a/include/revng/ADT/UpcastablePointer.h
+++ b/include/revng/ADT/UpcastablePointer.h
@@ -52,7 +52,7 @@ template<typename T>
 concept UpcastablePointerLike = PointerLike<T> and Upcastable<pointee<T>>;
 
 template<typename T>
-concept NotVoid = !same_as<void, T>;
+concept NotVoid = not std::is_void_v<T>;
 
 template<NotVoid ReturnT, typename L, UpcastablePointerLike P, size_t I = 0>
 ReturnT upcast(P &Upcastable, const L &Callable, const ReturnT &IfNull) {

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -211,6 +211,149 @@ enum Values {
   f14_systemz,
   f15_systemz
 };
+} // end namespace model::Register
+
+namespace llvm::yaml {
+template<>
+struct ScalarEnumerationTraits<model::Register::Values> {
+  template<typename T>
+  static void enumeration(T &io, model::Register::Values &V) {
+    using namespace model::Register;
+    io.enumCase(V, "Invalid", Invalid);
+    io.enumCase(V, "eax_x86", eax_x86);
+    io.enumCase(V, "ebx_x86", ebx_x86);
+    io.enumCase(V, "ecx_x86", ecx_x86);
+    io.enumCase(V, "edx_x86", edx_x86);
+    io.enumCase(V, "esi_x86", esi_x86);
+    io.enumCase(V, "edi_x86", edi_x86);
+    io.enumCase(V, "ebp_x86", ebp_x86);
+    io.enumCase(V, "esp_x86", esp_x86);
+    io.enumCase(V, "rax_x86_64", rax_x86_64);
+    io.enumCase(V, "rbx_x86_64", rbx_x86_64);
+    io.enumCase(V, "rcx_x86_64", rcx_x86_64);
+    io.enumCase(V, "rdx_x86_64", rdx_x86_64);
+    io.enumCase(V, "rbp_x86_64", rbp_x86_64);
+    io.enumCase(V, "rsp_x86_64", rsp_x86_64);
+    io.enumCase(V, "rsi_x86_64", rsi_x86_64);
+    io.enumCase(V, "rdi_x86_64", rdi_x86_64);
+    io.enumCase(V, "r8_x86_64", r8_x86_64);
+    io.enumCase(V, "r9_x86_64", r9_x86_64);
+    io.enumCase(V, "r10_x86_64", r10_x86_64);
+    io.enumCase(V, "r11_x86_64", r11_x86_64);
+    io.enumCase(V, "r12_x86_64", r12_x86_64);
+    io.enumCase(V, "r13_x86_64", r13_x86_64);
+    io.enumCase(V, "r14_x86_64", r14_x86_64);
+    io.enumCase(V, "r15_x86_64", r15_x86_64);
+    io.enumCase(V, "xmm0_x86_64", xmm0_x86_64);
+    io.enumCase(V, "xmm1_x86_64", xmm1_x86_64);
+    io.enumCase(V, "xmm2_x86_64", xmm2_x86_64);
+    io.enumCase(V, "xmm3_x86_64", xmm3_x86_64);
+    io.enumCase(V, "xmm4_x86_64", xmm4_x86_64);
+    io.enumCase(V, "xmm5_x86_64", xmm5_x86_64);
+    io.enumCase(V, "xmm6_x86_64", xmm6_x86_64);
+    io.enumCase(V, "xmm7_x86_64", xmm7_x86_64);
+    io.enumCase(V, "r0_arm", r0_arm);
+    io.enumCase(V, "r1_arm", r1_arm);
+    io.enumCase(V, "r2_arm", r2_arm);
+    io.enumCase(V, "r3_arm", r3_arm);
+    io.enumCase(V, "r4_arm", r4_arm);
+    io.enumCase(V, "r5_arm", r5_arm);
+    io.enumCase(V, "r6_arm", r6_arm);
+    io.enumCase(V, "r7_arm", r7_arm);
+    io.enumCase(V, "r8_arm", r8_arm);
+    io.enumCase(V, "r9_arm", r9_arm);
+    io.enumCase(V, "r10_arm", r10_arm);
+    io.enumCase(V, "r11_arm", r11_arm);
+    io.enumCase(V, "r12_arm", r12_arm);
+    io.enumCase(V, "r13_arm", r13_arm);
+    io.enumCase(V, "r14_arm", r14_arm);
+    io.enumCase(V, "x0_aarch64", x0_aarch64);
+    io.enumCase(V, "x1_aarch64", x1_aarch64);
+    io.enumCase(V, "x2_aarch64", x2_aarch64);
+    io.enumCase(V, "x3_aarch64", x3_aarch64);
+    io.enumCase(V, "x4_aarch64", x4_aarch64);
+    io.enumCase(V, "x5_aarch64", x5_aarch64);
+    io.enumCase(V, "x6_aarch64", x6_aarch64);
+    io.enumCase(V, "x7_aarch64", x7_aarch64);
+    io.enumCase(V, "x8_aarch64", x8_aarch64);
+    io.enumCase(V, "x9_aarch64", x9_aarch64);
+    io.enumCase(V, "x10_aarch64", x10_aarch64);
+    io.enumCase(V, "x11_aarch64", x11_aarch64);
+    io.enumCase(V, "x12_aarch64", x12_aarch64);
+    io.enumCase(V, "x13_aarch64", x13_aarch64);
+    io.enumCase(V, "x14_aarch64", x14_aarch64);
+    io.enumCase(V, "x15_aarch64", x15_aarch64);
+    io.enumCase(V, "x16_aarch64", x16_aarch64);
+    io.enumCase(V, "x17_aarch64", x17_aarch64);
+    io.enumCase(V, "x18_aarch64", x18_aarch64);
+    io.enumCase(V, "x19_aarch64", x19_aarch64);
+    io.enumCase(V, "x20_aarch64", x20_aarch64);
+    io.enumCase(V, "x21_aarch64", x21_aarch64);
+    io.enumCase(V, "x22_aarch64", x22_aarch64);
+    io.enumCase(V, "x23_aarch64", x23_aarch64);
+    io.enumCase(V, "x24_aarch64", x24_aarch64);
+    io.enumCase(V, "x25_aarch64", x25_aarch64);
+    io.enumCase(V, "x26_aarch64", x26_aarch64);
+    io.enumCase(V, "x27_aarch64", x27_aarch64);
+    io.enumCase(V, "x28_aarch64", x28_aarch64);
+    io.enumCase(V, "x29_aarch64", x29_aarch64);
+    io.enumCase(V, "lr_aarch64", lr_aarch64);
+    io.enumCase(V, "sp_aarch64", sp_aarch64);
+    io.enumCase(V, "v0_mips", v0_mips);
+    io.enumCase(V, "v1_mips", v1_mips);
+    io.enumCase(V, "a0_mips", a0_mips);
+    io.enumCase(V, "a1_mips", a1_mips);
+    io.enumCase(V, "a2_mips", a2_mips);
+    io.enumCase(V, "a3_mips", a3_mips);
+    io.enumCase(V, "s0_mips", s0_mips);
+    io.enumCase(V, "s1_mips", s1_mips);
+    io.enumCase(V, "s2_mips", s2_mips);
+    io.enumCase(V, "s3_mips", s3_mips);
+    io.enumCase(V, "s4_mips", s4_mips);
+    io.enumCase(V, "s5_mips", s5_mips);
+    io.enumCase(V, "s6_mips", s6_mips);
+    io.enumCase(V, "s7_mips", s7_mips);
+    io.enumCase(V, "gp_mips", gp_mips);
+    io.enumCase(V, "sp_mips", sp_mips);
+    io.enumCase(V, "fp_mips", fp_mips);
+    io.enumCase(V, "ra_mips", ra_mips);
+    io.enumCase(V, "r0_systemz", r0_systemz);
+    io.enumCase(V, "r1_systemz", r1_systemz);
+    io.enumCase(V, "r2_systemz", r2_systemz);
+    io.enumCase(V, "r3_systemz", r3_systemz);
+    io.enumCase(V, "r4_systemz", r4_systemz);
+    io.enumCase(V, "r5_systemz", r5_systemz);
+    io.enumCase(V, "r6_systemz", r6_systemz);
+    io.enumCase(V, "r7_systemz", r7_systemz);
+    io.enumCase(V, "r8_systemz", r8_systemz);
+    io.enumCase(V, "r9_systemz", r9_systemz);
+    io.enumCase(V, "r10_systemz", r10_systemz);
+    io.enumCase(V, "r11_systemz", r11_systemz);
+    io.enumCase(V, "r12_systemz", r12_systemz);
+    io.enumCase(V, "r13_systemz", r13_systemz);
+    io.enumCase(V, "r14_systemz", r14_systemz);
+    io.enumCase(V, "r15_systemz", r15_systemz);
+    io.enumCase(V, "f0_systemz", f0_systemz);
+    io.enumCase(V, "f1_systemz", f1_systemz);
+    io.enumCase(V, "f2_systemz", f2_systemz);
+    io.enumCase(V, "f3_systemz", f3_systemz);
+    io.enumCase(V, "f4_systemz", f4_systemz);
+    io.enumCase(V, "f5_systemz", f5_systemz);
+    io.enumCase(V, "f6_systemz", f6_systemz);
+    io.enumCase(V, "f7_systemz", f7_systemz);
+    io.enumCase(V, "f8_systemz", f8_systemz);
+    io.enumCase(V, "f9_systemz", f9_systemz);
+    io.enumCase(V, "f10_systemz", f10_systemz);
+    io.enumCase(V, "f11_systemz", f11_systemz);
+    io.enumCase(V, "f12_systemz", f12_systemz);
+    io.enumCase(V, "f13_systemz", f13_systemz);
+    io.enumCase(V, "f14_systemz", f14_systemz);
+    io.enumCase(V, "f15_systemz", f15_systemz);
+  }
+};
+} // namespace llvm::yaml
+
+namespace model::Register {
 
 inline llvm::StringRef getName(Values V) {
   return getNameFromYAMLEnumScalar(V);
@@ -403,147 +546,8 @@ getInvalidValueFromYAMLScalar<model::Register::Values>() {
   return model::Register::Invalid;
 }
 
-namespace llvm::yaml {
-template<>
-struct ScalarEnumerationTraits<model::Register::Values> {
-  template<typename T>
-  static void enumeration(T &io, model::Register::Values &V) {
-    using namespace model::Register;
-    io.enumCase(V, "Invalid", Invalid);
-    io.enumCase(V, "eax_x86", eax_x86);
-    io.enumCase(V, "ebx_x86", ebx_x86);
-    io.enumCase(V, "ecx_x86", ecx_x86);
-    io.enumCase(V, "edx_x86", edx_x86);
-    io.enumCase(V, "esi_x86", esi_x86);
-    io.enumCase(V, "edi_x86", edi_x86);
-    io.enumCase(V, "ebp_x86", ebp_x86);
-    io.enumCase(V, "esp_x86", esp_x86);
-    io.enumCase(V, "rax_x86_64", rax_x86_64);
-    io.enumCase(V, "rbx_x86_64", rbx_x86_64);
-    io.enumCase(V, "rcx_x86_64", rcx_x86_64);
-    io.enumCase(V, "rdx_x86_64", rdx_x86_64);
-    io.enumCase(V, "rbp_x86_64", rbp_x86_64);
-    io.enumCase(V, "rsp_x86_64", rsp_x86_64);
-    io.enumCase(V, "rsi_x86_64", rsi_x86_64);
-    io.enumCase(V, "rdi_x86_64", rdi_x86_64);
-    io.enumCase(V, "r8_x86_64", r8_x86_64);
-    io.enumCase(V, "r9_x86_64", r9_x86_64);
-    io.enumCase(V, "r10_x86_64", r10_x86_64);
-    io.enumCase(V, "r11_x86_64", r11_x86_64);
-    io.enumCase(V, "r12_x86_64", r12_x86_64);
-    io.enumCase(V, "r13_x86_64", r13_x86_64);
-    io.enumCase(V, "r14_x86_64", r14_x86_64);
-    io.enumCase(V, "r15_x86_64", r15_x86_64);
-    io.enumCase(V, "xmm0_x86_64", xmm0_x86_64);
-    io.enumCase(V, "xmm1_x86_64", xmm1_x86_64);
-    io.enumCase(V, "xmm2_x86_64", xmm2_x86_64);
-    io.enumCase(V, "xmm3_x86_64", xmm3_x86_64);
-    io.enumCase(V, "xmm4_x86_64", xmm4_x86_64);
-    io.enumCase(V, "xmm5_x86_64", xmm5_x86_64);
-    io.enumCase(V, "xmm6_x86_64", xmm6_x86_64);
-    io.enumCase(V, "xmm7_x86_64", xmm7_x86_64);
-    io.enumCase(V, "r0_arm", r0_arm);
-    io.enumCase(V, "r1_arm", r1_arm);
-    io.enumCase(V, "r2_arm", r2_arm);
-    io.enumCase(V, "r3_arm", r3_arm);
-    io.enumCase(V, "r4_arm", r4_arm);
-    io.enumCase(V, "r5_arm", r5_arm);
-    io.enumCase(V, "r6_arm", r6_arm);
-    io.enumCase(V, "r7_arm", r7_arm);
-    io.enumCase(V, "r8_arm", r8_arm);
-    io.enumCase(V, "r9_arm", r9_arm);
-    io.enumCase(V, "r10_arm", r10_arm);
-    io.enumCase(V, "r11_arm", r11_arm);
-    io.enumCase(V, "r12_arm", r12_arm);
-    io.enumCase(V, "r13_arm", r13_arm);
-    io.enumCase(V, "r14_arm", r14_arm);
-    io.enumCase(V, "x0_aarch64", x0_aarch64);
-    io.enumCase(V, "x1_aarch64", x1_aarch64);
-    io.enumCase(V, "x2_aarch64", x2_aarch64);
-    io.enumCase(V, "x3_aarch64", x3_aarch64);
-    io.enumCase(V, "x4_aarch64", x4_aarch64);
-    io.enumCase(V, "x5_aarch64", x5_aarch64);
-    io.enumCase(V, "x6_aarch64", x6_aarch64);
-    io.enumCase(V, "x7_aarch64", x7_aarch64);
-    io.enumCase(V, "x8_aarch64", x8_aarch64);
-    io.enumCase(V, "x9_aarch64", x9_aarch64);
-    io.enumCase(V, "x10_aarch64", x10_aarch64);
-    io.enumCase(V, "x11_aarch64", x11_aarch64);
-    io.enumCase(V, "x12_aarch64", x12_aarch64);
-    io.enumCase(V, "x13_aarch64", x13_aarch64);
-    io.enumCase(V, "x14_aarch64", x14_aarch64);
-    io.enumCase(V, "x15_aarch64", x15_aarch64);
-    io.enumCase(V, "x16_aarch64", x16_aarch64);
-    io.enumCase(V, "x17_aarch64", x17_aarch64);
-    io.enumCase(V, "x18_aarch64", x18_aarch64);
-    io.enumCase(V, "x19_aarch64", x19_aarch64);
-    io.enumCase(V, "x20_aarch64", x20_aarch64);
-    io.enumCase(V, "x21_aarch64", x21_aarch64);
-    io.enumCase(V, "x22_aarch64", x22_aarch64);
-    io.enumCase(V, "x23_aarch64", x23_aarch64);
-    io.enumCase(V, "x24_aarch64", x24_aarch64);
-    io.enumCase(V, "x25_aarch64", x25_aarch64);
-    io.enumCase(V, "x26_aarch64", x26_aarch64);
-    io.enumCase(V, "x27_aarch64", x27_aarch64);
-    io.enumCase(V, "x28_aarch64", x28_aarch64);
-    io.enumCase(V, "x29_aarch64", x29_aarch64);
-    io.enumCase(V, "lr_aarch64", lr_aarch64);
-    io.enumCase(V, "sp_aarch64", sp_aarch64);
-    io.enumCase(V, "v0_mips", v0_mips);
-    io.enumCase(V, "v1_mips", v1_mips);
-    io.enumCase(V, "a0_mips", a0_mips);
-    io.enumCase(V, "a1_mips", a1_mips);
-    io.enumCase(V, "a2_mips", a2_mips);
-    io.enumCase(V, "a3_mips", a3_mips);
-    io.enumCase(V, "s0_mips", s0_mips);
-    io.enumCase(V, "s1_mips", s1_mips);
-    io.enumCase(V, "s2_mips", s2_mips);
-    io.enumCase(V, "s3_mips", s3_mips);
-    io.enumCase(V, "s4_mips", s4_mips);
-    io.enumCase(V, "s5_mips", s5_mips);
-    io.enumCase(V, "s6_mips", s6_mips);
-    io.enumCase(V, "s7_mips", s7_mips);
-    io.enumCase(V, "gp_mips", gp_mips);
-    io.enumCase(V, "sp_mips", sp_mips);
-    io.enumCase(V, "fp_mips", fp_mips);
-    io.enumCase(V, "ra_mips", ra_mips);
-    io.enumCase(V, "r0_systemz", r0_systemz);
-    io.enumCase(V, "r1_systemz", r1_systemz);
-    io.enumCase(V, "r2_systemz", r2_systemz);
-    io.enumCase(V, "r3_systemz", r3_systemz);
-    io.enumCase(V, "r4_systemz", r4_systemz);
-    io.enumCase(V, "r5_systemz", r5_systemz);
-    io.enumCase(V, "r6_systemz", r6_systemz);
-    io.enumCase(V, "r7_systemz", r7_systemz);
-    io.enumCase(V, "r8_systemz", r8_systemz);
-    io.enumCase(V, "r9_systemz", r9_systemz);
-    io.enumCase(V, "r10_systemz", r10_systemz);
-    io.enumCase(V, "r11_systemz", r11_systemz);
-    io.enumCase(V, "r12_systemz", r12_systemz);
-    io.enumCase(V, "r13_systemz", r13_systemz);
-    io.enumCase(V, "r14_systemz", r14_systemz);
-    io.enumCase(V, "r15_systemz", r15_systemz);
-    io.enumCase(V, "f0_systemz", f0_systemz);
-    io.enumCase(V, "f1_systemz", f1_systemz);
-    io.enumCase(V, "f2_systemz", f2_systemz);
-    io.enumCase(V, "f3_systemz", f3_systemz);
-    io.enumCase(V, "f4_systemz", f4_systemz);
-    io.enumCase(V, "f5_systemz", f5_systemz);
-    io.enumCase(V, "f6_systemz", f6_systemz);
-    io.enumCase(V, "f7_systemz", f7_systemz);
-    io.enumCase(V, "f8_systemz", f8_systemz);
-    io.enumCase(V, "f9_systemz", f9_systemz);
-    io.enumCase(V, "f10_systemz", f10_systemz);
-    io.enumCase(V, "f11_systemz", f11_systemz);
-    io.enumCase(V, "f12_systemz", f12_systemz);
-    io.enumCase(V, "f13_systemz", f13_systemz);
-    io.enumCase(V, "f14_systemz", f14_systemz);
-    io.enumCase(V, "f15_systemz", f15_systemz);
-  }
-};
-} // namespace llvm::yaml
-
 namespace model::RegisterState {
+
 enum Values {
   Invalid,
   No,
@@ -554,19 +558,6 @@ enum Values {
   Maybe,
   Contradiction
 };
-
-inline llvm::StringRef getName(Values V) {
-  return getNameFromYAMLEnumScalar(V);
-}
-
-inline Values fromName(llvm::StringRef Name) {
-  return getValueFromYAMLScalar<Values>(Name);
-}
-
-inline bool shouldEmit(model::RegisterState::Values V) {
-  return (V == model::RegisterState::Yes or V == model::RegisterState::YesOrDead
-          or V == model::RegisterState::Dead);
-}
 
 } // namespace model::RegisterState
 
@@ -587,6 +578,23 @@ struct ScalarEnumerationTraits<model::RegisterState::Values> {
   }
 };
 } // namespace llvm::yaml
+
+namespace model::RegisterState {
+
+inline llvm::StringRef getName(Values V) {
+  return getNameFromYAMLEnumScalar(V);
+}
+
+inline Values fromName(llvm::StringRef Name) {
+  return getValueFromYAMLScalar<Values>(Name);
+}
+
+inline bool shouldEmit(model::RegisterState::Values V) {
+  return (V == model::RegisterState::Yes or V == model::RegisterState::YesOrDead
+          or V == model::RegisterState::Dead);
+}
+
+} // namespace model::RegisterState
 
 class model::FunctionABIRegister {
 public:

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -29,45 +29,6 @@ class BasicBlock;
 // TODO: Prevent changing the keys. Currently we need them to be public and
 //       non-const for serialization purposes.
 
-template<typename T, char Separator>
-struct CompositeScalar {
-  static_assert(std::tuple_size_v<T> >= 0);
-
-  template<size_t I = 0>
-  static void output(const T &Value, void *Ctx, llvm::raw_ostream &Output) {
-    if constexpr (I < std::tuple_size_v<T>) {
-
-      if constexpr (I != 0) {
-        Output << Separator;
-      }
-
-      using element = std::tuple_element_t<I, T>;
-      Output << getNameFromYAMLScalar<element>(get<I>(Value));
-
-      CompositeScalar::output<I + 1>(Value, Ctx, Output);
-    }
-  }
-
-  template<size_t I = 0>
-  static llvm::StringRef input(llvm::StringRef Scalar, void *Ctx, T &Value) {
-    if constexpr (I < std::tuple_size_v<T>) {
-      auto [Before, After] = Scalar.split(Separator);
-
-      using element = std::tuple_element_t<I, T>;
-      get<I>(Value) = getValueFromYAMLScalar<element>(Before);
-
-      return CompositeScalar::input<I + 1>(After, Ctx, Value);
-    } else {
-      revng_assert(Scalar.size() == 0);
-      return Scalar;
-    }
-  }
-
-  static llvm::yaml::QuotingType mustQuote(llvm::StringRef) {
-    return llvm::yaml::QuotingType::Double;
-  }
-};
-
 template<>
 struct KeyedObjectTraits<MetaAddress>
   : public IdentityKeyedObjectTraits<MetaAddress> {};

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -922,9 +922,6 @@ template<>
 struct llvm::yaml::MappingTraits<model::Binary>
   : public TupleLikeMappingTraits<model::Binary> {};
 
-constexpr auto IsYamlizable = [](auto *K) {
-  return Yamlizable<std::remove_pointer_t<decltype(K)>>;
-};
 static_assert(validateTupleTree<model::Binary>(IsYamlizable),
               "All elements of the model must be YAMLizable");
 

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -15,6 +15,7 @@
 #include "revng/ADT/KeyedObjectContainer.h"
 #include "revng/ADT/KeyedObjectTraits.h"
 #include "revng/ADT/TupleTreePath.h"
+#include "revng/ADT/UpcastablePointer.h"
 #include "revng/Support/Assert.h"
 #include "revng/Support/Debug.h"
 #include "revng/Support/YAMLTraits.h"
@@ -447,7 +448,14 @@ struct CallByPathVisitorWithInstance {
       V.template visitTupleElement<T, I>(Element);
   }
 
-  template<typename T, typename K, typename KeyT>
+  template<typename T, IsUpcastablePointer K, typename KeyT>
+  void visitContainerElement(KeyT Key, K &Element) {
+    PathSize -= 1;
+    if (PathSize == 0)
+      V.template visitContainerElement<T>(Key, *Element.get());
+  }
+
+  template<typename T, IsNotUpcastablePointer K, typename KeyT>
   void visitContainerElement(KeyT Key, K &Element) {
     PathSize -= 1;
     if (PathSize == 0)

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -57,6 +57,10 @@ static_assert(NotYamlizable<NoYaml>);
 static_assert(Yamlizable<int>);
 static_assert(Yamlizable<std::vector<int>>);
 
+constexpr inline auto IsYamlizable = [](auto *K) {
+  return Yamlizable<std::remove_pointer_t<decltype(K)>>;
+};
+
 //
 // slice
 //

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -1008,6 +1008,11 @@ public:
     return fromPath(*stringAsPath<RootT>(Path));
   }
 
+  bool operator==(const TupleTreeReference &Other) const {
+    // The paths are the same even if they are referred to different roots
+    return Path == Other.Path;
+  }
+
 public:
   std::string toString() const { return *pathAsString<RootT>(Path); }
 

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -1116,7 +1116,13 @@ public:
 public:
   template<typename S>
   void serialize(S &Stream) const {
-    serialize(Stream, Root);
+    revng_assert(Root);
+    ::serialize(Stream, *Root);
+  }
+
+  void serialize(std::string &Buffer) const {
+    llvm::raw_string_ostream Stream(Buffer);
+    serialize(Stream);
   }
 
 public:

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -987,13 +987,11 @@ constexpr bool validateTupleTree(L Check) {
   INTROSPECTION_2(class, __VA_ARGS__)     \
   }
 
-template<typename T>
+template<TupleTreeCompatible T>
 class TupleTree;
 
 template<typename T, typename RootT>
 class TupleTreeReference {
-  friend class TupleTree<RootT>;
-
 public:
   using pointee = T;
 
@@ -1074,7 +1072,7 @@ void serialize(S &Stream, T &Element) {
   YAMLOutput << Element;
 }
 
-template<typename T>
+template<TupleTreeCompatible T>
 class TupleTree {
 private:
   std::unique_ptr<T> Root;
@@ -1174,9 +1172,3 @@ private:
     visitTupleTree(*Root, Visitor, [](auto) {});
   }
 };
-
-static_assert(std::is_default_constructible_v<TupleTree<int>>);
-static_assert(not std::is_copy_assignable_v<TupleTree<int>>);
-static_assert(not std::is_copy_constructible_v<TupleTree<int>>);
-static_assert(std::is_move_assignable_v<TupleTree<int>>);
-static_assert(std::is_move_constructible_v<TupleTree<int>>);

--- a/include/revng/Model/TupleTreeDiff.h
+++ b/include/revng/Model/TupleTreeDiff.h
@@ -141,33 +141,6 @@ private:
     }
   }
 
-  template<UnsortedContainer T>
-  void diffImpl(T &LHS, T &RHS) {
-    using value_type = typename T::value_type;
-    using KOT = KeyedObjectTraits<value_type>;
-    using key_type = decltype(KOT::key(std::declval<value_type>()));
-    std::map<key_type, value_type *> LHSMap, RHSMap;
-    for (value_type &Element : LHS)
-      LHSMap[KOT::key(Element)] = &Element;
-    for (value_type &Element : RHS)
-      RHSMap[KOT::key(Element)] = &Element;
-
-    for (auto [LHSElement, RHSElement] : zipmap_range(LHSMap, RHSMap)) {
-      if (LHSElement == nullptr) {
-        // Added
-        Result.add(Stack, RHSElement->second);
-      } else if (RHSElement == nullptr) {
-        // Removed
-        Result.remove(Stack, LHSElement->second);
-      } else {
-        // Identical
-        Stack.push_back(*LHSElement);
-        diffImpl(*LHSElement->second, *RHSElement->second);
-        Stack.pop_back();
-      }
-    }
-  }
-
   template<NotTupleTreeCompatible T>
   void diffImpl(T &LHS, T &RHS) {
     if (LHS != RHS)

--- a/include/revng/Support/YAMLTraits.h
+++ b/include/revng/Support/YAMLTraits.h
@@ -7,9 +7,17 @@
 #include "llvm/Support/YAMLTraits.h"
 
 template<typename T>
+concept HasScalarTraits = llvm::yaml::has_ScalarTraits<T>::value;
+
+template<typename T>
+concept HasScalarEnumTraits = llvm::yaml::has_ScalarEnumerationTraits<T>::value;
+
+template<typename T>
+concept HasScalarOrEnumTraits = HasScalarTraits<T> or HasScalarEnumTraits<T>;
+
+template<HasScalarEnumTraits T>
 inline llvm::StringRef getNameFromYAMLEnumScalar(T V) {
   using namespace llvm::yaml;
-  static_assert(has_ScalarEnumerationTraits<T>::value);
   struct GetScalarIO {
     llvm::StringRef Result;
     void enumCase(const T &V,
@@ -26,11 +34,9 @@ inline llvm::StringRef getNameFromYAMLEnumScalar(T V) {
   return ExtractName.Result;
 }
 
-template<typename T>
+template<HasScalarOrEnumTraits T>
 inline std::string getNameFromYAMLScalar(T V) {
   using namespace llvm::yaml;
-  static_assert(has_ScalarTraits<T>::value
-                or has_ScalarEnumerationTraits<T>::value);
 
   if constexpr (has_ScalarTraits<T>::value) {
     std::string Buffer;
@@ -48,11 +54,9 @@ T getInvalidValueFromYAMLScalar() {
   revng_abort();
 }
 
-template<typename T>
+template<HasScalarOrEnumTraits T>
 inline T getValueFromYAMLScalar(llvm::StringRef Name) {
   using namespace llvm::yaml;
-  static_assert(has_ScalarTraits<T>::value
-                or has_ScalarEnumerationTraits<T>::value);
 
   T Result;
 

--- a/include/revng/Support/YAMLTraits.h
+++ b/include/revng/Support/YAMLTraits.h
@@ -85,3 +85,42 @@ inline T getValueFromYAMLScalar(llvm::StringRef Name) {
 
   return Result;
 }
+
+template<typename T, char Separator>
+struct CompositeScalar {
+  static_assert(std::tuple_size_v<T> >= 0);
+
+  template<size_t I = 0>
+  static void output(const T &Value, void *Ctx, llvm::raw_ostream &Output) {
+    if constexpr (I < std::tuple_size_v<T>) {
+
+      if constexpr (I != 0) {
+        Output << Separator;
+      }
+
+      using element = std::tuple_element_t<I, T>;
+      Output << getNameFromYAMLScalar<element>(get<I>(Value));
+
+      CompositeScalar::output<I + 1>(Value, Ctx, Output);
+    }
+  }
+
+  template<size_t I = 0>
+  static llvm::StringRef input(llvm::StringRef Scalar, void *Ctx, T &Value) {
+    if constexpr (I < std::tuple_size_v<T>) {
+      auto [Before, After] = Scalar.split(Separator);
+
+      using element = std::tuple_element_t<I, T>;
+      get<I>(Value) = getValueFromYAMLScalar<element>(Before);
+
+      return CompositeScalar::input<I + 1>(After, Ctx, Value);
+    } else {
+      revng_assert(Scalar.size() == 0);
+      return Scalar;
+    }
+  }
+
+  static llvm::yaml::QuotingType mustQuote(llvm::StringRef) {
+    return llvm::yaml::QuotingType::Double;
+  }
+};

--- a/tests/unit/Model.cpp
+++ b/tests/unit/Model.cpp
@@ -203,3 +203,9 @@ BOOST_AUTO_TEST_CASE(TestTupleTreeDiff) {
     diff(Left, Right).dump();
   }
 }
+
+static_assert(std::is_default_constructible_v<TupleTree<TestTupleTree::Root>>);
+static_assert(not std::is_copy_assignable_v<TupleTree<TestTupleTree::Root>>);
+static_assert(not std::is_copy_constructible_v<TupleTree<TestTupleTree::Root>>);
+static_assert(std::is_move_assignable_v<TupleTree<TestTupleTree::Root>>);
+static_assert(std::is_move_constructible_v<TupleTree<TestTupleTree::Root>>);


### PR DESCRIPTION
This MR does works on improving interactions between `TupleTreeReference`, `UpcastablePointer`, and `KeyedObjectTraits`. While doing this, it also tries to slightly improve these classes when this is possible without major refactoring.

At the moment, this MR is composed of y commits. Each does what follows (from older to newer):
- Drops template parameter from `KeyedObjectTraits`. This was necessary before we used concepts to play with `enable_if`. Now we can drop it entirely.
- Uses `std::is_void_v` instead of `std::is_same_v(void, T)` in `UpcastablePointer`.
- Fixes a problem causing bad `TupleTree` traversal with `TupleTreeReference`. Specifically, `CallByPathVisitorWithInstance` did not know how to `visitContainerElement` when the element of the container was an `UpcastablePointer`. This caused the visit to always return `nullptr` even when the `TupleTreeReference` was well-formed. This has been fixed by adding an overload with proper concept constraint, that teaches `CallByPathVisitorWithInstance` how to properly traverse `UpcastablePointers`.
- Requires `IsKeyedObjectContainer` in `TupleTree.h` wherever possible, instead of `IsContainer`.
- 2 commits improving `operator==` for `TupleTreeReference` and `TupleTreePath`
- Fix serialization of `TupleTree`. The changed overload was not used anywhere, and actually failed to compile if someone tried to use it. Now it's fixed, and it enables serializing to a `std::string` buffer, instead of requiring a stream.
- Fix copy/move constructor/assignment in `TupleTreePath.h`. Before this commit, copy/move assignments did not check for `this != &Other` and copy/move constructors were not defined starting from the associated assignments. Both these things are best practices for maintainability, that are fixed by this commit.
- Define `operator<=>` for `TupleTreeReference`
- Add concepts to `YAMLTraits.h`. This considerably helps when adding new yaml-serializable things, because compilation error messages become much more readable
- Cleanup `UpcastablePointer` copy/move constructor and assignments operators. They were a little bit inconsistent before, now they are conforming with typical best practices.
- Move `CompositeScalar` to `YAMLTraits.h`, so that it can be used outside `Binary.h`. We'll need it for the type system.
- Move `IsYamlizable` generic lambda to `TupleTree.h`, so that it can be used outside `Binary.h`. We'll need it for the type system as well
- Add `TupleTreeCompatible` constraint to `TupleTree` type template parameter. It does not make sense to say `TupleTree<T>` is `T` is not `TupleTreeCompatible`.