### PR TITLE
Improve `StringMapContainer` to make it more `revng-pipeline` friendly

### DIFF
--- a/include/revng/Model/QualifiedType.h
+++ b/include/revng/Model/QualifiedType.h
@@ -9,6 +9,7 @@
 #include "revng/ADT/RecursiveCoroutine.h"
 #include "revng/Model/PrimitiveTypeKind.h"
 #include "revng/Model/Qualifier.h"
+#include "revng/Model/TypeKind.h"
 #include "revng/Model/VerifyHelper.h"
 
 /* TUPLE-TREE-YAML

--- a/include/revng/Model/Type.h
+++ b/include/revng/Model/Type.h
@@ -14,6 +14,7 @@
 #include "revng/Model/Identifier.h"
 #include "revng/Model/QualifiedType.h"
 #include "revng/Model/Register.h"
+#include "revng/Model/TypeKind.h"
 #include "revng/Support/Assert.h"
 #include "revng/Support/Debug.h"
 #include "revng/Support/YAMLTraits.h"

--- a/include/revng/Model/TypeKind.h
+++ b/include/revng/Model/TypeKind.h
@@ -1,0 +1,8 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/Model/Generated/Early/TypeKind.h"
+#include "revng/Model/Generated/Late/TypeKind.h"

--- a/include/revng/Pipeline/ContainerSet.h
+++ b/include/revng/Pipeline/ContainerSet.h
@@ -172,7 +172,7 @@ public:
     }
   }
 
-  void dump() const { dump(dbg); }
+  void dump() const debug_function { dump(dbg); }
 };
 
 } // namespace pipeline

--- a/include/revng/Pipeline/Pipe.h
+++ b/include/revng/Pipeline/Pipe.h
@@ -299,7 +299,7 @@ public:
     Pipe->dump(OS, Indentation + 1);
   }
 
-  void dump() const { dump(dbg); }
+  void dump() const debug_function { dump(dbg); }
 
 private:
   template<typename PipeType>

--- a/include/revng/Pipes/AllFunctions.h
+++ b/include/revng/Pipes/AllFunctions.h
@@ -1,0 +1,18 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/Model/Binary.h"
+#include "revng/Pipeline/Kind.h"
+#include "revng/Pipeline/Target.h"
+
+namespace revng::pipes {
+
+pipeline::TargetsList
+compactFunctionTargets(const model::Binary &Model,
+                       pipeline::TargetsList::List &Targets,
+                       const pipeline::Kind &K);
+
+} // end namespace revng::pipes

--- a/include/revng/Pipes/FunctionStringMap.h
+++ b/include/revng/Pipes/FunctionStringMap.h
@@ -16,7 +16,7 @@
 
 namespace revng::pipes {
 
-class StringMapContainer : public pipeline::Container<StringMapContainer> {
+class FunctionStringMap : public pipeline::Container<FunctionStringMap> {
 public:
   /// Wrapper for std::string that allows YAML-serialization as multiline string
   struct String {
@@ -39,24 +39,24 @@ public:
   static char ID;
 
 public:
-  StringMapContainer(llvm::StringRef Name,
-                     llvm::StringRef MIMEType,
-                     const pipeline::Kind &K,
-                     const model::Binary &Model) :
-    pipeline::Container<StringMapContainer>(Name, MIMEType),
+  FunctionStringMap(llvm::StringRef Name,
+                    llvm::StringRef MIMEType,
+                    const pipeline::Kind &K,
+                    const model::Binary &Model) :
+    pipeline::Container<FunctionStringMap>(Name, MIMEType),
     Map(),
     TheKind(&K),
     Model(&Model) {
     revng_assert(&K.rank() == &FunctionsRank);
   }
 
-  StringMapContainer(const StringMapContainer &) = default;
-  StringMapContainer &operator=(const StringMapContainer &) = default;
+  FunctionStringMap(const FunctionStringMap &) = default;
+  FunctionStringMap &operator=(const FunctionStringMap &) = default;
 
-  StringMapContainer(StringMapContainer &&) = default;
-  StringMapContainer &operator=(StringMapContainer &&) = default;
+  FunctionStringMap(FunctionStringMap &&) = default;
+  FunctionStringMap &operator=(FunctionStringMap &&) = default;
 
-  ~StringMapContainer() override = default;
+  ~FunctionStringMap() override = default;
 
 public:
   void clear() override { Map.clear(); }
@@ -73,7 +73,7 @@ public:
   llvm::Error deserialize(const llvm::MemoryBuffer &Buffer) override;
 
 protected:
-  void mergeBackImpl(StringMapContainer &&Container) override;
+  void mergeBackImpl(FunctionStringMap &&Container) override;
 
 public:
   /// std::map-like methods
@@ -110,31 +110,31 @@ public:
   ConstIterator begin() const { return Map.begin(); }
   ConstIterator end() const { return Map.end(); }
 
-}; // end class StringMapContainer
+}; // end class FunctionStringMap
 
-class RegisterStringMapContainer : public pipeline::Registry {
+class RegisterFunctionStringMap : public pipeline::Registry {
 private:
   llvm::StringRef Name;
   llvm::StringRef MIMEType;
   const pipeline::Kind &K;
 
 public:
-  RegisterStringMapContainer(llvm::StringRef Name,
-                             llvm::StringRef MIMEType,
-                             const pipeline::Kind &K) :
+  RegisterFunctionStringMap(llvm::StringRef Name,
+                            llvm::StringRef MIMEType,
+                            const pipeline::Kind &K) :
     Name(Name), MIMEType(MIMEType), K(K) {}
 
 public:
-  virtual ~RegisterStringMapContainer() override = default;
+  virtual ~RegisterFunctionStringMap() override = default;
 
 public:
   void registerContainersAndPipes(pipeline::Loader &Loader) override {
     const model::Binary &Model = *getModelFromContext(Loader.getContext());
     auto Factory = [&Model, this](llvm::StringRef ContainerName) {
-      return std::make_unique<StringMapContainer>(ContainerName,
-                                                  MIMEType,
-                                                  K,
-                                                  Model);
+      return std::make_unique<FunctionStringMap>(ContainerName,
+                                                 MIMEType,
+                                                 K,
+                                                 Model);
     };
     Loader.addContainerFactory(Name, Factory);
   }

--- a/include/revng/Pipes/ModelGlobal.h
+++ b/include/revng/Pipes/ModelGlobal.h
@@ -28,7 +28,12 @@ private:
 public:
   constexpr static const char *Name = "model.yml";
   static const char ID;
-  void clear() final { Model = TupleTree<model::Binary>(); }
+  void clear() final {
+    // Reset the model by copying that, so that references to the underlying
+    // model::Binary are stable across calls to clear();
+    TupleTree<model::Binary> New{};
+    Model = New;
+  }
   llvm::Error serialize(llvm::raw_ostream &OS) const final;
   llvm::Error deserialize(const llvm::MemoryBuffer &Buffer) final;
 

--- a/include/revng/Pipes/StringMapContainer.h
+++ b/include/revng/Pipes/StringMapContainer.h
@@ -83,6 +83,11 @@ public:
     return Map.insert_or_assign(Key, std::move(Value));
   };
 
+  bool contains(MetaAddress Key) const { return Map.contains(Key); }
+
+  Iterator find(MetaAddress Key) { return Map.find(Key); }
+  ConstIterator find(MetaAddress Key) const { return Map.find(Key); }
+
   Iterator begin() { return Map.begin(); }
   Iterator end() { return Map.end(); }
 

--- a/include/revng/Pipes/StringMapContainer.h
+++ b/include/revng/Pipes/StringMapContainer.h
@@ -14,7 +14,14 @@ namespace revng::pipes {
 
 class StringMapContainer : public pipeline::Container<StringMapContainer> {
 public:
-  using MapType = std::map<MetaAddress, std::string>;
+  /// Wrapper for std::string that allows YAML-serialization as multiline string
+  struct String {
+    std::string TheString;
+    operator std::string() const { return TheString; }
+  };
+
+public:
+  using MapType = std::map<MetaAddress, String>;
   using ValueType = MapType::value_type;
   using Iterator = MapType::iterator;
   using ConstIterator = MapType::const_iterator;
@@ -62,10 +69,10 @@ protected:
 public:
   /// std::map-like methods
 
-  std::string &operator[](MetaAddress M) { return Map[M]; };
+  std::string &operator[](MetaAddress M) { return Map[M].TheString; };
 
-  std::string &at(MetaAddress M) { return Map.at(M); };
-  const std::string &at(MetaAddress M) const { return Map.at(M); };
+  std::string &at(MetaAddress M) { return Map.at(M).TheString; };
+  const std::string &at(MetaAddress M) const { return Map.at(M).TheString; };
 
   std::pair<Iterator, bool> insert(const ValueType &V) {
     return Map.insert(V);
@@ -76,11 +83,11 @@ public:
 
   std::pair<Iterator, bool>
   insert_or_assign(MetaAddress Key, const std::string &Value) {
-    return Map.insert_or_assign(Key, Value);
+    return Map.insert_or_assign(Key, String{ Value });
   };
   std::pair<Iterator, bool>
   insert_or_assign(MetaAddress Key, std::string &&Value) {
-    return Map.insert_or_assign(Key, std::move(Value));
+    return Map.insert_or_assign(Key, String{ std::move(Value) });
   };
 
   bool contains(MetaAddress Key) const { return Map.contains(Key); }

--- a/include/revng/Pipes/TaggedFunctionKind.h
+++ b/include/revng/Pipes/TaggedFunctionKind.h
@@ -7,6 +7,8 @@
 #include "llvm/ADT/StringRef.h"
 
 #include "revng/Pipeline/LLVMContainer.h"
+#include "revng/Pipes/AllFunctions.h"
+#include "revng/Pipes/ModelGlobal.h"
 #include "revng/Support/FunctionTags.h"
 
 namespace revng::pipes {
@@ -32,7 +34,9 @@ public:
 
   pipeline::TargetsList
   compactTargets(const pipeline::Context &Ctx,
-                 pipeline::TargetsList::List &Targets) const final;
+                 pipeline::TargetsList::List &Targets) const final {
+    return compactFunctionTargets(*getModelFromContext(Ctx), Targets, *this);
+  }
 
   void expandTarget(const pipeline::Context &Ctx,
                     const pipeline::Target &Input,

--- a/include/revng/Pipes/Yield/Assembly.h
+++ b/include/revng/Pipes/Yield/Assembly.h
@@ -12,7 +12,7 @@
 #include "revng/Pipeline/Contract.h"
 #include "revng/Pipeline/Target.h"
 #include "revng/Pipes/FileContainer.h"
-#include "revng/Pipes/StringMapContainer.h"
+#include "revng/Pipes/FunctionStringMap.h"
 
 namespace revng::pipes {
 
@@ -27,7 +27,7 @@ public:
   void run(pipeline::Context &Context,
            const FileContainer &SourceBinary,
            const pipeline::LLVMContainer &TargetsList,
-           StringMapContainer &OutputAssembly);
+           FunctionStringMap &OutputAssembly);
 
   void print(const pipeline::Context &Ctx,
              llvm::raw_ostream &OS,

--- a/include/revng/TupleTree/TupleTree.h
+++ b/include/revng/TupleTree/TupleTree.h
@@ -37,26 +37,19 @@ private:
 public:
   TupleTree() : Root(new T) {}
 
-  // Prevent accidental copy
-  TupleTree(const TupleTree &Other) = delete;
-  TupleTree &operator=(const TupleTree &Other) = delete;
+  // Allow expensive copy
+  TupleTree(const TupleTree &Other) { *this = Other; }
+  TupleTree &operator=(const TupleTree &Other) {
+    if (this != &Other) {
+      *Root = *Other.Root;
+      initializeReferences();
+    }
+    return *this;
+  }
 
   // Moving is fine
   TupleTree(TupleTree &&Other) = default;
   TupleTree &operator=(TupleTree &&Other) = default;
-
-  // Explicit cloning
-  TupleTree clone() const {
-    TupleTree Result;
-
-    // Copy the root
-    Result.Root.reset(new T(*Root));
-
-    // Update references to root
-    Result.initializeReferences();
-
-    return Result;
-  }
 
   template<IsTupleTreeReference TTR>
   void replaceReferences(const std::map<TTR, TTR> &Map) {

--- a/lib/Pipes/AllFunctions.cpp
+++ b/lib/Pipes/AllFunctions.cpp
@@ -1,0 +1,51 @@
+/// \file AllFunctions.cpp
+/// \brief
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/Model/Binary.h"
+#include "revng/Model/Function.h"
+#include "revng/Pipes/AllFunctions.h"
+
+namespace revng::pipes {
+
+pipeline::TargetsList
+compactFunctionTargets(const model::Binary &Model,
+                       pipeline::TargetsList::List &Targets,
+                       const pipeline::Kind &K) {
+
+  if (Model.Functions.size() == 0)
+    return Targets;
+
+  std::set<std::string> TargetsSet;
+  const pipeline::Target AllFunctions({ pipeline::PathComponent::all() }, K);
+
+  // enumerate the targets
+  for (const pipeline::Target &Target : Targets) {
+    // if we see a * then no need to check if we have all functions, just
+    // return that.
+    if (Target.getPathComponents().back().isAll())
+      return pipeline::TargetsList({ AllFunctions });
+
+    TargetsSet.insert(Target.getPathComponents().back().getName());
+  }
+
+  // check if all functions in the model, that are not fake, are in the targets.
+  // if they are, return *
+  const auto IsNotFake = [](const auto &F) {
+    return F.Type != model::FunctionType::Fake;
+  };
+  const auto IsInTargetSet = [&TargetsSet](const model::Function &F) {
+    return TargetsSet.contains(F.Entry.toString());
+  };
+  if (llvm::all_of(llvm::make_filter_range(Model.Functions, IsNotFake),
+                   IsInTargetSet)) {
+    return pipeline::TargetsList({ AllFunctions });
+  }
+
+  return Targets;
+}
+
+} // end namespace revng::pipes

--- a/lib/Pipes/CMakeLists.txt
+++ b/lib/Pipes/CMakeLists.txt
@@ -8,6 +8,7 @@ revng_add_library_internal(
   AddPrimitiveTypesPipe.cpp
   CompileModulePipe.cpp
   FileContainer.cpp
+  FunctionStringMap.cpp
   ImportBinaryPipe.cpp
   LiftPipe.cpp
   LinkSupportPipe.cpp
@@ -17,7 +18,6 @@ revng_add_library_internal(
   PipelineManager.cpp
   Pipes.cpp
   RootKind.cpp
-  StringMapContainer.cpp
   TaggedFunctionKind.cpp
   Yield/Assembly.cpp)
 

--- a/lib/Pipes/CMakeLists.txt
+++ b/lib/Pipes/CMakeLists.txt
@@ -6,6 +6,7 @@ revng_add_library_internal(
   revngPipes
   SHARED
   AddPrimitiveTypesPipe.cpp
+  AllFunctions.cpp
   CompileModulePipe.cpp
   FileContainer.cpp
   FunctionStringMap.cpp

--- a/lib/Pipes/FunctionStringMap.cpp
+++ b/lib/Pipes/FunctionStringMap.cpp
@@ -1,3 +1,6 @@
+/// \file FunctionStringMap.cpp
+/// \brief
+
 //
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
@@ -10,7 +13,8 @@
 #include "revng/Model/Function.h"
 #include "revng/Model/Type.h"
 #include "revng/Pipeline/Target.h"
-#include "revng/Pipes/StringMapContainer.h"
+#include "revng/Pipes/FunctionStringMap.h"
+#include "revng/Pipes/ModelGlobal.h"
 #include "revng/Support/MetaAddress/YAMLTraits.h"
 #include "revng/Support/YAMLTraits.h"
 
@@ -18,11 +22,11 @@ using namespace pipeline;
 
 namespace revng::pipes {
 
-char StringMapContainer::ID = 0;
+char FunctionStringMap::ID = 0;
 
 std::unique_ptr<ContainerBase>
-StringMapContainer::cloneFiltered(const TargetsList &Targets) const {
-  auto Clone = std::make_unique<StringMapContainer>(*this);
+FunctionStringMap::cloneFiltered(const TargetsList &Targets) const {
+  auto Clone = std::make_unique<FunctionStringMap>(*this);
 
   // Returns true if Targets contains a Target that matches the Entry in the Map
   const auto EntryIsInTargets = [&](const auto &Entry) {
@@ -37,7 +41,7 @@ StringMapContainer::cloneFiltered(const TargetsList &Targets) const {
   return Clone;
 }
 
-void StringMapContainer::mergeBackImpl(StringMapContainer &&Other) {
+void FunctionStringMap::mergeBackImpl(FunctionStringMap &&Other) {
   // Stuff in Other should overwrite what's in this container.
   // We first merge this->Map into Other.Map (which keeps Other's version if
   // present), and then we replace this->Map with the newly merged version of
@@ -46,7 +50,7 @@ void StringMapContainer::mergeBackImpl(StringMapContainer &&Other) {
   this->Map = std::move(Other.Map);
 }
 
-TargetsList StringMapContainer::enumerate() const {
+TargetsList FunctionStringMap::enumerate() const {
   TargetsList Result;
 
   for (const auto &[MetaAddress, Mapped] : Map)
@@ -68,7 +72,7 @@ TargetsList StringMapContainer::enumerate() const {
   return Result;
 }
 
-bool StringMapContainer::remove(const TargetsList &Targets) {
+bool FunctionStringMap::remove(const TargetsList &Targets) {
   bool Changed = false;
 
   auto End = Map.end();
@@ -97,7 +101,7 @@ bool StringMapContainer::remove(const TargetsList &Targets) {
 namespace llvm {
 namespace yaml {
 
-using StringType = revng::pipes::StringMapContainer::String;
+using StringType = revng::pipes::FunctionStringMap::String;
 
 template<>
 struct BlockScalarTraits<StringType> {
@@ -131,13 +135,13 @@ struct CustomMappingTraits<std::map<MetaAddress, StringType>> {
 
 namespace revng::pipes {
 
-llvm::Error StringMapContainer::serialize(llvm::raw_ostream &OS) const {
+llvm::Error FunctionStringMap::serialize(llvm::raw_ostream &OS) const {
   llvm::yaml::Output YAMLOutput(OS);
   YAMLOutput << const_cast<std::map<MetaAddress, String> &>(Map);
   return llvm::Error::success();
 }
 
-llvm::Error StringMapContainer::deserialize(const llvm::MemoryBuffer &Buffer) {
+llvm::Error FunctionStringMap::deserialize(const llvm::MemoryBuffer &Buffer) {
 
   llvm::yaml::Input YAMLInput(Buffer);
   YAMLInput >> Map;

--- a/lib/Pipes/FunctionStringMap.cpp
+++ b/lib/Pipes/FunctionStringMap.cpp
@@ -119,8 +119,7 @@ struct CustomMappingTraits<std::map<MetaAddress, StringType>> {
 namespace revng::pipes {
 
 llvm::Error FunctionStringMap::serialize(llvm::raw_ostream &OS) const {
-  llvm::yaml::Output YAMLOutput(OS);
-  YAMLOutput << const_cast<std::map<MetaAddress, String> &>(Map);
+  ::serialize(OS, Map);
   return llvm::Error::success();
 }
 

--- a/lib/Pipes/ModelGlobal.cpp
+++ b/lib/Pipes/ModelGlobal.cpp
@@ -28,7 +28,7 @@ llvm::Error ModelGlobal::deserialize(const llvm::MemoryBuffer &Buffer) {
       !MaybeBin)
     return llvm::errorCodeToError(MaybeBin.getError());
   else
-    Model = std::move(*MaybeBin);
+    Model = *MaybeBin;
 
   return llvm::Error::success();
 }

--- a/lib/Pipes/TaggedFunctionKind.cpp
+++ b/lib/Pipes/TaggedFunctionKind.cpp
@@ -28,46 +28,6 @@ using namespace pipeline;
 using namespace ::revng::pipes;
 using namespace llvm;
 
-pipeline::TargetsList
-TaggedFunctionKind::compactTargets(const pipeline::Context &Ctx,
-                                   pipeline::TargetsList::List &Targets) const {
-
-  const model::Binary &Model = *getModelFromContext(Ctx);
-
-  if (Model.Functions.size() == 0) {
-    return Targets;
-  }
-
-  std::set<std::string> TargetsSet;
-  const pipeline::Target AllFunctions({ pipeline::PathComponent::all() },
-                                      *this);
-
-  // enumerate the targets
-  for (const pipeline::Target &Target : Targets) {
-    // if we see a * then no need to check if we have all functions, just
-    // return that.
-    if (Target.getPathComponents().back().isAll())
-      return pipeline::TargetsList({ AllFunctions });
-
-    TargetsSet.insert(Target.getPathComponents().back().getName());
-  }
-
-  // check if all functions in the model, that are not fake, are in the targets.
-  // if they are, return *
-  const auto IsNotFake = [](const auto &F) {
-    return F.Type != model::FunctionType::Fake;
-  };
-  const auto IsInTargetSet = [&TargetsSet](const model::Function &F) {
-    return TargetsSet.contains(F.Entry.toString());
-  };
-  if (llvm::all_of(llvm::make_filter_range(Model.Functions, IsNotFake),
-                   IsInTargetSet)) {
-    return pipeline::TargetsList({ AllFunctions });
-  }
-
-  return Targets;
-}
-
 void TaggedFunctionKind::expandTarget(const Context &Ctx,
                                       const Target &Input,
                                       TargetsList &Output) const {

--- a/lib/Pipes/Yield/Assembly.cpp
+++ b/lib/Pipes/Yield/Assembly.cpp
@@ -20,7 +20,7 @@ namespace revng::pipes {
 void YieldAssemblyPipe::run(pipeline::Context &Context,
                             const FileContainer &SourceBinary,
                             const pipeline::LLVMContainer &TargetList,
-                            StringMapContainer &Output) {
+                            FunctionStringMap &Output) {
   // Access the model
   const auto &Model = revng::pipes::getModelFromContext(Context);
 
@@ -77,8 +77,8 @@ std::array<pipeline::ContractGroup, 1> YieldAssemblyPipe::getContract() const {
 } // end namespace revng::pipes
 
 using revng::pipes::FunctionAssemblyHTML;
-using revng::pipes::StringMapContainer;
-static revng::pipes::RegisterStringMapContainer
+using revng::pipes::FunctionStringMap;
+static revng::pipes::RegisterFunctionStringMap
   AssemblyContainer("FunctionAssemblyHTML",
                     "application/"
                     "x.yaml.function-assembly"

--- a/lib/Pipes/Yield/Assembly.cpp
+++ b/lib/Pipes/Yield/Assembly.cpp
@@ -7,7 +7,6 @@
 #include "revng/Lift/LoadBinaryPass.h"
 #include "revng/Model/Binary.h"
 #include "revng/Pipeline/Pipe.h"
-#include "revng/Pipeline/RegisterContainerFactory.h"
 #include "revng/Pipeline/RegisterPipe.h"
 #include "revng/Pipes/Kinds.h"
 #include "revng/Pipes/ModelGlobal.h"
@@ -79,13 +78,11 @@ std::array<pipeline::ContractGroup, 1> YieldAssemblyPipe::getContract() const {
 
 using revng::pipes::FunctionAssemblyHTML;
 using revng::pipes::StringMapContainer;
-static pipeline::RegisterContainerFactory
-  AssemblyContainer("FunctionAssemblyHTML", [](llvm::StringRef Name) {
-    return std::make_unique<StringMapContainer>(Name,
-                                                "application/"
-                                                "x.yaml.function-assembly"
-                                                ".html-body",
-                                                FunctionAssemblyHTML);
-  });
+static revng::pipes::RegisterStringMapContainer
+  AssemblyContainer("FunctionAssemblyHTML",
+                    "application/"
+                    "x.yaml.function-assembly"
+                    ".html-body",
+                    FunctionAssemblyHTML);
 
 static pipeline::RegisterPipe<revng::pipes::YieldAssemblyPipe> AssemblyPipe;

--- a/tests/unit/Model.cpp
+++ b/tests/unit/Model.cpp
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(CABIFunctionTypeArgumentsPathShouldParse) {
 }
 
 static_assert(std::is_default_constructible_v<TupleTree<TestTupleTree::Root>>);
-static_assert(not std::is_copy_assignable_v<TupleTree<TestTupleTree::Root>>);
-static_assert(not std::is_copy_constructible_v<TupleTree<TestTupleTree::Root>>);
+static_assert(std::is_copy_assignable_v<TupleTree<TestTupleTree::Root>>);
+static_assert(std::is_copy_constructible_v<TupleTree<TestTupleTree::Root>>);
 static_assert(std::is_move_assignable_v<TupleTree<TestTupleTree::Root>>);
 static_assert(std::is_move_constructible_v<TupleTree<TestTupleTree::Root>>);

--- a/tools/yield/Common.cpp
+++ b/tools/yield/Common.cpp
@@ -45,9 +45,9 @@ static opt<std::string> ModelPath(llvm::cl::Positional,
 
 } // namespace options
 
-static revng::pipes::StringMapContainer createMap() {
+static revng::pipes::StringMapContainer createMap(const model::Binary &Model) {
   using C = revng::pipes::StringMapContainer;
-  return C("", "", pipeline::Kind{ "", &revng::pipes::RootRank });
+  return C("", "", pipeline::Kind{ "", &revng::pipes::RootRank }, Model);
 }
 
 ReturnValueType parseCommandLineOptions(int Argc, char *Argv[]) {
@@ -84,6 +84,6 @@ ReturnValueType parseCommandLineOptions(int Argc, char *Argv[]) {
   return ReturnValueType(*Result.IR,
                          **Result.Model,
                          BinView,
-                         createMap(),
+                         createMap(**Result.Model),
                          std::move(Result));
 }

--- a/tools/yield/Common.cpp
+++ b/tools/yield/Common.cpp
@@ -45,8 +45,8 @@ static opt<std::string> ModelPath(llvm::cl::Positional,
 
 } // namespace options
 
-static revng::pipes::StringMapContainer createMap(const model::Binary &Model) {
-  using C = revng::pipes::StringMapContainer;
+static revng::pipes::FunctionStringMap createMap(const model::Binary &Model) {
+  using C = revng::pipes::FunctionStringMap;
   return C("", "", pipeline::Kind{ "", &revng::pipes::RootRank }, Model);
 }
 

--- a/tools/yield/Common.h
+++ b/tools/yield/Common.h
@@ -7,7 +7,7 @@
 #include <memory>
 
 #include "revng/Lift/LoadBinaryPass.h"
-#include "revng/Pipes/StringMapContainer.h"
+#include "revng/Pipes/FunctionStringMap.h"
 #include "revng/TupleTree/TupleTree.h"
 
 namespace llvm {
@@ -30,6 +30,6 @@ struct ObjectLifetimeController {
 using ReturnValueType = std::tuple<const llvm::Module &,
                                    const model::Binary &,
                                    RawBinaryView,
-                                   revng::pipes::StringMapContainer,
+                                   revng::pipes::FunctionStringMap,
                                    ObjectLifetimeController>;
 ReturnValueType parseCommandLineOptions(int Argc, char *Argv[]);


### PR DESCRIPTION
This MR is blocking for porting `revng-c` to work with `revng-pipeline`