### PR TITLE
Fix pipeline drivers targetless invocation

### DIFF
--- a/tools/pipeline/analyze/Main.cpp
+++ b/tools/pipeline/analyze/Main.cpp
@@ -136,7 +136,7 @@ int main(int argc, const char *argv[]) {
       auto Index = Pair.index();
       const auto &ContainerName = Pair.value();
       for (const auto &Kind : Analysis->getAcceptedKinds(Index)) {
-        Map.add(ContainerName, Target(*Kind));
+        Map.add(ContainerName, Kind->allTargets(Manager.context()));
       }
     }
 

--- a/tools/pipeline/artifact/Main.cpp
+++ b/tools/pipeline/artifact/Main.cpp
@@ -119,7 +119,7 @@ int main(int argc, const char *argv[]) {
 
   ContainerToTargetsMap Map;
   if (Arguments.size() == 2) {
-    Map.add(ContainerName, Target(*Kind));
+    Map.add(ContainerName, Kind->allTargets(Manager.context()));
   } else {
     for (llvm::StringRef Argument : llvm::drop_begin(Arguments, 2)) {
       auto SlashRemoved = Argument.drop_front();


### PR DESCRIPTION
Analyze and artifact crashed when targets were not specified