### PR TITLE
Refactor PTML C

### DIFF
--- a/include/revng/Model/QualifiedType.h
+++ b/include/revng/Model/QualifiedType.h
@@ -55,6 +55,8 @@ public:
   bool isArray() const;
   /// Checks if is a pointer type, unwrapping typedefs
   bool isPointer() const;
+  /// Checks if is a const type, unwrapping typedefs
+  bool isConst() const;
   /// Checks if is of a given TypeKind, unwrapping typedefs
   bool is(model::TypeKind::Values K) const;
 

--- a/include/revng/PTML/Tag.h
+++ b/include/revng/PTML/Tag.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/StringMap.h"
 
 #include "revng/ADT/Concepts.h"
+#include "revng/PTML/Constants.h"
 #include "revng/Support/Assert.h"
 #include "revng/Support/Debug.h"
 #include "revng/Support/YAMLTraits.h"
@@ -82,6 +83,11 @@ public:
 
   bool verify() const debug_function { return !TheTag.empty(); }
 };
+
+inline Tag scopeTag(const llvm::StringRef AttributeName) {
+  return Tag(ptml::tags::Div)
+    .addAttribute(ptml::attributes::Scope, AttributeName);
+}
 
 inline std::string operator+(const Tag &LHS, const llvm::StringRef RHS) {
   return LHS.serialize() + RHS.str();

--- a/include/revng/Support/IRHelpers.h
+++ b/include/revng/Support/IRHelpers.h
@@ -831,15 +831,25 @@ inline llvm::Function *getCallee(llvm::Instruction *I) {
     return nullptr;
 }
 
-inline bool isCallTo(const llvm::Instruction *I, llvm::StringRef Name) {
+inline bool isCallTo(const llvm::Value *I, llvm::StringRef Name) {
   revng_assert(I != nullptr);
-  const llvm::Function *Callee = getCallee(I);
+
+  auto *Call = llvm::dyn_cast<llvm::Instruction>(I);
+  if (not Call)
+    return false;
+
+  const llvm::Function *Callee = getCallee(Call);
   return Callee != nullptr && Callee->getName() == Name;
 }
 
-inline bool isCallTo(const llvm::Instruction *I, llvm::Function *F) {
+inline bool isCallTo(const llvm::Value *I, llvm::Function *F) {
   revng_assert(I != nullptr);
-  const llvm::Function *Callee = getCallee(I);
+
+  auto *Call = llvm::dyn_cast<llvm::Instruction>(I);
+  if (not Call)
+    return false;
+
+  const llvm::Function *Callee = getCallee(Call);
   return Callee != nullptr && Callee == F;
 }
 

--- a/include/revng/TupleTree/Visits.h
+++ b/include/revng/TupleTree/Visits.h
@@ -594,12 +594,12 @@ private:
 };
 
 template<UpcastablePointerLike P, typename L>
-void invokeBySerializedKey(llvm::StringRef SerializedKey, const L &Callable) {
+void invokeBySerializedKey(llvm::StringRef SerializedKey, L &&Callable) {
   using element_type = std::remove_reference_t<decltype(*std::declval<P>())>;
   using KOT = KeyedObjectTraits<element_type>;
   using KeyT = decltype(KOT::key(std::declval<element_type>()));
   auto Key = getValueFromYAMLScalar<KeyT>(SerializedKey);
-  invokeByKey<P, KeyT, L>(Key, Callable);
+  invokeByKey<P, KeyT, L>(Key, std::forward<L>(Callable));
 }
 
 template<UpcastablePointerLike T>


### PR DESCRIPTION
This PR contains a few preliminary changes that are necessary for a larger refactor of the PTML C generation, that happens later in revng-c decompilation pipeline.