### PR TITLE
Miscellaneous fixes and improvements for `model::Qualifier` and `model::QualifiedType`

### DIFF
--- a/include/revng/Model/QualifiedType.h
+++ b/include/revng/Model/QualifiedType.h
@@ -37,10 +37,18 @@ public:
   std::optional<uint64_t> size() const debug_function;
   RecursiveCoroutine<std::optional<uint64_t>> size(VerifyHelper &VH) const;
 
+  /// Checks if is a scalar type, unwrapping typedefs
   bool isScalar() const;
+  /// Checks if is a primitive type, unwrapping typedefs
   bool isPrimitive(model::PrimitiveTypeKind::Values V) const;
-  bool isVoid() const { return isPrimitive(model::PrimitiveTypeKind::Void); }
+  /// Checks if is float, unwrapping typedefs
   bool isFloat() const { return isPrimitive(model::PrimitiveTypeKind::Float); }
+  /// Checks if is void, unwrapping typedefs
+  bool isVoid() const { return isPrimitive(model::PrimitiveTypeKind::Void); }
+  /// Checks if is an array type, unwrapping typedefs
+  bool isArray() const;
+  /// Checks if is a pointer type, withouth unwrapping typedefs
+  bool isPointer() const;
 
 public:
   bool verify() const debug_function;

--- a/include/revng/Model/Qualifier.h
+++ b/include/revng/Model/Qualifier.h
@@ -50,19 +50,19 @@ public:
   }
 
 public:
-  bool isConstQualifier() const {
-    revng_assert(verify(true));
-    return Kind == QualifierKind::Const;
+  static bool isConst(const Qualifier &Q) {
+    revng_assert(Q.verify(true));
+    return Q.Kind == QualifierKind::Const;
   }
 
-  bool isArrayQualifier() const {
-    revng_assert(verify(true));
-    return Kind == QualifierKind::Array;
+  static bool isArray(const Qualifier &Q) {
+    revng_assert(Q.verify(true));
+    return Q.Kind == QualifierKind::Array;
   }
 
-  bool isPointerQualifier() const {
-    revng_assert(verify(true));
-    return Kind == QualifierKind::Pointer;
+  static bool isPointer(const Qualifier &Q) {
+    revng_assert(Q.verify(true));
+    return Q.Kind == QualifierKind::Pointer;
   }
 
 public:

--- a/lib/Model/Importer/Dwarf/DwarfImporter.cpp
+++ b/lib/Model/Importer/Dwarf/DwarfImporter.cpp
@@ -627,7 +627,7 @@ private:
       case llvm::dwarf::DW_TAG_const_type: {
         model::Qualifier NewQualifier;
         NewQualifier.Kind = model::QualifierKind::Const;
-        Type.Qualifiers.push_back(NewQualifier);
+        Type.Qualifiers.insert(Type.Qualifiers.begin(), NewQualifier);
       } break;
 
       case llvm::dwarf::DW_TAG_array_type: {
@@ -666,7 +666,7 @@ private:
               rc_return nullptr;
             }
 
-            Type.Qualifiers.push_back(NewQualifier);
+            Type.Qualifiers.insert(Type.Qualifiers.begin(), NewQualifier);
           }
         }
       } break;
@@ -683,7 +683,7 @@ private:
 
         NewQualifier.Kind = model::QualifierKind::Pointer;
         NewQualifier.Size = *MaybeByteSize->getAsUnsignedConstant();
-        Type.Qualifiers.push_back(NewQualifier);
+        Type.Qualifiers.insert(Type.Qualifiers.begin(), NewQualifier);
       } break;
 
       default:

--- a/lib/Model/Type.cpp
+++ b/lib/Model/Type.cpp
@@ -4,6 +4,7 @@
 
 #include <bit>
 #include <cstddef>
+#include <functional>
 #include <random>
 #include <string>
 #include <type_traits>
@@ -648,10 +649,55 @@ QualifiedType::size(VerifyHelper &VH) const {
   rc_return rc_recur UnqualifiedType.get()->size(VH);
 }
 
