### PR TITLE
Fix: revng-model-inject on modeless modules

### DIFF
--- a/include/revng/Model/LoadModelPass.h
+++ b/include/revng/Model/LoadModelPass.h
@@ -14,6 +14,7 @@
 inline const char *ModelMetadataName = "revng.model";
 
 TupleTree<model::Binary> loadModel(const llvm::Module &M);
+bool hasModel(const llvm::Module &M);
 
 class ModelWrapper {
 private:

--- a/include/revng/Model/ToolHelpers.h
+++ b/include/revng/Model/ToolHelpers.h
@@ -166,7 +166,8 @@ public:
       return MaybeModule.takeError();
 
     Result.Module = std::move(*MaybeModule);
-    Result.Model = loadModel(*Result.Module);
+    if (hasModel(*Result.Module))
+      Result.Model = loadModel(*Result.Module);
 
     return Result;
   }

--- a/lib/Model/LoadModelPass.cpp
+++ b/lib/Model/LoadModelPass.cpp
@@ -26,10 +26,15 @@ using RP = RegisterPass<T>;
 static RP<LoadModelWrapperPass>
   X("load-model", "Deserialize the model", true, true);
 
-TupleTree<model::Binary> loadModel(const llvm::Module &M) {
+bool hasModel(const llvm::Module &M) {
   NamedMDNode *NamedMD = M.getNamedMetadata(ModelMetadataName);
-  revng_check(NamedMD and NamedMD->getNumOperands());
+  return NamedMD and NamedMD->getNumOperands();
+}
 
+TupleTree<model::Binary> loadModel(const llvm::Module &M) {
+  revng_check(hasModel(M));
+
+  NamedMDNode *NamedMD = M.getNamedMetadata(ModelMetadataName);
   auto *Tuple = cast<MDTuple>(NamedMD->getOperand(0));
   revng_check(Tuple->getNumOperands());
 


### PR DESCRIPTION
Inject is meant to inject a model into a module, but it is failing when operating on a module that had no model metadata at all.
This commit fixes the bug