### PR TITLE
Drop torture tests

### DIFF
--- a/tests/runtime/RuntimeTests.cmake
+++ b/tests/runtime/RuntimeTests.cmake
@@ -65,21 +65,3 @@ endmacro()
 register_derived_artifact("lifted" "abi-enforced-for-decompilation" ".bc"
                           "FILE")
 
-macro(artifact_handler CATEGORY INPUT_FILE CONFIGURATION OUTPUT TARGET_NAME)
-  if("${CATEGORY}" STREQUAL "tests_runtime"
-     AND NOT "${CONFIGURATION}" STREQUAL "static_native"
-     AND "${TARGET_NAME}" MATCHES "calc")
-    set(COMMAND_TO_RUN
-        "./bin/revng"
-        llvm
-        pipeline
-        "${INPUT_FILE}"
-        "${OUTPUT}"
-        Lifted
-        EnforceABI
-        "root/*:CSVsPromoted")
-    set(DEPEND_ON revng-all-binaries)
-  endif()
-endmacro()
-register_derived_artifact("lifted" "abi-enforced-for-decompilation-torture"
-                          ".bc" "FILE")


### PR DESCRIPTION
Torture tests have become useless, since over time they have become bitwise identical to regular tests.

This commit removes them since they are now just a waste of time.