### PR TITLE
Fix revng analysis crash

### DIFF
--- a/include/revng/Pipeline/Target.h
+++ b/include/revng/Pipeline/Target.h
@@ -224,6 +224,17 @@ public:
     return Contained.erase(std::forward<Args>(A)...);
   }
 
+  TargetsList intersect(const TargetsList &Other) const {
+    TargetsList ToReturn;
+    std::set_intersection(begin(),
+                          end(),
+                          Other.begin(),
+                          Other.end(),
+                          std::back_inserter(ToReturn.Contained));
+    llvm::sort(ToReturn.Contained);
+    return ToReturn;
+  }
+
 private:
   struct Comp {
     bool operator()(const Target &T, const Kind &K) const {

--- a/lib/Pipeline/Runner.cpp
+++ b/lib/Pipeline/Runner.cpp
@@ -384,7 +384,7 @@ const KindsRegistry &Runner::getKindsRegistry() const {
 
 void Runner::getDiffInvalidations(const GlobalTupleTreeDiff &Diff,
                                   InvalidationMap &Map) const {
-  for (const auto &Step : *this) {
+  for (const auto &Step : llvm::drop_begin(*this)) {
     auto &StepInvalidations = Map[Step.getName()];
     for (const auto &Cotainer : Step.containers()) {
       if (not Cotainer.second)
@@ -393,6 +393,8 @@ void Runner::getDiffInvalidations(const GlobalTupleTreeDiff &Diff,
       auto &ContainerInvalidations = StepInvalidations[Cotainer.first()];
       for (const Kind &Rule : getKindsRegistry())
         Rule.getInvalidations(getContext(), ContainerInvalidations, Diff);
+      auto Enumeration = Cotainer.second->enumerate();
+      ContainerInvalidations = ContainerInvalidations.intersect(Enumeration);
     }
   }
 }

--- a/lib/Pipes/PipelineManager.cpp
+++ b/lib/Pipes/PipelineManager.cpp
@@ -386,8 +386,10 @@ PipelineManager::runAnalysis(llvm::StringRef AnalysisName,
                                     Targets,
                                     Map,
                                     Options);
-  if (Result)
-    recalculateAllPossibleTargets();
+  if (not Result)
+    return Result.takeError();
+
+  recalculateAllPossibleTargets();
 
   // TODO: to remove once invalidations are working
   if (auto Invalidations = invalidateAllPossibleTargets(); !!Invalidations)
@@ -402,8 +404,10 @@ llvm::Expected<DiffMap>
 PipelineManager::runAllAnalyses(InvalidationMap &Map,
                                 const llvm::StringMap<std::string> &Options) {
   auto Result = Runner->runAllAnalyses(Map, Options);
-  if (Result)
-    recalculateAllPossibleTargets();
+  if (not Result)
+    return Result.takeError();
+
+  recalculateAllPossibleTargets();
 
   // TODO: to remove once invalidations are working
   if (auto Invalidations = invalidateAllPossibleTargets(); !!Invalidations)


### PR DESCRIPTION
Ensures that only content that is actually inside a container is elegible to be removed