### PR TITLE
Add pointer size to the model's information

### DIFF
--- a/include/revng/Model/Architecture.h
+++ b/include/revng/Model/Architecture.h
@@ -34,6 +34,27 @@ inline llvm::StringRef getName(Values V) {
   }
 }
 
+inline uint8_t getPointerByteSize(Values V) {
+  switch (V) {
+  case Invalid:
+    return 0U;
+  case x86:
+    return 4U;
+  case x86_64:
+    return 8U;
+  case arm:
+    return 4U;
+  case aarch64:
+    return 8U;
+  case mips:
+    return 4U;
+  case systemz:
+    return 8U;
+  default:
+    revng_abort();
+  }
+}
+
 inline Values fromLLVMArchitecture(llvm::Triple::ArchType A) {
   switch (A) {
   case llvm::Triple::x86:


### PR DESCRIPTION
Add a function that, given the architecture of the binary analyzed, returns the byte size that registers holding pointers have in that architecture.