### PR TITLE
Add opaque function to LLVM test helpers

### DIFF
--- a/include/revng/UnitTestHelpers/LLVMTestHelpers.h
+++ b/include/revng/UnitTestHelpers/LLVMTestHelpers.h
@@ -26,6 +26,8 @@ target triple = "x86_64-pc-linux-gnu"
 
 declare i64 @llvm.bswap.i64(i64)
 
+declare i64 @opaque(i64)
+
 define void @main() {
 initial_block:
 )LLVM";


### PR DESCRIPTION
This commits adds an opaque function that can be called by simple LLVM IR snippets used in unit tests.