### PR TITLE
Update revng to build against llvm-12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,6 @@ add_flag_if_available("-Wno-maybe-uninitialized")
 add_flag_if_available("-Wno-unused-local-typedefs")
 add_flag_if_available("-Wno-init-list-lifetime")
 add_flag_if_available("-Wno-ambiguous-reversed-operator")
-add_flag_if_available("-Wno-deprecated-enum-enum-conversion")
 
 # Add some extra warnings
 add_flag_if_available("-Wstrict-aliasing")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_flag_if_available("-Wno-unused-parameter")
 add_flag_if_available("-Wno-unused-variable")
 add_flag_if_available("-Wno-maybe-uninitialized")
-add_flag_if_available("-Wno-unused-local-typedefs")
 add_flag_if_available("-Wno-init-list-lifetime")
 add_flag_if_available("-Wno-ambiguous-reversed-operator")
 

--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -23,7 +23,7 @@ template<typename T, typename BaseType>
 class Parent : public BaseType {
 public:
   template<typename... Args>
-  explicit Parent(Args &&... args) :
+  explicit Parent(Args &&...args) :
     BaseType(std::forward<Args>(args)...), TheParent(nullptr) {}
 
   Parent(const Parent &) = default;
@@ -161,7 +161,7 @@ public:
 
 public:
   template<typename... Args>
-  explicit ForwardNode(Args &&... args) : Base(std::forward<Args>(args)...) {}
+  explicit ForwardNode(Args &&...args) : Base(std::forward<Args>(args)...) {}
 
   ForwardNode(const ForwardNode &) = default;
   ForwardNode(ForwardNode &&) = default;
@@ -298,7 +298,7 @@ public:
 
 public:
   template<typename... Args>
-  explicit BidirectionalNode(Args &&... args) :
+  explicit BidirectionalNode(Args &&...args) :
     Base(std::forward<Args>(args)...) {}
 
   BidirectionalNode(const BidirectionalNode &) = default;
@@ -413,7 +413,7 @@ public:
 
 public:
   template<class... Args>
-  NodeT *addNode(Args &&... A) {
+  NodeT *addNode(Args &&...A) {
     Nodes.push_back(std::make_unique<NodeT>(std::forward<Args>(A)...));
     if constexpr (NodeT::has_parent)
       Nodes.back()->setParent(this);

--- a/include/revng/ADT/RecursiveCoroutine-coroutine.h
+++ b/include/revng/ADT/RecursiveCoroutine-coroutine.h
@@ -85,10 +85,10 @@ struct RecursivePromise : public ReturnBase<ReturnT> {
       ResumeAwaiter(std::experimental::coroutine_handle<> AwaiterHandle) :
         Awaiter(AwaiterHandle) {}
 
-      bool await_ready() const { return false; }
+      bool await_ready() const noexcept { return false; }
 
       std::experimental::coroutine_handle<>
-      await_suspend(std::experimental::coroutine_handle<>) {
+      await_suspend(std::experimental::coroutine_handle<>) noexcept {
         std::experimental::coroutine_handle<>
           ToResume = std::experimental::noop_coroutine();
         if (Awaiter and not Awaiter.done()) {
@@ -98,7 +98,7 @@ struct RecursivePromise : public ReturnBase<ReturnT> {
         return ToResume;
       }
 
-      void await_resume() const { revng_abort(); }
+      void await_resume() const noexcept { revng_abort(); }
 
     private:
       std::experimental::coroutine_handle<> Awaiter;

--- a/include/revng/BasicAnalyses/AdvancedValueInfo.h
+++ b/include/revng/BasicAnalyses/AdvancedValueInfo.h
@@ -307,7 +307,7 @@ private:
 
       auto NewRange = llvm::ConstantRange::getFull(BitWidth);
       if (Destination == nullptr)
-        NewRange = LVI.getConstantRange(I, Source);
+        NewRange = LVI.getConstantRange(I, Source->getTerminator());
       else
         NewRange = LVI.getConstantRangeOnEdge(I, Source, Destination);
 

--- a/include/revng/BasicAnalyses/AdvancedValueInfo.h
+++ b/include/revng/BasicAnalyses/AdvancedValueInfo.h
@@ -67,6 +67,7 @@ getUniqueUnknown(llvm::ScalarEvolution &SE, const llvm::SCEV *SC) {
       case scUMinExpr:
       case scUDivExpr:
       case scAddExpr:
+      case scPtrToInt:
         break;
 
       case scUnknown:

--- a/include/revng/BasicAnalyses/MaterializedValue.h
+++ b/include/revng/BasicAnalyses/MaterializedValue.h
@@ -31,13 +31,17 @@ public:
 
 public:
   bool operator==(const MaterializedValue &Other) const {
-    auto This = std::tie(IsValid, SymbolName, Value);
-    auto That = std::tie(Other.IsValid, Other.SymbolName, Other.Value);
+    auto MaxBitWidth = std::max(Value.getBitWidth(), Other.Value.getBitWidth());
+    auto ZExtValue = Value.zextOrSelf(MaxBitWidth);
+    auto ZExtOther = Other.Value.zextOrSelf(MaxBitWidth);
+    auto This = std::tie(IsValid, SymbolName, ZExtValue);
+    auto That = std::tie(Other.IsValid, Other.SymbolName, ZExtOther);
     return This == That;
   }
 
   bool operator<(const MaterializedValue &Other) const {
-    if (Value.ult(Other.Value))
+    auto MaxBitWidth = std::max(Value.getBitWidth(), Other.Value.getBitWidth());
+    if (Value.zextOrSelf(MaxBitWidth).ult(Other.Value.zextOrSelf(MaxBitWidth)))
       return true;
     auto This = std::tie(IsValid, SymbolName);
     auto That = std::tie(Other.IsValid, Other.SymbolName);

--- a/include/revng/Model/TupleTreeDiff.h
+++ b/include/revng/Model/TupleTreeDiff.h
@@ -89,7 +89,6 @@ private:
 
   template<size_t I = 0, typename T>
   requires IsNotTupleEnd<T, I> void diffTuple(T &LHS, T &RHS) {
-    using child_type = typename std::tuple_element<I, T>::type;
 
     Stack.push_back(size_t(I));
     diffImpl(get<I>(LHS), get<I>(RHS));
@@ -121,10 +120,6 @@ private:
 
   template<SortedContainer T>
   void diffImpl(T &LHS, T &RHS) {
-    using value_type = typename T::value_type;
-    using KOT = KeyedObjectTraits<value_type>;
-    using key_type = decltype(KOT::key(std::declval<value_type>()));
-
     for (auto [LHSElement, RHSElement] : zipmap_range(LHS, RHS)) {
       if (LHSElement == nullptr) {
         // Added

--- a/include/revng/Support/Generator.h
+++ b/include/revng/Support/Generator.h
@@ -145,7 +145,7 @@ public:
 
   generator() noexcept : m_coroutine(nullptr) {}
 
-  generator(generator && other) noexcept : m_coroutine(other.m_coroutine) {
+  generator(generator &&other) noexcept : m_coroutine(other.m_coroutine) {
     other.m_coroutine = nullptr;
   }
 
@@ -177,7 +177,7 @@ public:
     return detail::generator_sentinel{};
   }
 
-  void swap(generator & other) noexcept {
+  void swap(generator &other) noexcept {
     std::swap(m_coroutine, other.m_coroutine);
   }
 

--- a/include/revng/Support/Statistics.h
+++ b/include/revng/Support/Statistics.h
@@ -177,7 +177,7 @@ private:
 
 // TODO: this is duplicated
 template<typename T, typename... Args>
-inline std::array<T, sizeof...(Args)> make_array(Args &&... args) {
+inline std::array<T, sizeof...(Args)> make_array(Args &&...args) {
   return { { std::forward<Args>(args)... } };
 }
 

--- a/lib/FunctionIsolation/InlineHelpers.cpp
+++ b/lib/FunctionIsolation/InlineHelpers.cpp
@@ -45,8 +45,8 @@ static CallInst *getCallToInline(Instruction *I) {
 
 static void doInline(CallInst *Call) {
   InlineFunctionInfo IFI;
-  auto Result = InlineFunction(Call, IFI, nullptr, false);
-  revng_assert(Result);
+  auto Result = InlineFunction(*Call, IFI, nullptr, false);
+  revng_assert(Result.isSuccess(), Result.getFailureReason());
 }
 
 static bool doInline(Function *F) {

--- a/lib/FunctionIsolation/InvokeIsolatedFunctions.cpp
+++ b/lib/FunctionIsolation/InvokeIsolatedFunctions.cpp
@@ -160,8 +160,12 @@ public:
         }
       }
 
-      // Emit the invoke instruction
-      Builder.CreateInvoke(F, InvokeReturnBlock, CatchBB, Arguments);
+      // Emit the invoke instruction, propagating debug info
+      auto *NewInvoke = Builder.CreateInvoke(F,
+                                             InvokeReturnBlock,
+                                             CatchBB,
+                                             Arguments);
+      NewInvoke->setDebugLoc(BB->front().getDebugLoc());
     }
 
     // Remove all the orphan basic blocks from the root function (e.g., the

--- a/lib/FunctionIsolation/PromoteCSVs.cpp
+++ b/lib/FunctionIsolation/PromoteCSVs.cpp
@@ -252,7 +252,8 @@ void PromoteCSVs::wrap(CallInst *Call,
     NewArguments.push_back(Builder.CreateLoad(CSV));
 
   // Emit the actual call
-  Value *Result = Builder.CreateCall(HelperWrapper, NewArguments);
+  Instruction *Result = Builder.CreateCall(HelperWrapper, NewArguments);
+  Result->setDebugLoc(Call->getDebugLoc());
 
   bool HasOutputCSVs = Written.size() != 0;
   bool OriginalWasVoid = HelperType->getReturnType()->isVoidTy();

--- a/runtime/support.c
+++ b/runtime/support.c
@@ -90,10 +90,10 @@ static void *prepare_stack(void *stack, int argc, char **argv) {
     PUSH(ptr, align, (void *) &tmp); \
   } while (0);
 
-#define PUSH_AUX(ptr, key, value)       \
-  do {                                  \
-    PUSH_REG(ptr, (target_reg)(value)); \
-    PUSH_REG(ptr, key);                 \
+#define PUSH_AUX(ptr, key, value)      \
+  do {                                 \
+    PUSH_REG(ptr, (uintptr_t)(value)); \
+    PUSH_REG(ptr, key);                \
   } while (0)
 
   // Reserve space for arguments and environment variables
@@ -120,10 +120,10 @@ static void *prepare_stack(void *stack, int argc, char **argv) {
   }
 
   PUSH_STR(stack, "revng");
-  platform_address = (target_reg) stack;
+  platform_address = (uintptr_t) stack;
 
   PUSH_STR(stack, "4 I used a dice");
-  random_address = (target_reg) stack;
+  random_address = (uintptr_t) stack;
 
   // Compute the value of stack pointer once we'll be done
 
@@ -176,7 +176,7 @@ static void *prepare_stack(void *stack, int argc, char **argv) {
   while (*--argp != NULL) {
     PUSH_STR(arg_area, *argp);
     SAFE_CAST(arg_area);
-    PUSH_REG(stack, (target_reg) arg_area);
+    PUSH_REG(stack, (uintptr_t) arg_area);
   }
 
   // Push the separator
@@ -186,7 +186,7 @@ static void *prepare_stack(void *stack, int argc, char **argv) {
   while (--argp != (argv - 1)) {
     PUSH_STR(arg_area, *argp);
     SAFE_CAST(arg_area);
-    PUSH_REG(stack, (target_reg) arg_area);
+    PUSH_REG(stack, (uintptr_t) arg_area);
   }
 
   PUSH_REG(stack, argc);
@@ -434,7 +434,7 @@ int main(int argc, char *argv[]) {
   brk += 0x1000;
 
   SAFE_CAST(brk);
-  target_set_brk((target_reg) brk);
+  target_set_brk((uintptr_t) brk);
 
   // Initialize the syscall system
   syscall_init();
@@ -451,7 +451,7 @@ int main(int argc, char *argv[]) {
 
   // Run the translated program
   SAFE_CAST(stack);
-  root((target_reg) stack);
+  root((uintptr_t) stack);
 }
 
 // Helper function used to raise an exception

--- a/tests/unit/GenericGraph.cpp
+++ b/tests/unit/GenericGraph.cpp
@@ -107,7 +107,6 @@ BOOST_AUTO_TEST_CASE(TestCompile) {
       using INGT = GraphTraits<Inverse<NodeType *>>;
       INGT::child_begin(Node);
 
-      using GGT = GraphTraits<GenericGraph<MyBidirectionalNodeWithEdges> *>;
       Graph.nodes();
     }
   }

--- a/tools/revng-lift/CodeGenerator.cpp
+++ b/tools/revng-lift/CodeGenerator.cpp
@@ -141,7 +141,7 @@ static cl::opt<bool> RecordPTC("record-ptc",
 static Logger<> PTCLog("ptc");
 
 template<typename T, typename... Args>
-inline std::array<T, sizeof...(Args)> make_array(Args &&... args) {
+inline std::array<T, sizeof...(Args)> make_array(Args &&...args) {
   return { { std::forward<Args>(args)... } };
 }
 

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -1392,7 +1392,6 @@ public:
     // to now the values that have been identified to which value in the
     // original function did they belong to
     uint32_t AVIID = TrackedValues.size();
-    using AVI = AdvancedValueInfoPass;
     Builder.SetInsertPoint(InstructionToTrack->getNextNode());
     Builder.CreateCall(AVIMarker,
                        { InstructionToTrack, Builder.getInt32(AVIID) });
@@ -1888,7 +1887,6 @@ void JumpTargetManager::harvest() {
         auto *Call = cast<CallInst>(U);
         if (Call->getParent() != nullptr) {
           // Report the instruction on the coverage CSV
-          using CI = ConstantInt;
           auto PC = MetaAddress::fromConstant(Call->getArgOperand(0));
 
           bool IsJT = isJumpTarget(PC);

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -1905,7 +1905,7 @@ void JumpTargetManager::harvest() {
     HarvestingStats.push("InstCombine");
     legacy::FunctionPassManager OptimizingPM(&TheModule);
     OptimizingPM.add(createSROAPass());
-    OptimizingPM.add(createConstantPropagationPass());
+    OptimizingPM.add(createInstSimplifyLegacyPass());
     OptimizingPM.doInitialization();
     OptimizingPM.run(*TheFunction);
     OptimizingPM.doFinalization();

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -17,6 +17,7 @@
 #include "boost/type_traits/is_same.hpp"
 
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/Analysis/BasicAliasAnalysis.h"
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/CodeGen/UnreachableBlockElim.h"
 #include "llvm/IR/IRBuilder.h"

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -1702,11 +1702,11 @@ void JumpTargetManager::harvestWithAVI() {
     FPM.addPass(DropHelperCallsPass(SyscallHelper, SyscallIDCSV, SCB));
     FPM.addPass(ShrinkInstructionOperandsPass());
     FPM.addPass(PromotePass());
-    FPM.addPass(InstCombinePass(false));
+    FPM.addPass(InstCombinePass(true));
     FPM.addPass(TypeShrinking::TypeShrinkingPass());
     FPM.addPass(JumpThreadingPass());
     FPM.addPass(UnreachableBlockElimPass());
-    FPM.addPass(InstCombinePass(false));
+    FPM.addPass(InstCombinePass(true));
     FPM.addPass(EarlyCSEPass(true));
     FPM.addPass(DropRangeMetadataPass());
     FPM.addPass(AdvancedValueInfoPass(this));


### PR DESCRIPTION
This PR is still a draft, since there are runtime errors in some of revng tests.

This is expected to build fine with `orc install --test revng`, with the following pre-requisites:
- `orchestra` is based on: https://github.com/revng/orchestra/pull/36
- `llvm` is based on: https://github.com/revng/llvm-project/pull/5

@aleclearmind can you take a look at the failing tests?