### PR TITLE
Miscellaneous model improvements

### DIFF
--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -396,17 +396,11 @@ bool callOnPathSteps(Visitor &V,
   using key_type = decltype(KOT::key(std::declval<value_type>()));
   auto TargetKey = Path[0].get<key_type>();
 
-  value_type *Matching = nullptr;
-  for (value_type &Element : M) {
-    using KOT = KeyedObjectTraits<value_type>;
-    if (KOT::key(Element) == TargetKey) {
-      Matching = &Element;
-      break;
-    }
-  }
-
-  if (Matching == nullptr)
+  auto It = M.find(TargetKey);
+  if (It == M.end())
     return false;
+
+  value_type *Matching = &*It;
 
   V.template visitContainerElement<RootT>(TargetKey, *Matching);
   if (Path.size() > 1) {

--- a/include/revng/Model/TupleTree.h
+++ b/include/revng/Model/TupleTree.h
@@ -1143,12 +1143,16 @@ public:
   }
 
 public:
-  static TupleTree deserialize(llvm::StringRef YAMLString) {
+  static llvm::ErrorOr<TupleTree> deserialize(llvm::StringRef YAMLString) {
     TupleTree Result;
 
     Result.Root = std::make_unique<T>();
     llvm::yaml::Input YAMLInput(YAMLString);
     YAMLInput >> *Result.Root;
+
+    std::error_code EC = YAMLInput.error();
+    if (EC)
+      return EC;
 
     // Update references to root
     Result.initializeReferences();

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -631,6 +631,8 @@ public:
   StructField(uint64_t Offset) : Offset(Offset) {}
   StructField() : StructField(0) {}
 
+  Identifier name() const;
+
   bool operator==(const StructField &) const = default;
 };
 INTROSPECTION_NS(model, StructField, CustomName, Type, Offset);
@@ -694,6 +696,8 @@ public:
   UnionField() : UnionField(0) {}
 
 public:
+  Identifier name() const;
+
   bool operator==(const UnionField &Other) const = default;
 };
 INTROSPECTION_NS(model, UnionField, CustomName, Type, Index);
@@ -914,6 +918,8 @@ public:
 
 public:
   bool operator==(const Argument &) const = default;
+
+  Identifier name() const;
 
 public:
   bool verify() const debug_function;

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -52,7 +52,7 @@ using Fields = typename TupleLikeTraits<T>::Fields;
 
 namespace model {
 
-extern const std::set<llvm::StringRef> CReservedKeywords;
+extern const std::set<llvm::StringRef> ReservedKeywords;
 
 /// \note Zero-sized identifiers are valid
 class Identifier : public llvm::SmallString<16> {
@@ -68,8 +68,8 @@ public:
     revng_assert(not Name.empty());
     Identifier Result;
 
-    // For reserved C keywords prepend the our reserved prefix and we're done.
-    if (CReservedKeywords.count(Name)) {
+    // For reserved C keywords prepend a non-reserved prefix and we're done.
+    if (ReservedKeywords.count(Name)) {
       Result += "prefix_";
       Result += Name;
       return Result;

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -360,7 +360,7 @@ public:
     return Kind == QualifierKind::Pointer;
   }
 
-  bool operator==(const Qualifier &) const = default;
+  std::strong_ordering operator<=>(const Qualifier &) const = default;
 };
 INTROSPECTION_NS(model, Qualifier, Kind, Size);
 

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -116,32 +116,54 @@ enum Values {
   Union,
   CABIFunctionType,
   RawFunctionType,
+  Count,
 };
 
+inline llvm::StringRef getName(Values V) {
+  switch (V) {
+  case Invalid:
+    return "Invalid";
+  case Primitive:
+    return "Primitive";
+  case Enum:
+    return "Enum";
+  case Typedef:
+    return "Typedef";
+  case Struct:
+    return "Struct";
+  case Union:
+    return "Union";
+  case CABIFunctionType:
+    return "CABIFunctionType";
+  case RawFunctionType:
+    return "RawFunctionType";
+  default:
+    revng_abort();
+  }
+  revng_abort();
+}
+
 } // end namespace model::TypeKind
+
+namespace llvm::yaml {
 
 // Make model::TypeKind yaml-serializable, required for making model::Type
 // yaml-serializable as well
 template<>
-struct llvm::yaml::ScalarEnumerationTraits<model::TypeKind::Values> {
+struct ScalarEnumerationTraits<model::TypeKind::Values> {
   template<typename IOType>
   static void enumeration(IOType &IO, model::TypeKind::Values &Val) {
-    IO.enumCase(Val, "Invalid", model::TypeKind::Invalid);
-    IO.enumCase(Val, "Primitive", model::TypeKind::Primitive);
-    IO.enumCase(Val, "Enum", model::TypeKind::Enum);
-    IO.enumCase(Val, "Typedef", model::TypeKind::Typedef);
-    IO.enumCase(Val, "Struct", model::TypeKind::Struct);
-    IO.enumCase(Val, "Union", model::TypeKind::Union);
-    IO.enumCase(Val, "CABIFunctionType", model::TypeKind::CABIFunctionType);
-    IO.enumCase(Val, "RawFunctionType", model::TypeKind::RawFunctionType);
+    using namespace model::TypeKind;
+    for (unsigned I = 0; I < Count; ++I) {
+      auto V = static_cast<Values>(I);
+      IO.enumCase(Val, getName(V).data(), V);
+    }
   }
 };
 
-namespace model::TypeKind {
+} // end namespace llvm::yaml
 
-inline llvm::StringRef getName(model::TypeKind::Values V) {
-  return getNameFromYAMLEnumScalar(V);
-}
+namespace model::TypeKind {
 
 inline model::TypeKind::Values fromName(llvm::StringRef Name) {
   return getValueFromYAMLScalar<model::TypeKind::Values>(Name);
@@ -157,22 +179,43 @@ namespace model::QualifierKind {
 // The idea is that a qualifier is something that you can add to a type T to
 // obtain another type R, in such a way that if T is fully known also R is fully
 // known. In this sense Pointer and Array types are qualified types.
-enum Values { Invalid, Pointer, Array, Const };
+enum Values { Invalid, Pointer, Array, Const, Count };
+
+inline llvm::StringRef getName(Values V) {
+  switch (V) {
+  case Invalid:
+    return "Invalid";
+  case Pointer:
+    return "Pointer";
+  case Array:
+    return "Array";
+  case Const:
+    return "Const";
+  default:
+    revng_abort();
+  }
+  revng_abort();
+}
 
 } // end namespace model::QualifierKind
+
+namespace llvm::yaml {
 
 // Make model::QualifierKind::Values yaml-serializable, required for making
 // model::Qualifier yaml-serializable as well
 template<>
-struct llvm::yaml::ScalarEnumerationTraits<model::QualifierKind::Values> {
+struct ScalarEnumerationTraits<model::QualifierKind::Values> {
   template<typename IOType>
   static void enumeration(IOType &IO, model::QualifierKind::Values &Val) {
-    IO.enumCase(Val, "Invalid", model::QualifierKind::Invalid);
-    IO.enumCase(Val, "Pointer", model::QualifierKind::Pointer);
-    IO.enumCase(Val, "Array", model::QualifierKind::Array);
-    IO.enumCase(Val, "Const", model::QualifierKind::Const);
+    using namespace model::QualifierKind;
+    for (unsigned I = 0; I < Count; ++I) {
+      auto V = static_cast<Values>(I);
+      IO.enumCase(Val, getName(V).data(), V);
+    }
   }
 };
+
+} // namespace llvm::yaml
 
 // Make model::Type derived types usable with UpcastablePointer
 template<>
@@ -374,34 +417,54 @@ enum Values {
   Number,
   Unsigned,
   Signed,
-  Float
+  Float,
+  Count
 };
+
+inline llvm::StringRef getName(Values V) {
+  switch (V) {
+  case Invalid:
+    return "Invalid";
+  case Void:
+    return "Void";
+  case Generic:
+    return "Generic";
+  case PointerOrNumber:
+    return "PointerOrNumber";
+  case Number:
+    return "Number";
+  case Unsigned:
+    return "Unsigned";
+  case Signed:
+    return "Signed";
+  case Float:
+    return "Float";
+  default:
+    revng_abort();
+  }
+  revng_abort();
+}
 
 } // end namespace model::PrimitiveTypeKind
 
+namespace llvm::yaml {
+
 // Make model::PrimitiveTypeKind::Values yaml-serializable
 template<>
-struct llvm::yaml::ScalarEnumerationTraits<model::PrimitiveTypeKind::Values> {
+struct ScalarEnumerationTraits<model::PrimitiveTypeKind::Values> {
   template<typename IOType>
   static void enumeration(IOType &IO, model::PrimitiveTypeKind::Values &Val) {
-    IO.enumCase(Val, "Invalid", model::PrimitiveTypeKind::Invalid);
-    IO.enumCase(Val, "Void", model::PrimitiveTypeKind::Void);
-    IO.enumCase(Val, "Generic", model::PrimitiveTypeKind::Generic);
-    IO.enumCase(Val,
-                "PointerOrNumber",
-                model::PrimitiveTypeKind::PointerOrNumber);
-    IO.enumCase(Val, "Number", model::PrimitiveTypeKind::Number);
-    IO.enumCase(Val, "Unsigned", model::PrimitiveTypeKind::Unsigned);
-    IO.enumCase(Val, "Signed", model::PrimitiveTypeKind::Signed);
-    IO.enumCase(Val, "Float", model::PrimitiveTypeKind::Float);
+    using namespace model::PrimitiveTypeKind;
+    for (unsigned I = 0; I < Count; ++I) {
+      auto V = static_cast<Values>(I);
+      IO.enumCase(Val, getName(V).data(), V);
+    }
   }
 };
 
-namespace model::PrimitiveTypeKind {
+} // end namespace llvm::yaml
 
-inline llvm::StringRef getName(model::PrimitiveTypeKind::Values V) {
-  return getNameFromYAMLEnumScalar(V);
-}
+namespace model::PrimitiveTypeKind {
 
 inline model::PrimitiveTypeKind::Values fromName(const llvm::Twine &Name) {
   return getValueFromYAMLScalar<model::PrimitiveTypeKind::Values>(Name.str());
@@ -803,19 +866,37 @@ V getOrDefault(const std::map<K, V> &Map, const K &Key, const V &Default) {
 }
 
 namespace model::abi {
-enum Values { Invalid, SystemV_x86_64 };
+
+enum Values { Invalid, SystemV_x86_64, Count };
+
+inline llvm::StringRef getName(Values V) {
+  switch (V) {
+  case Invalid:
+    return "Invalid";
+  case SystemV_x86_64:
+    return "SystemV_x86_64";
+  default:
+    revng_abort();
+  }
+  revng_abort();
+}
+
 } // namespace model::abi
 
 namespace llvm::yaml {
+
 template<>
 struct ScalarEnumerationTraits<model::abi::Values> {
-  template<typename T>
-  static void enumeration(T &IO, model::abi::Values &V) {
+  template<typename IOType>
+  static void enumeration(IOType &IO, model::abi::Values &Val) {
     using namespace model::abi;
-    IO.enumCase(V, "Invalid", Invalid);
-    IO.enumCase(V, "SystemV_x86_64", SystemV_x86_64);
+    for (unsigned I = 0; I < Count; ++I) {
+      auto V = static_cast<Values>(I);
+      IO.enumCase(Val, getName(V).data(), V);
+    }
   }
 };
+
 } // namespace llvm::yaml
 
 /// \brief The argument of a function type

--- a/lib/Model/CMakeLists.txt
+++ b/lib/Model/CMakeLists.txt
@@ -9,4 +9,5 @@ revng_add_analyses_library_internal(revngModel
   Type.cpp)
 
 target_link_libraries(revngModel
-  revngSupport)
+  revngSupport
+  ${LLVM_LIBRARIES})

--- a/lib/Model/LoadModelPass.cpp
+++ b/lib/Model/LoadModelPass.cpp
@@ -36,7 +36,7 @@ TupleTree<model::Binary> loadModel(const llvm::Module &M) {
   Metadata *MD = Tuple->getOperand(0).get();
   StringRef YAMLString = cast<MDString>(MD)->getString();
 
-  return TupleTree<model::Binary>::deserialize(YAMLString);
+  return std::move(TupleTree<model::Binary>::deserialize(YAMLString).get());
 }
 
 static TupleTree<model::Binary> extractModel(Module &M) {

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -145,7 +145,7 @@ public:
   uint64_t get() { return Distribution(Generator); }
 };
 
-llvm::ManagedStatic<RNG> IDGenerator;
+static llvm::ManagedStatic<RNG> IDGenerator;
 
 model::Type::Type(TypeKind::Values TK) :
   model::Type::Type(TK, IDGenerator->get()) {

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -176,6 +176,8 @@ bool Qualifier::verify(VerifyHelper &VH) const {
     return VH.maybeFail(Size == 0);
   case QualifierKind::Array:
     return VH.maybeFail(Size > 0);
+  default:
+    revng_abort();
   }
 
   return VH.fail();
@@ -199,6 +201,9 @@ isValidPrimitiveSize(PrimitiveTypeKind::Values PrimKind, uint8_t BS) {
 
   case PrimitiveTypeKind::Float:
     return BS == 2 or BS == 4 or BS == 8 or BS == 16;
+
+  default:
+    revng_abort();
   }
 
   revng_abort();
@@ -429,6 +434,9 @@ QualifiedType::size(VerifyHelper &VH) const {
     case QualifierKind::Const:
       // Do nothing, just skip over it
       break;
+
+    default:
+      revng_abort();
     }
   }
 
@@ -494,6 +502,9 @@ RecursiveCoroutine<std::optional<uint64_t>> Type::size(VerifyHelper &VH) const {
     }
     Size = { Max == 0 ? ResultType{} : Max };
   } break;
+
+  default:
+    revng_abort();
   }
 
   VH.setSize(this, Size ? *Size : 0);
@@ -580,6 +591,8 @@ inline RecursiveCoroutine<bool> isScalar(const QualifiedType &QT) {
       rc_return false;
     case QualifierKind::Const:
       break;
+    default:
+      revng_abort();
     }
   }
 

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -23,7 +23,38 @@ namespace model {
 
 const Identifier Identifier::Empty = Identifier("");
 
-const std::set<llvm::StringRef> CReservedKeywords = {
+const std::set<llvm::StringRef> ReservedKeywords = {
+  // reserved keywords for primitive types
+  "void"
+  "pointer_or_number8_t"
+  "pointer_or_number16_t"
+  "pointer_or_number32_t"
+  "pointer_or_number64_t"
+  "pointer_or_number128_t"
+  "number8_t"
+  "number16_t"
+  "number32_t"
+  "number64_t"
+  "number128_t"
+  "generic8_t"
+  "generic16_t"
+  "generic32_t"
+  "generic64_t"
+  "generic128_t"
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "int128_t"
+  "uint8_t"
+  "uint16_t"
+  "uint32_t"
+  "uint64_t"
+  "uint128_t"
+  "float16_t"
+  "float32_t"
+  "float64_t"
+  "float128_t"
   // C reserved keywords
   "auto",
   "break",
@@ -156,7 +187,7 @@ Identifier model::UnionField::name() const {
   using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
-    (Twine("field_") + Twine(Index)).toVector(Result);
+    (Twine("unnamed_field_") + Twine(Index)).toVector(Result);
   else
     Result = CustomName;
   return Result;
@@ -166,7 +197,7 @@ Identifier model::StructField::name() const {
   using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
-    (Twine("field_at_offset_") + Twine(Offset)).toVector(Result);
+    (Twine("unnamed_field_at_offset_") + Twine(Offset)).toVector(Result);
   else
     Result = CustomName;
   return Result;
@@ -176,7 +207,7 @@ Identifier model::Argument::name() const {
   using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
-    (Twine("arg_") + Twine(Index)).toVector(Result);
+    (Twine("unnamed_arg_") + Twine(Index)).toVector(Result);
   else
     Result = CustomName;
   return Result;
@@ -346,6 +377,10 @@ PrimitiveType::PrimitiveType(uint64_t ID) :
   Type(AssociatedKind, ID),
   PrimitiveKind(getPrimitiveKind(ID)),
   Size(getPrimitiveSize(ID)) {
+}
+
+static bool beginsWithReservedPrefix(llvm::StringRef Name) {
+  return Name.startswith("unnamed_");
 }
 
 bool EnumEntry::verify() const {
@@ -568,7 +603,8 @@ bool Identifier::verify(VerifyHelper &VH) const {
   return VH.maybeFail(not(not empty() and std::isdigit((*this)[0]))
                       and not startswith("_")
                       and AllAlphaNumOrUnderscore(*this)
-                      and not CReservedKeywords.count(llvm::StringRef(*this)));
+                      and not beginsWithReservedPrefix(*this)
+                      and not ReservedKeywords.count(llvm::StringRef(*this)));
 }
 
 static RecursiveCoroutine<bool>

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -151,6 +151,36 @@ model::Type::Type(TypeKind::Values TK) :
   model::Type::Type(TK, IDGenerator->get()) {
 }
 
+Identifier model::UnionField::name() const {
+  using llvm::Twine;
+  Identifier Result;
+  if (CustomName.empty())
+    (Twine("field_") + Twine(Index)).toVector(Result);
+  else
+    Result = CustomName;
+  return Result;
+}
+
+Identifier model::StructField::name() const {
+  using llvm::Twine;
+  Identifier Result;
+  if (CustomName.empty())
+    (Twine("field_at_offset_") + Twine(Offset)).toVector(Result);
+  else
+    Result = CustomName;
+  return Result;
+}
+
+Identifier model::Argument::name() const {
+  using llvm::Twine;
+  Identifier Result;
+  if (CustomName.empty())
+    (Twine("arg_") + Twine(Index)).toVector(Result);
+  else
+    Result = CustomName;
+  return Result;
+}
+
 Identifier model::Type::name() const {
   auto *This = this;
   auto GetName = [](auto &Upcasted) -> Identifier { return Upcasted.name(); };

--- a/tests/unit/ModelType.cpp
+++ b/tests/unit/ModelType.cpp
@@ -28,10 +28,10 @@ serializeDeserialize(const TupleTree<model::Binary> &T) {
   auto Deserialized = TupleTree<model::Binary>::deserialize(Buffer);
 
   std::string OtherBuffer;
-  Deserialized.serialize(OtherBuffer);
+  Deserialized->serialize(OtherBuffer);
   llvm::outs() << "Deserialized\n" << OtherBuffer;
 
-  return Deserialized;
+  return std::move(Deserialized.get());
 }
 
 static bool checkSerialization(const TupleTree<model::Binary> &T) {

--- a/tests/unit/TestKeyedObject.h
+++ b/tests/unit/TestKeyedObject.h
@@ -34,3 +34,4 @@ struct llvm::yaml::MappingTraits<Element>
   : public TupleLikeMappingTraits<Element> {};
 
 static_assert(HasKeyObjectTraits<Element>);
+static_assert(not IsKeyedObjectContainer<std::vector<std::pair<int, int>>>);

--- a/tests/unit/UnitTests.cmake
+++ b/tests/unit/UnitTests.cmake
@@ -18,6 +18,7 @@ target_compile_definitions(test_lazysmallbitvector
 target_include_directories(test_lazysmallbitvector
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_lazysmallbitvector
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -38,6 +39,7 @@ target_include_directories(test_stackanalysis
           "${CMAKE_BINARY_DIR}/lib/StackAnalysis")
 target_link_libraries(test_stackanalysis
   revngStackAnalysis
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -55,6 +57,7 @@ target_compile_definitions(test_classsentinel
 target_include_directories(test_classsentinel
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_classsentinel
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -72,6 +75,7 @@ target_compile_definitions(test_irhelpers
 target_include_directories(test_irhelpers
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_irhelpers
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -89,6 +93,7 @@ target_compile_definitions(test_advancedvalueinfo
 target_include_directories(test_advancedvalueinfo
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_advancedvalueinfo
+  revngModel
   revngSupport
   revngBasicAnalyses
   Boost::unit_test_framework
@@ -106,6 +111,7 @@ target_compile_definitions(test_zipmapiterator
 target_include_directories(test_zipmapiterator
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_zipmapiterator
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -123,6 +129,7 @@ target_compile_definitions(test_constantrangeset
 target_include_directories(test_constantrangeset
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_constantrangeset
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -140,6 +147,7 @@ target_compile_definitions(test_shrinkinstructionoperands
 target_include_directories(test_shrinkinstructionoperands
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_shrinkinstructionoperands
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -158,6 +166,7 @@ target_include_directories(test_metaaddress
 target_compile_definitions(test_metaaddress
   PRIVATE "BOOST_TEST_DYN_LINK=1")
 target_link_libraries(test_metaaddress
+  revngModel
   revngSupport
   revngUnitTestHelpers
   ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
@@ -175,6 +184,7 @@ target_compile_definitions(test_filtered_graph_traits
 target_include_directories(test_filtered_graph_traits
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_filtered_graph_traits
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -192,6 +202,7 @@ target_compile_definitions(test_smallmap
 target_include_directories(test_smallmap
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_smallmap
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -209,6 +220,7 @@ target_compile_definitions(test_genericgraph
 target_include_directories(test_genericgraph
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_genericgraph
+  revngModel
   revngSupport
   Boost::unit_test_framework
   ${LLVM_LIBRARIES})
@@ -225,6 +237,7 @@ target_compile_definitions(test_keyedobjectscontainers
 target_include_directories(test_keyedobjectscontainers
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_keyedobjectscontainers
+  revngModel
   revngSupport
   revngUnitTestHelpers
   Boost::unit_test_framework
@@ -242,6 +255,7 @@ target_compile_definitions(test_model
 target_include_directories(test_model
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_model
+  revngModel
   revngSupport
   revngUnitTestHelpers
   revngModel
@@ -260,6 +274,7 @@ target_compile_definitions(test_instantiatepasses
 target_include_directories(test_instantiatepasses
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_instantiatepasses
+  revngModel
   revngSupport
   revngUnitTestHelpers
   revngModel
@@ -278,6 +293,7 @@ target_compile_definitions(test_upcastablepointer
 target_include_directories(test_upcastablepointer
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_upcastablepointer
+  revngModel
   revngSupport
   revngUnitTestHelpers
   revngModel
@@ -297,6 +313,7 @@ macro(add_recursive_coroutine_test NAME)
   target_include_directories("${NAME}"
     PRIVATE "${CMAKE_SOURCE_DIR}")
   target_link_libraries("${NAME}"
+    revngModel
     revngSupport
     ${LLVM_LIBRARIES})
   add_test(NAME "${NAME}" COMMAND "./bin/${NAME}")
@@ -321,6 +338,7 @@ target_compile_definitions(test_model_type
 target_include_directories(test_model_type
   PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_model_type
+  revngModel
   revngSupport
   revngUnitTestHelpers
   revngModel


### PR DESCRIPTION
- Add missing `static` to a global variable
- Link `librevngModel` with llvm libraries
- Modernize enums associated with `model::Type`, providing efficient `getName` helpers to all of them
- Add name() members to various Model types
- Add operator<=> for model::Qualifier
- Fix callOnPathSteps for KeyedObjectContainer
- Fix missing linking for libraries in unittests
- Stricten verification for model::Identifier
- Enable error checking on Model deserialization
- Prevent model::Type CustomNames from colliding