### PR TITLE
Check-conventions: handle dirs with 0 python files

### DIFF
--- a/scripts/check-revng-conventions
+++ b/scripts/check-revng-conventions
@@ -142,11 +142,12 @@ function run_clang_format() {
 
 # Run black
 function run_black() {
-    PYTHON_FILES="$( ( git grep -l '^#!.*python' && git ls-files | grep '\.py$' ) | sort -u )"
+    readarray -t PYTHON_FILES < <(( git grep -l '^#!.*python' && git ls-files | grep '\.py$' ) | sort -u )
+    if [[ ${#PYTHON_FILES[@]} -eq 0 ]]; then return; fi
     if test "$FORCE_FORMAT" -gt 0; then
-        black -q -l 100 $PYTHON_FILES
+        black -q -l 100 "${PYTHON_FILES[@]}"
     else
-        black --check -l 100 $PYTHON_FILES | grep 'Oh no'
+        black --check -l 100 "${PYTHON_FILES[@]}" | grep 'Oh no'
     fi
 }
 


### PR DESCRIPTION
Same fix as https://github.com/revng/revng/pull/139, but better according to @fcremo 