### PR TITLE
TupleTree: make Root a `std::variant<RootT *, const RootT*>`

### DIFF
--- a/include/revng/ADT/KeyedObjectContainer.h
+++ b/include/revng/ADT/KeyedObjectContainer.h
@@ -31,16 +31,10 @@ class SortedVector;
 namespace detail {
 
 template<typename T>
-using no_cv_t = std::remove_cv_t<T>;
-
-template<typename T, template<typename...> class Ref>
-concept is_no_cv_specialization_v = is_specialization_v<no_cv_t<T>, Ref>;
+concept IsMutableSet = is_specialization_v<T, MutableSet>;
 
 template<typename T>
-concept IsMutableSet = is_no_cv_specialization_v<T, MutableSet>;
-
-template<typename T>
-concept IsSortedVector = is_no_cv_specialization_v<T, SortedVector>;
+concept IsSortedVector = is_specialization_v<T, SortedVector>;
 
 template<typename T>
 concept IsKOC = IsMutableSet<T> or IsSortedVector<T>;

--- a/include/revng/ADT/STLExtras.h
+++ b/include/revng/ADT/STLExtras.h
@@ -23,10 +23,14 @@ struct is_specialization : std::false_type {};
 template<template<typename...> class Ref, typename... Args>
 struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
+template<template<typename...> class Ref, typename... Args>
+struct is_specialization<const Ref<Args...>, Ref> : std::true_type {};
+
 template<typename Test, template<typename...> class Ref>
 constexpr bool is_specialization_v = is_specialization<Test, Ref>::value;
 
 static_assert(is_specialization_v<std::vector<int>, std::vector>);
+static_assert(is_specialization_v<const std::vector<int>, std::vector>);
 static_assert(is_specialization_v<std::pair<int, long>, std::pair>);
 
 //

--- a/include/revng/ADT/TupleTreePath.h
+++ b/include/revng/ADT/TupleTreePath.h
@@ -169,4 +169,6 @@ public:
 
 public:
   size_t size() const { return Storage.size(); }
+
+  bool empty() const { return Storage.empty(); }
 };

--- a/include/revng/Model/Binary.h
+++ b/include/revng/Model/Binary.h
@@ -688,10 +688,18 @@ public:
                                 "/Types/" + getNameFromYAMLScalar(T->key()));
   }
 
+  model::TypePath getTypePath(const model::Type *T) const {
+    return TypePath::fromString(this,
+                                "/Types/" + getNameFromYAMLScalar(T->key()));
+  }
+
   TypePath recordNewType(UpcastablePointer<Type> &&T);
 
   model::TypePath
   getPrimitiveType(PrimitiveTypeKind::Values V, uint8_t ByteSize);
+
+  model::TypePath
+  getPrimitiveType(PrimitiveTypeKind::Values V, uint8_t ByteSize) const;
 
   bool verifyTypes() const debug_function;
   bool verifyTypes(bool Assert) const debug_function;

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -515,7 +515,7 @@ public:
 
 public:
   PrimitiveType(PrimitiveTypeKind::Values PrimitiveKind, uint8_t ByteSize);
-  PrimitiveType(uint64_t ID);
+  explicit PrimitiveType(uint64_t ID);
   PrimitiveType() : PrimitiveType(model::PrimitiveTypeKind::Void) {}
 
 public:
@@ -539,7 +539,7 @@ public:
   SortedVector<Identifier> Aliases;
 
 public:
-  EnumEntry(uint64_t Value) : Value(Value) {}
+  explicit EnumEntry(uint64_t Value) : Value(Value) {}
   EnumEntry() : EnumEntry(0) {}
 
 public:
@@ -587,7 +587,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  EnumType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit EnumType(uint64_t ID) : Type(AssociatedKind, ID) {}
   EnumType() : Type(AssociatedKind) {}
 
 public:
@@ -621,7 +621,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  TypedefType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit TypedefType(uint64_t ID) : Type(AssociatedKind, ID) {}
   TypedefType() : Type(AssociatedKind) {}
 
 public:
