### PR TITLE
EarlyFunctionAnalysis: fix end address of a jump target basic block

### DIFF
--- a/lib/EarlyFunctionAnalysis/EarlyFunctionAnalysis.cpp
+++ b/lib/EarlyFunctionAnalysis/EarlyFunctionAnalysis.cpp
@@ -790,7 +790,10 @@ CFEPAnalyzer<FunctionOracle>::collectDirectCFG(OutlinedFunction *F) {
           } else {
             Instruction *I = &(*Succ->begin());
 
-            if (auto *Call = getCallTo(I, PreHookMarker.F)) {
+            if (isa<ReturnInst>(I)) {
+              // Did we meet the end of the cloned function? Do nothing
+              revng_assert(Succ->getInstList().size() == 1);
+            } else if (auto *Call = getCallTo(I, PreHookMarker.F)) {
               MetaAddress Destination;
               model::FunctionEdgeType::Values Type;
               auto *CalleePC = Call->getArgOperand(1);


### PR DESCRIPTION
EarlyFunctionAnalysis was considering jump targets as part of the
current basic block, thus computing the final address erroneously.