### PR TITLE
Fix memory leak in TupleTreePath::operator=

### DIFF
--- a/include/revng/ADT/TupleTreePath.h
+++ b/include/revng/ADT/TupleTreePath.h
@@ -110,6 +110,7 @@ public:
   char *id() const override { return typeID<T>(); }
 
   void clone(TupleTreeKeyWrapper *Target) const override {
+    Target->~TupleTreeKeyWrapper();
     new (Target) ConcreteTupleTreeKeyWrapper(*get());
   }
 };


### PR DESCRIPTION
Operator= should cleanup the object that is being assigned before resizing it, otherwise the TupleTreeKeyWrapper destructor is never called and, as a consequence, the object pointed by the Pointer member is never freed.