### PR TITLE
Handle missing model in SerializeModelPass

### DIFF
--- a/include/revng/Model/SerializeModelPass.h
+++ b/include/revng/Model/SerializeModelPass.h
@@ -19,7 +19,7 @@ public:
   SerializeModelWrapperPass() : llvm::ModulePass(ID) {}
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override final {
     AU.setPreservesAll();
-    AU.addRequired<LoadModelWrapperPass>();
+    AU.addUsedIfAvailable<LoadModelWrapperPass>();
   }
 
 public:


### PR DESCRIPTION
Before this commit, SerializeModelPass and SerializeModelWrapperPass hadhard dependencies on the passes that load the model from LLVM-IR.

This commit makes this dependency optional. When the passes for model serialization are executed, if they see that nobody requested to load the model, they will not try to serialize it.

This prevents them from crashing when running in pipelines that only contain passes that ignore the model.

This is particularly beneficial because `revng opt` automatically adds `-serialize-model` at the end of each pipeline and, before this commit, this meant that `revng opt` could not be used for unit-testing simple llvm passes that do not use the model.

With this commit, `revng opt` can be used for unit-tests, even on LLVM IR with missing model.