-inline RecursiveCoroutine<bool>
-isPrimitive(const model::QualifiedType &QT,
-            model::PrimitiveTypeKind::Values V) {
+static RecursiveCoroutine<bool> isArrayImpl(const model::QualifiedType &QT) {
+  const auto &NotIsConst = std::not_fn(model::Qualifier::isConst);
+  for (const auto &Q : llvm::make_filter_range(QT.Qualifiers, NotIsConst)) {
 
+    // If we find an array first, it's definitely an array, otherwise we
+    // found a pointer first, so it's definitely not an array
+    if (Qualifier::isArray(Q))
+      rc_return true;
+
+    rc_return false;
+  }
+
+  if (auto *TD = dyn_cast<model::TypedefType>(QT.UnqualifiedType.get()))
+    rc_return rc_recur isArrayImpl(TD->UnderlyingType);
+
+  // If there are no non-const qualifiers, it's not an array
+  rc_return false;
+}
+
+bool QualifiedType::isArray() const {
+  return isArrayImpl(*this);
+}
+
+static RecursiveCoroutine<bool> isPointerImpl(const model::QualifiedType &QT) {
+  const auto &NotIsConst = std::not_fn(Qualifier::isConst);
+  for (const auto &Q : llvm::make_filter_range(QT.Qualifiers, NotIsConst)) {
+
+    // If we find a pointer first, it's definitely a pointer, otherwise we
+    // found an array first, so it's definitely not a pointer
+    if (Qualifier::isPointer(Q))
+      rc_return true;
+
+    rc_return false;
+  }
+
+  if (auto *TD = dyn_cast<model::TypedefType>(QT.UnqualifiedType.get()))
+    rc_return rc_recur isPointerImpl(TD->UnderlyingType);
+
+  // If there are no non-const qualifiers, it's not a pointer
+  rc_return false;
+}
+
+bool QualifiedType::isPointer() const {
+  return isPointerImpl(*this);
+}
+
+static RecursiveCoroutine<bool>
+isPrimitiveImpl(const model::QualifiedType &QT,
+                model::PrimitiveTypeKind::Values V) {
   if (QT.Qualifiers.size() != 0
       and not llvm::all_of(QT.Qualifiers, Qualifier::isConst))
     rc_return false;
@@ -659,14 +705,15 @@ isPrimitive(const model::QualifiedType &QT,
   const model::Type *UnqualifiedType = QT.UnqualifiedType.get();
   if (auto *Primitive = llvm::dyn_cast<PrimitiveType>(UnqualifiedType))
     rc_return Primitive->PrimitiveKind == V;
-  else if (auto *Typedef = llvm::dyn_cast<TypedefType>(UnqualifiedType))
-    rc_return rc_recur isPrimitive(Typedef->UnderlyingType, V);
+
+  if (auto *Typedef = llvm::dyn_cast<TypedefType>(UnqualifiedType))
+    rc_return rc_recur isPrimitiveImpl(Typedef->UnderlyingType, V);
 
   rc_return false;
 }
 
-bool QualifiedType::isPrimitive(model::PrimitiveTypeKind::Values V) const {
-  return model::isPrimitive(*this, V);
+bool QualifiedType::isPrimitive(PrimitiveTypeKind::Values V) const {
+  return isPrimitiveImpl(*this, V);
 }
 
 std::optional<uint64_t> Type::size() const {
@@ -827,7 +874,7 @@ verifyImpl(VerifyHelper &VH, const TypedefType *T) {
                          and rc_recur T->UnderlyingType.verify(VH));
 }
 
-inline RecursiveCoroutine<bool> isScalar(const QualifiedType &QT) {
+inline RecursiveCoroutine<bool> isScalarImpl(const QualifiedType &QT) {
   for (const Qualifier &Q : QT.Qualifiers) {
     switch (Q.Kind) {
     case QualifierKind::Invalid:
@@ -847,15 +894,16 @@ inline RecursiveCoroutine<bool> isScalar(const QualifiedType &QT) {
   revng_assert(Unqualified != nullptr);
   if (llvm::isa<model::PrimitiveType>(Unqualified)) {
     rc_return true;
-  } else if (auto *Typedef = llvm::dyn_cast<model::TypedefType>(Unqualified)) {
-    rc_return rc_recur isScalar(Typedef->UnderlyingType);
   }
+
+  if (auto *Typedef = llvm::dyn_cast<model::TypedefType>(Unqualified))
+    rc_return rc_recur isScalarImpl(Typedef->UnderlyingType);
 
   rc_return false;
 }
 
 bool model::QualifiedType::isScalar() const {
-  return ::model::isScalar(*this);
+  return isScalarImpl(*this);
 }
 
 static RecursiveCoroutine<bool>
@@ -1163,7 +1211,7 @@ template<typename T>
 RecursiveCoroutine<bool>
 verifyTypedRegisterCommon(const T &TypedRegister, VerifyHelper &VH) {
   // Ensure the type we're pointing to is scalar
-  if (not isScalar(TypedRegister->Type))
+  if (not TypedRegister->Type.isScalar())
     rc_return VH.fail();
 
   if (TypedRegister->Location == Register::Invalid)


### PR DESCRIPTION
This PR does the following.

1. Fixes the order of `model::Qualifier`s in `model::QualifiedType`s generated when importing by DWARF. Before, the order was broken because it assumed `Qualifier`s should be emitted in the same order as in C, while they actually need to be emitted left-to-right. This is particularly important because in C nested array qualifiers have opposite order w.r.t. to the other qualifiers, e.g. `int * const x` means "a constant pointer to int" (right-to-left), but `int *x[3][4]` means "an array with 3 elements, each of which is an array of 4 pointers to `int` (left-to-right, but only for the arrays, because the pointer is considered at the end). This weirdness of nested arrays means the C does not have a single natural order of qualifiers, so we cannot assume the ordering of `model::Qualifier`s to be like C (technically we could, but that would be cumbersome to handle, and unintuitive for users to specify in the model in YAML), so to second most natural choice is left-to-right.

2. Provides a set of useful helpers for inspecting properties of `model::Qualifier`s and `model::QualifiedType`.