### PR TITLE
revng-artifact: improve error message

### DIFF
--- a/tools/pipeline/artifact/Main.cpp
+++ b/tools/pipeline/artifact/Main.cpp
@@ -88,7 +88,9 @@ int main(int argc, char *argv[]) {
   InvalidationMap InvMap;
   for (auto &AnalysesListName : AnalysesLists) {
     if (!Manager.getRunner().hasAnalysesList(AnalysesListName)) {
-      return EXIT_FAILURE;
+      AbortOnError(createStringError(inconvertibleErrorCode(),
+                                     "Analysis `%s' not found",
+                                     AnalysesListName.c_str()));
     }
 
     AnalysesList AL = Manager.getRunner().getAnalysesList(AnalysesListName);


### PR DESCRIPTION
This commit improves the error message of the `revng-artifact` tool whenever it fails to find an analysis that is passed in with the `--analyses-list` flag.

Before this commit the tool was failing silently, now it reports the fact that is not able to find the analysis.