### PR TITLE
check-revng-conventions: fix black invocation

### DIFF
--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -143,10 +143,12 @@ function run_clang_format() {
 # Run black
 function run_black() {
     PYTHON_FILES="$( ( git grep -l '^#!.*python' && git ls-files | grep '\.py$' ) | sort -u )"
-    if test "$FORCE_FORMAT" -gt 0; then
-        black -q -l 100 $PYTHON_FILES
-    else
-        black --check -l 100 $PYTHON_FILES | grep 'Oh no'
+    if [ ! -z "$PYTHON_FILES" ]; then
+        if test "$FORCE_FORMAT" -gt 0; then
+            black -q -l 100 $PYTHON_FILES
+        else
+            black --check -l 100 $PYTHON_FILES | grep 'Oh no'
+        fi
     fi
 }
 


### PR DESCRIPTION
Before this commit, the black code formatter for python was invoked even if the list of python files was empty, causing errors in that case.

This never happened in revng, but it happens in other revng projects that do not have python files.

This commit fixes the script, skipping the invocation to black whenever no python files is found.