### PR TITLE
Feature/debug info pass

### DIFF
--- a/include/revng/Support/DebugInfo.h
+++ b/include/revng/Support/DebugInfo.h
@@ -1,0 +1,17 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/Pass.h"
+
+class DebugInfo : public llvm::ModulePass {
+public:
+  static char ID;
+
+public:
+  DebugInfo() : ModulePass(ID) {}
+
+  bool runOnModule(llvm::Module &M) override;
+};

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -7,6 +7,7 @@ revng_add_library_internal(revngSupport SHARED
   CommandLine.cpp
   Debug.cpp
   DebugHelper.cpp
+  DebugInfo.cpp
   ExampleAnalysis.cpp
   FunctionTags.cpp
   IRHelpers.cpp

--- a/lib/Support/DebugInfo.cpp
+++ b/lib/Support/DebugInfo.cpp
@@ -1,0 +1,34 @@
+/// \file DebugInfo.cpp
+/// \brief Run an instance of DebugHelper over the IR.
+
+#include "llvm/IR/AssemblyAnnotationWriter.h"
+#include "llvm/IR/IRBuilder.h"
+
+#include "revng/Support/CommandLine.h"
+#include "revng/Support/Debug.h"
+#include "revng/Support/DebugHelper.h"
+#include "revng/Support/DebugInfo.h"
+#include "revng/Support/revng.h"
+
+using namespace llvm;
+
+char DebugInfo::ID = 0;
+static RegisterPass<DebugInfo> X("debug-info", "Add debug metadata");
+
+cl::opt<std::string> DebugPath("debug-info-path",
+                               cl::desc("Filename produced as output"),
+                               cl::value_desc("filename"),
+                               cl::NumOccurrencesFlag::Optional);
+
+bool DebugInfo::runOnModule(Module &M) {
+  std::string DecoratedModulePath;
+  if (DebugPath.size() == 0) {
+    DecoratedModulePath = M.getModuleIdentifier();
+  } else {
+    DecoratedModulePath = DebugPath;
+  }
+
+  DebugHelper DBG("debug_info", &M, DebugInfoType::LLVMIR, DecoratedModulePath);
+  DBG.generateDebugInfo();
+  return true;
+}


### PR DESCRIPTION
Add a pass which which invokes DebugHelper in order to decorate an LLVM
IR module with the debug information that can be later exploited by gdb
in order to perform src stepping when executing a translated binary.

Add also an option in revng translate to automatically schedule the
pass.

I also addressed some doubts expressed in a previous MR that later dropped this functionality, [here](https://github.com/revng/revng/pull/37#discussion_r562720680) and [here](https://github.com/revng/revng/pull/37#discussion_r562720680), specifically the extraction of the class definition in an header, and the addition of a cl::opt that enables to specify a name for the newly created module, while the default behavior is to overwrite the input module in place.