### PR TITLE
`revng::SmallMap::contains`

### DIFF
--- a/include/revng/ADT/SmallMap.h
+++ b/include/revng/ADT/SmallMap.h
@@ -352,6 +352,10 @@ public:
       return const_iterator(Map.lower_bound(Key));
   }
 
+  bool contains(const K &Key) const {
+    return find(Key) != end();
+  }
+
   void clear() {
     // TODO: we should invoke some destructors at a certain point
     Size = 0;

--- a/tests/unit/SmallMap.cpp
+++ b/tests/unit/SmallMap.cpp
@@ -102,3 +102,14 @@ BOOST_AUTO_TEST_CASE(CustomCompare) {
   revng_check(MIt != Map.end());
   revng_check(RIt->second == MIt->second);
 }
+
+BOOST_AUTO_TEST_CASE(Contains) {
+  SmallMap<int, int, 1, std::greater<int>> Map;
+  int Value = 42;
+
+  revng_check(!Map.contains(Value));
+
+  Map.insert({ Value, 1 });
+  revng_check(Map.contains(Value));
+  revng_check(!Map.contains(Value + 1));
+}


### PR DESCRIPTION
Now that we updated our active `llvm` branch to 12, we can actually add this method I've greatly missed.
For the context, `llvm::SmallSet::contains` was finally added in llvm-12.