### PR TITLE
Workaround: renvg.h should not use model headers

### DIFF
--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -25,3 +25,13 @@ target_link_libraries(revngSupport ${LLVM_LIBRARIES})
 
 target_include_directories(revngSupport
   INTERFACE $<INSTALL_INTERFACE:include/>)
+
+# support has a dependency to the generated model files because of revng.h
+#
+# revng.h includes model headers which depends on the generated headers.
+# we cannot add the dependency to the model because the model itself depends
+# on support and would generate a cyclic dependency. 
+# The proper fix would be to entirelly remove every use of model headers is 
+# support.
+add_dependencies(revngSupport generate-model-tuple-tree-code)
+


### PR DESCRIPTION
Before this commit the bug can be found by
orc clean revng
cd /root/of/orchestra
rm -rf ./root
orc configure revng
cd build/revng/optimized
ninja renvgSupport

the error should manifest itself as some generated headers missing

revng.h is currently using some headers belonging to model, while not
expressing a dependency to the model target. Such dependency cannot be
expressed because revngModel already depends on revngSupport, it would
generate cyclic dependencies.

The proper fix would be to rewrite revng.h so that it does not uses the
model.