### PR TITLE
Fix artifact emission crash

### DIFF
--- a/tools/pipeline/artifact/Main.cpp
+++ b/tools/pipeline/artifact/Main.cpp
@@ -134,7 +134,10 @@ int main(int argc, const char *argv[]) {
 
   AbortOnError(Manager.storeToDisk());
 
-  auto Produced = Container.second->cloneFiltered(Map.at(ContainerName));
+  const TargetsList &Targets = Map.contains(ContainerName) ?
+                                 Map.at(ContainerName) :
+                                 TargetsList();
+  auto Produced = Container.second->cloneFiltered(Targets);
   AbortOnError(Produced->storeToDisk(Output));
 
   if (not SaveModel.empty()) {


### PR DESCRIPTION
When artifact was requested to produce the functions of a binary that had 0 functions it crashed. This commit fixes it by checking if something has been actually being produced.