### PR TITLE
revng analyze: fix typo in argument description

### DIFF
--- a/tools/pipeline/analyze/Main.cpp
+++ b/tools/pipeline/analyze/Main.cpp
@@ -43,7 +43,7 @@ using namespace revng;
 
 static cl::list<string> Arguments(Positional,
                                   ZeroOrMore,
-                                  desc("<ArtifactToProduce> <InputBinary>"),
+                                  desc("<AnalysisToRun> <InputBinary>"),
                                   cat(MainCategory));
 
 static opt<string> Output("o",


### PR DESCRIPTION
`s/ArtifactToProduce/AnalysisToRun`

The misspelling on the argument description made the `--help` option very unhelpful in discovering the proper usage of the tool.