### PR TITLE
Add map-like methods to `StringMapContainer` for usability

### DIFF
--- a/include/revng/Pipes/StringMapContainer.h
+++ b/include/revng/Pipes/StringMapContainer.h
@@ -13,7 +13,14 @@
 namespace revng::pipes {
 
 class StringMapContainer : public pipeline::Container<StringMapContainer> {
-  std::map<MetaAddress, std::string> Map;
+public:
+  using MapType = std::map<MetaAddress, std::string>;
+  using ValueType = MapType::value_type;
+  using Iterator = MapType::iterator;
+  using ConstIterator = MapType::const_iterator;
+
+private:
+  MapType Map;
   const pipeline::Kind *TheKind;
 
 public:
@@ -51,6 +58,36 @@ public:
 
 protected:
   void mergeBackImpl(StringMapContainer &&Container) override;
+
+public:
+  /// std::map-like methods
+
+  std::string &operator[](MetaAddress M) { return Map[M]; };
+
+  std::string &at(MetaAddress M) { return Map.at(M); };
+  const std::string &at(MetaAddress M) const { return Map.at(M); };
+
+  std::pair<Iterator, bool> insert(const ValueType &V) {
+    return Map.insert(V);
+  };
+  std::pair<Iterator, bool> insert(ValueType &&V) {
+    return Map.insert(std::move(V));
+  };
+
+  std::pair<Iterator, bool>
+  insert_or_assign(MetaAddress Key, const std::string &Value) {
+    return Map.insert_or_assign(Key, Value);
+  };
+  std::pair<Iterator, bool>
+  insert_or_assign(MetaAddress Key, std::string &&Value) {
+    return Map.insert_or_assign(Key, std::move(Value));
+  };
+
+  Iterator begin() { return Map.begin(); }
+  Iterator end() { return Map.end(); }
+
+  ConstIterator begin() const { return Map.begin(); }
+  ConstIterator end() const { return Map.end(); }
 
 }; // end class StringMapContainer
 

--- a/include/revng/Pipes/StringMapContainer.h
+++ b/include/revng/Pipes/StringMapContainer.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "revng/Pipeline/Container.h"
+#include "revng/Pipeline/ContainerSet.h"
 #include "revng/Support/MetaAddress.h"
 
 namespace revng::pipes {
@@ -52,5 +53,12 @@ protected:
   void mergeBackImpl(StringMapContainer &&Container) override;
 
 }; // end class StringMapContainer
+
+inline pipeline::ContainerFactory
+makeStringMapContainerFactory(pipeline::Kind &K, llvm::StringRef MIMEType) {
+  return [&K, MIMEType](llvm::StringRef Name) {
+    return std::make_unique<StringMapContainer>(Name, MIMEType, K);
+  };
+}
 
 } // end namespace revng::pipes

--- a/lib/Pipes/StringMapContainer.cpp
+++ b/lib/Pipes/StringMapContainer.cpp
@@ -25,7 +25,7 @@ StringMapContainer::cloneFiltered(const TargetsList &Targets) const {
   // Returns true if Targets contains a Target that matches the Entry in the Map
   const auto EntryIsInTargets = [&](const auto &Entry) {
     const auto &KeyMetaAddress = Entry.first;
-    pipeline::Target EntryTarget{KeyMetaAddress.toString(), *TheKind };
+    pipeline::Target EntryTarget{ KeyMetaAddress.toString(), *TheKind };
     return Targets.contains(EntryTarget);
   };
 
@@ -56,7 +56,14 @@ bool StringMapContainer::remove(const TargetsList &Targets) {
 
   auto End = Map.end();
   for (const Target &T : Targets) {
-    revng_assert(T.getPathComponents().size() == 1);
+    revng_assert(&T.getKind() == TheKind);
+
+    // if a target to remove is *, drop everything
+    if (T.getPathComponents().back().isAll()) {
+      clear();
+      return true;
+    }
+
     std::string MetaAddrStr = T.getPathComponents().back().getName();
     auto It = Map.find(MetaAddress::fromString(MetaAddrStr));
     if (It != End) {


### PR DESCRIPTION
Before this MR, the functionality of `StringMapContainer` was cut-down to the minimum to get the code to compiler, but provided no real API to use the container as a map.

This MR fixes this problem and
- fixes a problem with the `remove` method when the targets were `isAll()`
- provides a factory for the container