### PR TITLE
Fix build error in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  add_flag_if_available("-Wno-unused-local-typedefs")
+endif()
+
 # Disable some warnings
 add_flag_if_available("-Wno-unused-parameter")
 add_flag_if_available("-Wno-unused-variable")


### PR DESCRIPTION
Builds in release mode failed because of unused local typedefs defined in headers included from boost. This commit disables that specific error.