@@ -659,7 +659,7 @@ public:
   uint64_t Offset = 0;
 
 public:
-  StructField(uint64_t Offset) : Offset(Offset) {}
+  explicit StructField(uint64_t Offset) : Offset(Offset) {}
   StructField() : StructField(0) {}
 
   Identifier name() const;
@@ -702,7 +702,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  StructType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit StructType(uint64_t ID) : Type(AssociatedKind, ID) {}
   StructType() : Type(AssociatedKind) {}
 
 public:
@@ -723,7 +723,7 @@ public:
   uint64_t Index;
 
 public:
-  UnionField(uint64_t Index) : AggregateField(), Index(Index) {}
+  explicit UnionField(uint64_t Index) : AggregateField(), Index(Index) {}
   UnionField() : UnionField(0) {}
 
 public:
@@ -765,7 +765,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  UnionType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit UnionType(uint64_t ID) : Type(AssociatedKind, ID) {}
   UnionType() : Type(AssociatedKind) {}
 
 public:
@@ -869,7 +869,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  RawFunctionType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit RawFunctionType(uint64_t ID) : Type(AssociatedKind, ID) {}
   RawFunctionType() : Type(AssociatedKind) {}
 
 public:
@@ -916,7 +916,7 @@ public:
   Identifier CustomName;
 
 public:
-  Argument(uint64_t Index) : Index(Index) {}
+  explicit Argument(uint64_t Index) : Index(Index) {}
   Argument() : Argument(0) {}
 
 public:
@@ -971,7 +971,7 @@ public:
 
 public:
   /// \note Not to be used directly, only KeyedObjectTraits should use this
-  CABIFunctionType(uint64_t ID) : Type(AssociatedKind, ID) {}
+  explicit CABIFunctionType(uint64_t ID) : Type(AssociatedKind, ID) {}
   CABIFunctionType() : Type(AssociatedKind) {}
 
 public:

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -492,7 +492,8 @@ public:
   bool verify() const debug_function;
   bool verify(bool Assert) const debug_function;
   RecursiveCoroutine<bool> verify(VerifyHelper &VH) const;
-  void dump() const debug_function;
+  void dump(llvm::raw_ostream &) const debug_function;
+  void dump() const debug_function { dump(llvm::dbgs()); }
 };
 INTROSPECTION_NS(model, QualifiedType, UnqualifiedType, Qualifiers);
 

