### PR TITLE
Fix: `ManagedStatic` `IDGenerator` was not `static`

### DIFF
--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -145,7 +145,7 @@ public:
   uint64_t get() { return Distribution(Generator); }
 };
 
-llvm::ManagedStatic<RNG> IDGenerator;
+static llvm::ManagedStatic<RNG> IDGenerator;
 
 model::Type::Type(TypeKind::Values TK) :
   model::Type::Type(TK, IDGenerator->get()) {


### PR DESCRIPTION
This caused failures in `llvm::shutdown` in downstream libraries that depended on the revngModel library, such as upcoming changes in `revng-c`.