### PR TITLE
pipeline analysis failure support

### DIFF
--- a/include/revng/Pipeline/Analysis.h
+++ b/include/revng/Pipeline/Analysis.h
@@ -59,8 +59,8 @@ public:
     Invokable.print(Ctx, OS, Indentation);
   }
 
-  void run(Context &Ctx, ContainerSet &Containers) override {
-    Invokable.run(Ctx, Containers);
+  llvm::Error run(Context &Ctx, ContainerSet &Containers) override {
+    return Invokable.run(Ctx, Containers);
   }
 
   std::vector<std::string> getRunningContainersNames() const override {

--- a/include/revng/Pipeline/Pipe.h
+++ b/include/revng/Pipeline/Pipe.h
@@ -38,7 +38,7 @@ concept Pipe = Invokable<T, FirstRunArg, Args...> and HasContract<T>;
 
 template<typename C, typename First, typename... Rest>
 constexpr bool
-checkPipe(void (C::*)(First, Rest...)) requires Pipe<C, First, Rest...> {
+checkPipe(auto (C::*)(First, Rest...)) requires Pipe<C, First, Rest...> {
   return true;
 }
 
@@ -133,8 +133,8 @@ public:
     Invokable.print(Ctx, OS, Indentation);
   }
 
-  void run(Context &Ctx, ContainerSet &Containers) override {
-    Invokable.run(Ctx, Containers);
+  llvm::Error run(Context &Ctx, ContainerSet &Containers) override {
+    return Invokable.run(Ctx, Containers);
   }
 
   std::vector<std::string> getRunningContainersNames() const override {

--- a/include/revng/Pipeline/Step.h
+++ b/include/revng/Pipeline/Step.h
@@ -179,9 +179,9 @@ public:
   }
 
 public:
-  void runAnalysis(llvm::StringRef AnalysisName,
-                   Context &Ctx,
-                   const ContainerToTargetsMap &Targets);
+  llvm::Error runAnalysis(llvm::StringRef AnalysisName,
+                          Context &Ctx,
+                          const ContainerToTargetsMap &Targets);
 
   /// Clones the Targets from the backing containers of this step
   /// and excutes all the pipes in sequence contained by this step

--- a/include/revng/Pipes/ImportBinaryPipe.h
+++ b/include/revng/Pipes/ImportBinaryPipe.h
@@ -21,7 +21,8 @@ public:
   std::array<pipeline::ContractGroup, 1> getContract() const { return {}; }
 
 public:
-  void run(pipeline::Context &Context, const FileContainer &SourceBinary);
+  llvm::Error
+  run(pipeline::Context &Context, const FileContainer &SourceBinary);
 
   void print(const pipeline::Context &Ctx,
              llvm::raw_ostream &OS,

--- a/lib/Pipeline/Runner.cpp
+++ b/lib/Pipeline/Runner.cpp
@@ -254,7 +254,11 @@ Runner::runAnalysis(llvm::StringRef AnalysisName,
   if (auto Error = run(StepName, Targets))
     return std::move(Error);
 
-  MaybeStep->second.runAnalysis(AnalysisName, *TheContext, Targets);
+  if (auto Error = MaybeStep->second.runAnalysis(AnalysisName,
+                                                 *TheContext,
+                                                 Targets);
+      Error)
+    return std::move(Error);
 
   auto &After = getContext().getGlobals();
   auto Map = Before.diff(After);

--- a/lib/Pipeline/Step.cpp
+++ b/lib/Pipeline/Step.cpp
@@ -89,7 +89,7 @@ ContainerSet Step::cloneAndRun(Context &Ctx, ContainerSet &&Input) {
 
   for (auto &Pipe : Pipes) {
     explainExecutedPipe(Ctx, *Pipe);
-    Pipe->run(Ctx, Input);
+    cantFail(Pipe->run(Ctx, Input));
     llvm::cantFail(Input.verify());
   }
   explainEndStep(Input.enumerate());
@@ -98,9 +98,9 @@ ContainerSet Step::cloneAndRun(Context &Ctx, ContainerSet &&Input) {
   return Containers.cloneFiltered(InputEnumeration);
 }
 
-void Step::runAnalysis(llvm::StringRef AnalysisName,
-                       Context &Ctx,
-                       const ContainerToTargetsMap &Targets) {
+llvm::Error Step::runAnalysis(llvm::StringRef AnalysisName,
+                              Context &Ctx,
+                              const ContainerToTargetsMap &Targets) {
   auto Stream = ExplanationLogger.getAsLLVMStream();
   ContainerToTargetsMap Map = Containers.enumerate();
   revng_assert(Map.contains(Targets),
@@ -111,7 +111,7 @@ void Step::runAnalysis(llvm::StringRef AnalysisName,
   explainExecutedPipe(Ctx, *TheAnalysis);
 
   auto Cloned = Containers.cloneFiltered(Targets);
-  TheAnalysis->run(Ctx, Cloned);
+  return TheAnalysis->run(Ctx, Cloned);
 }
 
 void Step::removeSatisfiedGoals(TargetsList &RequiredInputs,


### PR DESCRIPTION
allow to return a llvm error from a analysis and have it propagate back all the way to main.