### PR TITLE
Fix: model diffs with upcastable pointers

### DIFF
--- a/include/revng/ADT/UpcastablePointer.h
+++ b/include/revng/ADT/UpcastablePointer.h
@@ -7,9 +7,11 @@
 #include <memory>
 #include <type_traits>
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 
 #include "revng/ADT/Concepts.h"
+#include "revng/ADT/KeyedObjectTraits.h"
 #include "revng/ADT/STLExtras.h"
 #include "revng/Support/Assert.h"
 
@@ -81,6 +83,28 @@ void upcast(P &Upcastable, const L &Callable) {
     return true;
   };
   upcast(Upcastable, Wrapper, false);
+}
+
+template<UpcastablePointerLike P, typename KeyT, typename L>
+void invokeFromKey(const KeyT &Key, const L &Callable) {
+  auto Upcastable = KeyedObjectTraits<P>::fromKey(Key);
+
+  upcast(Upcastable, [&Callable]<typename UpcastedT>(const UpcastedT &C) {
+    Callable(static_cast<UpcastedT *>(nullptr));
+  });
+}
+
+template<UpcastablePointerLike P, typename KeyT, typename L, typename ReturnT>
+ReturnT
+invokeFromKey(const KeyT &Key, const L &Callable, const ReturnT &IfNull) {
+  auto Upcastable = KeyedObjectTraits<P>::fromKey(Key);
+
+  return upcast(
+    Upcastable,
+    [&Callable]<typename UpcastedT>(const UpcastedT &C) {
+      return Callable(static_cast<UpcastedT *>(nullptr));
+    },
+    IfNull);
 }
 
 /// A unique_ptr copiable thanks to LLVM RTTI

--- a/tests/unit/Model.cpp
+++ b/tests/unit/Model.cpp
@@ -283,7 +283,6 @@ BOOST_AUTO_TEST_CASE(TestTupleTreeDiffDeserialization) {
   llvm::raw_string_ostream Stream(S);
   serialize(Stream, Diff);
   Stream.flush();
-  llvm::errs() << S;
 
   auto Diff2 = llvm::cantFail(deserialize<TupleTreeDiff<model::Binary>>(S));
 
@@ -293,6 +292,21 @@ BOOST_AUTO_TEST_CASE(TestTupleTreeDiffDeserialization) {
   Stream2.flush();
 
   BOOST_TEST(S == S2);
+}
+
+BOOST_AUTO_TEST_CASE(CABIFunctionTypeArgumentsPathShouldParse) {
+  auto MaybeParsed = stringAsPath<model::Binary>("/Types/"
+                                                 "CABIFunctionType-"
+                                                 "639541743756555135/"
+                                                 "Arguments");
+  BOOST_TEST(MaybeParsed.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(CABIFunctionTypePathShouldParse) {
+  auto MaybeParsed = stringAsPath<model::Binary>("/Types/"
+                                                 "CABIFunctionType-"
+                                                 "639541743756555135");
+  BOOST_TEST(MaybeParsed.has_value());
 }
 
 static_assert(std::is_default_constructible_v<TupleTree<TestTupleTree::Root>>);


### PR DESCRIPTION
Model diffs that contained a upcastable pointer were broken.

When parsing a path, fields on upcasted classes would be ignored, even thought the key of the accessed object did contained all information needed to access the correct class.  