### PR TITLE
Add custom traceback support

### DIFF
--- a/include/revng/PipelineC/PipelineC.h
+++ b/include/revng/PipelineC/PipelineC.h
@@ -75,6 +75,14 @@ extern "C" {
  */
 
 /**
+ * Allow setting a custom abort hook.
+ * This will be called just before abort() in case of an assertion failure.
+ * Useful if calling from a non-C language to print extra debug information.
+ */
+typedef void (*AbortHook)(void);
+void rp_set_custom_abort_hook(AbortHook Hook);
+
+/**
  * Must be invoked before any other rp_* function is used, must be invoked
  * exactly once. This will take care of initializing all llvm related stuff
  * needed by the revng pipeline to operate.

--- a/include/revng/Support/Assert.h
+++ b/include/revng/Support/Assert.h
@@ -193,6 +193,9 @@ noret void revng_do_abort(const char *Message, const char *File, unsigned Line);
   MACRO_OVERLOAD_1_OR_2(__VA_ARGS__, revng_check_impl, revng_check_impl_nomsg) \
   (__VA_ARGS__)
 
+typedef void (*AbortHook)(void);
+void setAbortHook(AbortHook Hook);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/PipelineC/PipelineC.cpp
+++ b/lib/PipelineC/PipelineC.cpp
@@ -23,6 +23,10 @@
 using namespace pipeline;
 using namespace revng::pipes;
 
+void rp_set_custom_abort_hook(AbortHook Hook) {
+  setAbortHook(Hook);
+}
+
 static bool Initialized = false;
 
 static bool loadLibraryPermanently(const char *LibraryPath) {

--- a/lib/Support/Assert.cpp
+++ b/lib/Support/Assert.cpp
@@ -13,14 +13,23 @@
 
 #include "revng/Support/Assert.h"
 
+static AbortHook abortHook = nullptr;
+
 static void printStackTrace() {
   llvm::raw_os_ostream Output(std::cerr);
   std::cerr << "\n";
   llvm::sys::PrintStackTrace(Output);
 }
 
+void setAbortHook(AbortHook Hook) {
+  abortHook = Hook;
+}
+
 [[noreturn]] static void terminate(void) {
   printStackTrace();
+  if (abortHook != nullptr) {
+    abortHook();
+  }
   abort();
 }
 


### PR DESCRIPTION
This allows tools using the raw c api to register a traceback function pointer to allow richer debug messages