--- a/include/revng/TupleTree/TupleTree.h
+++ b/include/revng/TupleTree/TupleTree.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <set>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
@@ -401,7 +402,7 @@ bool callOnPathSteps(Visitor &V,
   if (It == M.end())
     return false;
 
-  value_type *Matching = &*It;
+  auto *Matching = &*It;
 
   V.template visitContainerElement<RootT>(TargetKey, *Matching);
   if (Path.size() > 1) {
@@ -1009,24 +1010,29 @@ struct std::tuple_size<T>
 template<TupleTreeCompatible T>
 class TupleTree;
 
-template<typename T, typename RootT>
+template<typename T, typename R>
+concept ConstOrNot = std::is_same_v<R, T> or std::is_same_v<const R, T>;
+
+template<typename T, typename RootType>
 class TupleTreeReference {
 public:
-  using pointee = T;
+  using RootT = RootType;
+  using RootVariant = std::variant<RootT *, const RootT *>;
 
 public:
-  RootT *Root = nullptr;
+  RootVariant Root = static_cast<RootT *>(nullptr);
   TupleTreePath Path;
 
 public:
-  static TupleTreeReference fromPath(RootT *Root, const TupleTreePath &Path) {
-    TupleTreeReference Result;
-    Result.Root = Root;
-    Result.Path = Path;
-    return Result;
+  static TupleTreeReference
+  fromPath(ConstOrNot<TupleTreeReference::RootT> auto *Root,
+           const TupleTreePath &Path) {
+    return TupleTreeReference{ .Root = RootVariant{ Root }, .Path = Path };
   }
 
-  static TupleTreeReference fromString(RootT *Root, llvm::StringRef Path) {
+  static TupleTreeReference
+  fromString(ConstOrNot<TupleTreeReference::RootT> auto *Root,
+             llvm::StringRef Path) {
     std::optional<TupleTreePath> OptionalPath = stringAsPath<RootT>(Path);
     if (not OptionalPath.has_value())
       return TupleTreeReference{};
@@ -1043,26 +1049,43 @@ public:
 
   const TupleTreePath &path() const { return Path; }
 
-  T *get() {
-    revng_check(Root != nullptr);
-
-    if (Path.size() == 0)
-      return nullptr;
-
-    return getByPath<T>(Path, *Root);
+private:
+  bool hasNullRoot() const {
+    const auto IsNullVisitor = [](const auto &Pointer) {
+      return Pointer == nullptr;
+    };
+    return std::visit(IsNullVisitor, Root);
   }
 
+  bool canGet() const {
+    return Root.index() != std::variant_npos and not hasNullRoot();
+  }
+
+public:
   const T *get() const {
-    revng_check(Root != nullptr);
+    revng_assert(canGet());
 
     if (Path.size() == 0)
       return nullptr;
 
-    return getByPath<T>(Path, *Root);
+    const auto GetByPathVisitor = [&Path = Path](const auto &RootPointer) {
+      return getByPath<T>(Path, *RootPointer);
+    };
+
+    return std::visit(GetByPathVisitor, Root);
+  }
+
+  T *get() {
+    revng_assert(canGet());
+
+    if (Path.size() == 0)
+      return nullptr;
+
+    return getByPath<T>(Path, *std::get<RootT *>(Root));
   }
 
   bool isValid() const debug_function {
-    return (*this != TupleTreeReference() and get() != nullptr);
+    return not hasNullRoot() and not Path.empty() and get() != nullptr;
   }
 };
 
@@ -1079,7 +1102,7 @@ struct llvm::yaml::ScalarTraits<T> {
   static llvm::StringRef input(llvm::StringRef Path, void *, T &Obj) {
     // We temporarily initialize Root to nullptr, a post-processing phase will
     // take care of fixup these
-    Obj = T::fromString(nullptr, Path);
+    Obj = T::fromString(static_cast<typename T::RootT *>(nullptr), Path);
     return {};
   }
 
@@ -1205,7 +1228,13 @@ private:
     bool Result = true;
 
     visitReferences([&Result, this](const auto &Element) {
-      Result = Result and (Element.Root == Root.get());
+      const auto SameRoot = [&]() {
+        const auto GetPtrToConstRoot =
+          [](const auto &RootPointer) -> const T * { return RootPointer; };
+
+        return std::visit(GetPtrToConstRoot, Element.Root) == Root.get();
+      };
+      Result = Result and SameRoot();
     });
 
     return Result;
@@ -1244,3 +1273,16 @@ struct NamedEnumScalarTraits {
     }
   }
 };
+
+/// \brief Specialization for the std::variant we have in TupleTreeReference
+template<bool X, typename T>
+inline void writeToLog(Logger<X> &This,
+                       const std::variant<T *, const T *> &Var,
+                       int Ignored) {
+  if (Var.index() == std::variant_npos)
+    writeToLog(This, llvm::StringRef("std::variant_npos"), Ignored);
+  else if (std::holds_alternative<T *>(Var))
+    writeToLog(This, std::get<T *>(Var), Ignored);
+  else if (std::holds_alternative<const T *>(Var))
+    writeToLog(This, std::get<const T *>(Var), Ignored);
+}

--- a/include/revng/TupleTree/TupleTree.h
+++ b/include/revng/TupleTree/TupleTree.h
@@ -25,7 +25,7 @@
 template<typename T>
 concept TupleTreeCompatible = IsKeyedObjectContainer<T>
                                 or HasTupleSize<T>
-                                or IsUpcastablePointer<T>;
+                                or UpcastablePointerLike<T>;
 // clang-format on
 
 template<typename T>

--- a/include/revng/TupleTree/TupleTree.h
+++ b/include/revng/TupleTree/TupleTree.h
@@ -1084,6 +1084,8 @@ public:
     return getByPath<T>(Path, *std::get<RootT *>(Root));
   }
 
+  const T *getConst() const { return get(); }
+
   bool isValid() const debug_function {
     return not hasNullRoot() and not Path.empty() and get() != nullptr;
   }

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -131,6 +131,13 @@ Binary::getPrimitiveType(PrimitiveTypeKind::Values V, uint8_t ByteSize) {
   return getTypePath(It->get());
 }
 
+model::TypePath
+Binary::getPrimitiveType(PrimitiveTypeKind::Values V, uint8_t ByteSize) const {
+  PrimitiveType Temporary(V, ByteSize);
+  Type::Key PrimitiveKey{ TypeKind::Primitive, Temporary.ID };
+  return getTypePath(Types.at(PrimitiveKey).get());
+}
+
 TypePath Binary::recordNewType(UpcastablePointer<Type> &&T) {
   auto It = Types.insert(T).first;
   return getTypePath(It->get());

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -728,9 +728,6 @@ verifyImpl(VerifyHelper &VH, const StructType *T) {
   if (T->Size == 0)
     rc_return VH.fail("Struct type has zero size", *T);
 
-  if (T->Fields.empty())
-    rc_return VH.fail("Struct has no fields", *T);
-
   size_t Index = 0;
   llvm::SmallSet<llvm::StringRef, 8> Names;
   auto FieldIt = T->Fields.begin();

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -443,8 +443,7 @@ static VoidConstResult isVoidConst(const QualifiedType *QualType) {
       // We know that it's const-qualified here, and it only has one
       // qualifier, hence we can skip the const-qualifier.
       Result.IsConst = true;
-      if (not QualType->UnqualifiedType.Root)
-        return Result;
+      return Result;
     }
 
     UnqualType = QualType->UnqualifiedType.get();

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -945,8 +945,8 @@ RecursiveCoroutine<bool> Type::verify(VerifyHelper &VH) const {
   rc_return VH.maybeFail(Result);
 }
 
-void QualifiedType::dump() const {
-  serialize(dbg, *this);
+void QualifiedType::dump(llvm::raw_ostream &OS) const {
+  serialize(OS, *this);
 }
 
 bool QualifiedType::verify() const {

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -797,6 +797,14 @@ verifyImpl(VerifyHelper &VH, const UnionType *T) {
     if (not rc_recur Field.verify(VH))
       rc_return VH.fail();
 
+    auto MaybeSize = rc_recur Field.Type.size(VH);
+
+    // Unions cannot have zero-sized fields
+    if (not MaybeSize) {
+      using llvm::Twine;
+      rc_return VH.fail("Field " + Twine(Field.Index + 1) + " zero-sized", *T);
+    }
+
     if (Field.CustomName.size() > 0) {
       if (not Names.insert(Field.CustomName).second)
         rc_return VH.fail();

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -19,6 +19,7 @@
 
 using llvm::cast;
 using llvm::dyn_cast;
+using llvm::Twine;
 
 namespace model {
 
@@ -185,7 +186,6 @@ model::Type::Type(TypeKind::Values TK) :
 }
 
 Identifier model::UnionField::name() const {
-  using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
     (Twine("unnamed_field_") + Twine(Index)).toVector(Result);
@@ -195,7 +195,6 @@ Identifier model::UnionField::name() const {
 }
 
 Identifier model::StructField::name() const {
-  using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
     (Twine("unnamed_field_at_offset_") + Twine(Offset)).toVector(Result);
@@ -205,7 +204,6 @@ Identifier model::StructField::name() const {
 }
 
 Identifier model::Argument::name() const {
-  using llvm::Twine;
   Identifier Result;
   if (CustomName.empty())
     (Twine("unnamed_arg_") + Twine(Index)).toVector(Result);
@@ -277,7 +275,6 @@ isValidPrimitiveSize(PrimitiveTypeKind::Values PrimKind, uint8_t BS) {
 }
 
 Identifier model::PrimitiveType::name() const {
-  using llvm::Twine;
   Identifier Result;
 
   switch (PrimitiveKind) {
@@ -318,7 +315,6 @@ Identifier model::PrimitiveType::name() const {
 
 template<typename T>
 Identifier customNameOrAutomatic(T *This) {
-  using llvm::Twine;
   if (not This->CustomName.empty())
     return This->CustomName;
   else
@@ -342,7 +338,6 @@ Identifier model::UnionType::name() const {
 }
 
 Identifier model::NamedTypedRegister::name() const {
-  using llvm::Twine;
   if (not CustomName.empty())
     return CustomName;
   else
@@ -636,7 +631,7 @@ bool Identifier::verify(VerifyHelper &VH) const {
                         and AllAlphaNumOrUnderscore(*this)
                         and not beginsWithReservedPrefix(*this)
                         and not ReservedKeywords.count(llvm::StringRef(*this)),
-                      llvm::Twine(*this) + " is not a valid identifier");
+                      Twine(*this) + " is not a valid identifier");
 }
 
 static RecursiveCoroutine<bool>
@@ -736,8 +731,7 @@ verifyImpl(VerifyHelper &VH, const StructType *T) {
     auto &Field = *FieldIt;
 
     if (not rc_recur Field.verify(VH))
-      rc_return VH.fail("Can't verify type of field " + llvm::Twine(Index + 1),
-                        *T);
+      rc_return VH.fail("Can't verify type of field " + Twine(Index + 1), *T);
 
     if (Field.Offset >= T->Size)
       rc_return VH.fail("Field " + Twine(Index + 1)
@@ -796,7 +790,6 @@ verifyImpl(VerifyHelper &VH, const UnionType *T) {
     uint64_t ExpectedIndex = Group.index();
 
     if (Field.Index != ExpectedIndex) {
-      using llvm::Twine;
       rc_return VH.fail(Twine("Union type is missing field ")
                           + Twine(ExpectedIndex),
                         *T);
@@ -809,12 +802,10 @@ verifyImpl(VerifyHelper &VH, const UnionType *T) {
 
     // Unions cannot have zero-sized fields
     if (not MaybeSize) {
-      using llvm::Twine;
       rc_return VH.fail("Field " + Twine(Field.Index) + " zero-sized", *T);
     }
 
     if (isVoidConst(&Field.Type).IsVoid) {
-      using llvm::Twine;
       rc_return VH.fail("Field " + Twine(Field.Index) + " is void", *T);
     }
 

--- a/tests/unit/ModelType.cpp
+++ b/tests/unit/ModelType.cpp
@@ -353,10 +353,18 @@ BOOST_AUTO_TEST_CASE(StructTypes) {
   revng_check(T->verify(true));
   revng_check(checkSerialization(T));
 
-  // Struct without fields are invalid
+  // Struct without fields are valid as long as their size is not zero
   Struct->Fields.clear();
+  revng_check(Struct->verify(false));
+  revng_check(T->verify(false));
+  Struct->Size = 0;
   revng_check(not Struct->verify(false));
   revng_check(not T->verify(false));
+
+  // Put the size back to a large value for the other tests.
+  Struct->Size = 100;
+  revng_check(Struct->verify(false));
+  revng_check(T->verify(false));
 
   // Struct x cannot have a field with type x
   Struct->Fields.clear();


### PR DESCRIPTION
This enables holding `TupleTreeReference`s to immutable model objects.

The patchset includes a few other changes that are necessary for enabling `TupleTreeReference`s to immutable model objects, or for improving their ergonomics.

This branch has already been tested, and checked for style issues.