### PR TITLE
Move copy_to_build_and_install to Common.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,15 +178,6 @@ endif()
 
 set(VERSION 0.0.0)
 
-function(copy_to_build_and_install INSTALL_TYPE DESTINATION)
-  foreach(INPUT_FILE ${ARGN})
-    make_directory("${CMAKE_BINARY_DIR}/${DESTINATION}")
-    configure_file("${INPUT_FILE}" "${CMAKE_BINARY_DIR}/${DESTINATION}"
-                   COPYONLY)
-    install("${INSTALL_TYPE}" "${INPUT_FILE}" DESTINATION "${DESTINATION}")
-  endforeach()
-endfunction()
-
 #
 # Support files (share/revng)
 #

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -199,3 +199,12 @@ function(check_python_requirements)
     endif()
   endforeach()
 endfunction()
+
+function(copy_to_build_and_install INSTALL_TYPE DESTINATION)
+  foreach(INPUT_FILE ${ARGN})
+    make_directory("${CMAKE_BINARY_DIR}/${DESTINATION}")
+    configure_file("${INPUT_FILE}" "${CMAKE_BINARY_DIR}/${DESTINATION}"
+                   COPYONLY)
+    install("${INSTALL_TYPE}" "${INPUT_FILE}" DESTINATION "${DESTINATION}")
+  endforeach()
+endfunction()


### PR DESCRIPTION
This enables using this handy helper function also in revng-c.