### PR TITLE
Allow lines to start with `.`

### DIFF
--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -182,7 +182,7 @@ function run_revng_checks() {
     $GREP "(\$" $FILES | grep -v 'R"LLVM.*(' | cat
 
     # Things should never be at the beginning of a line
-    for REGEXP in '\.[^\.]' '\*>' '/[^/\*]' ':[^:\(]*)' '==' '\!=' '<[^<]' '>' '>=' '<=' '//\s*WIP' '#if\s*[01]'; do
+    for REGEXP in '\*>' '/[^/\*]' ':[^:\(]*)' '==' '\!=' '<[^<]' '>' '>=' '<=' '//\s*WIP' '#if\s*[01]'; do
         $GREP "^\s*$REGEXP" $FILES | cat
     done
 


### PR DESCRIPTION
This rule, even if it prevents weird line-breaks, does not allow us to take full advantage of both designated initializers and method-chaining idiom.