### PR TITLE
RegisterLLVMPass.h: add missing include

### DIFF
--- a/include/revng/Pipeline/RegisterLLVMPass.h
+++ b/include/revng/Pipeline/RegisterLLVMPass.h
@@ -4,6 +4,7 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include "revng/Pipeline/Loader.h"
 #include "revng/Pipeline/Pipe.h"
 #include "revng/Pipeline/Registry.h"
 


### PR DESCRIPTION
Missing `#include "revng/Pipeline/Loader.h"` causes compilation error when calling `Loader.registerLLVMPass<LLVMPass>(Name);`.

This is a problem since whoever includes `RegisterLLVMPass.h` should include `Loader.h` **before** `RegisterLLVMPass.h` to compile without errors. This is subject to breakage if `Loader.h` ever changes name and `clang-format` starts reordering the include **after** `RegisterLLVMPass.h`.

This commit inlcudes `Loader.h` directly in `RegisterLLVMPass.h` to fix the root cause.