### PR TITLE
Add an include category for Qt headers.

### DIFF
--- a/lib/StackAnalysis/FunctionABI.cpp
+++ b/lib/StackAnalysis/FunctionABI.cpp
@@ -13,9 +13,8 @@
 #include "revng/Support/GraphAlgorithms.h"
 #include "revng/Support/MonotoneFramework.h"
 
-#include "FunctionABI.h"
-
 #include "ABIIR.h"
+#include "FunctionABI.h"
 
 using std::conditional;
 using std::tuple;

--- a/lib/StackAnalysis/InterproceduralAnalysis.cpp
+++ b/lib/StackAnalysis/InterproceduralAnalysis.cpp
@@ -9,9 +9,8 @@
 
 #include "revng/Support/Statistics.h"
 
-#include "InterproceduralAnalysis.h"
-
 #include "Cache.h"
+#include "InterproceduralAnalysis.h"
 
 using llvm::BasicBlock;
 using llvm::GlobalVariable;

--- a/lib/StackAnalysis/Intraprocedural.cpp
+++ b/lib/StackAnalysis/Intraprocedural.cpp
@@ -7,10 +7,9 @@
 
 #include <iomanip>
 
-#include "Intraprocedural.h"
-
 #include "Cache.h"
 #include "InterproceduralAnalysis.h"
+#include "Intraprocedural.h"
 
 using llvm::AllocaInst;
 using llvm::ArrayRef;

--- a/scripts/clang-format-style-file
+++ b/scripts/clang-format-style-file
@@ -82,12 +82,16 @@ IncludeCategories:
     Priority:     -5,
   }
 - {
-    Regex:        '^"boost/',
+    Regex:        '^"Qt[^/]+/',
     Priority:     -6,
   }
 - {
-    Regex:        '^<',
+    Regex:        '^"boost/',
     Priority:     -7,
+  }
+- {
+    Regex:        '^<',
+    Priority:     -8,
   }
 IndentCaseLabels: false,
 IndentPPDirectives: None,

--- a/scripts/clang-format-style-file
+++ b/scripts/clang-format-style-file
@@ -93,6 +93,7 @@ IncludeCategories:
     Regex:        '^<',
     Priority:     -8,
   }
+IncludeIsMainRegex: _THIS_SEQUENCE_IS_NEVER_GOING_TO_HAPPEN,
 IndentCaseLabels: false,
 IndentPPDirectives: None,
 IndentWidth: 2,

--- a/tools/revng-lift/CPUStateAccessAnalysisPass.cpp
+++ b/tools/revng-lift/CPUStateAccessAnalysisPass.cpp
@@ -25,7 +25,6 @@
 #include "revng/Support/IRHelpers.h"
 
 #include "CPUStateAccessAnalysisPass.h"
-
 #include "VariableManager.h"
 
 namespace llvm {

--- a/tools/revng-lift/CodeGenerator.cpp
+++ b/tools/revng-lift/CodeGenerator.cpp
@@ -48,7 +48,6 @@
 #include "revng/Support/revng.h"
 
 #include "CodeGenerator.h"
-
 #include "ExternalJumpsHandler.h"
 #include "InstructionTranslator.h"
 #include "JumpTargetManager.h"

--- a/tools/revng-lift/ExternalJumpsHandler.cpp
+++ b/tools/revng-lift/ExternalJumpsHandler.cpp
@@ -22,9 +22,8 @@
 #include "revng/Support/Debug.h"
 #include "revng/Support/ProgramCounterHandler.h"
 
-#include "ExternalJumpsHandler.h"
-
 #include "BinaryFile.h"
+#include "ExternalJumpsHandler.h"
 
 using namespace llvm;
 using std::string;

--- a/tools/revng-lift/InstructionTranslator.cpp
+++ b/tools/revng-lift/InstructionTranslator.cpp
@@ -26,7 +26,6 @@
 #include "revng/Support/Range.h"
 
 #include "InstructionTranslator.h"
-
 #include "PTCInterface.h"
 #include "VariableManager.h"
 

--- a/tools/revng-lift/JumpTargetManager.cpp
+++ b/tools/revng-lift/JumpTargetManager.cpp
@@ -49,11 +49,10 @@
 #include "revng/TypeShrinking/BitLiveness.h"
 #include "revng/TypeShrinking/TypeShrinking.h"
 
-#include "JumpTargetManager.h"
-
 #include "AdvancedValueInfoPass.h"
 #include "CPUStateAccessAnalysisPass.h"
 #include "DropHelperCallsPass.h"
+#include "JumpTargetManager.h"
 #include "SubGraph.h"
 
 using namespace llvm;

--- a/tools/revng-lift/PTCDump.cpp
+++ b/tools/revng-lift/PTCDump.cpp
@@ -14,7 +14,6 @@
 #include "revng/Support/Assert.h"
 
 #include "PTCDump.h"
-
 #include "PTCInterface.h"
 
 static const int MAX_TEMP_NAME_LENGTH = 128;

--- a/tools/revng-lift/VariableManager.cpp
+++ b/tools/revng-lift/VariableManager.cpp
@@ -26,10 +26,9 @@
 #include "revng/Support/IRHelpers.h"
 #include "revng/Support/revng.h"
 
-#include "VariableManager.h"
-
 #include "PTCDump.h"
 #include "PTCInterface.h"
+#include "VariableManager.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
Since `cold-revng` extensively uses Qt headers it'd be nice to group them separately from all the others.

It also attempts to prevent clang-format from selecting a "main" header and putting it into a '0'-category.