### PR TITLE
GraphAlgorithms: fix `nodesBetween` implementation

### DIFF
--- a/include/revng/ValueMaterializer/ControlFlowEdgesGraph.h
+++ b/include/revng/ValueMaterializer/ControlFlowEdgesGraph.h
@@ -39,7 +39,11 @@ public:
   ControlFlowEdgesGraph() = default;
 
 public:
-  Node *at(llvm::BasicBlock *BB) { return NodeMap[BB]; }
+  Node *at(llvm::BasicBlock *BB) {
+    auto It = NodeMap.find(BB);
+    revng_assert(It != NodeMap.end());
+    return It->second;
+  }
 
   const auto &interstingInstructions() const { return Interesting; }
 

--- a/tests/unit/GraphAlgorithms.cpp
+++ b/tests/unit/GraphAlgorithms.cpp
@@ -90,9 +90,105 @@ static NestedLoopGraph<NodeType> createNLGGraph() {
   return NLG;
 }
 
+template<typename NodeType>
+struct NonCanonicalLoopGraph {
+  using Node = NodeType;
+  GenericGraph<Node> Graph;
+  Node *LoopHeader;
+  Node *SecondLoopHeader;
+  Node *LoopLatch;
+  Node *LoopSuccessor;
+  Node *SecondLoopSuccessor;
+  Node *SecondLoopLatch;
+};
+
+template<typename NodeType>
+static NonCanonicalLoopGraph<NodeType> createNCLGGraph() {
+  NonCanonicalLoopGraph<NodeType> NCLG;
+  auto &Graph = NCLG.Graph;
+
+  // Create nodes
+  NCLG.LoopHeader = Graph.addNode(1);
+  NCLG.SecondLoopHeader = Graph.addNode(2);
+  NCLG.LoopLatch = Graph.addNode(3);
+  NCLG.LoopSuccessor = Graph.addNode(4);
+  NCLG.SecondLoopSuccessor = Graph.addNode(5);
+  NCLG.SecondLoopLatch = Graph.addNode(6);
+
+  // Create edges
+  NCLG.LoopHeader->addSuccessor(NCLG.SecondLoopHeader);
+  NCLG.SecondLoopHeader->addSuccessor(NCLG.LoopLatch);
+  NCLG.SecondLoopHeader->addSuccessor(NCLG.LoopSuccessor);
+  NCLG.LoopLatch->addSuccessor(NCLG.LoopSuccessor);
+  NCLG.LoopSuccessor->addSuccessor(NCLG.SecondLoopSuccessor);
+  NCLG.LoopSuccessor->addSuccessor(NCLG.SecondLoopLatch);
+  NCLG.SecondLoopSuccessor->addSuccessor(NCLG.SecondLoopLatch);
+  NCLG.LoopLatch->addSuccessor(NCLG.LoopHeader);
+  NCLG.SecondLoopLatch->addSuccessor(NCLG.SecondLoopHeader);
+  return NCLG;
+}
+
+template<typename NodeType>
+struct NonCanonicalAlternateLoopGraph {
+  using Node = NodeType;
+  GenericGraph<Node> Graph;
+  Node *LoopHeader;
+  Node *SecondLoopHeader;
+  Node *LoopLatch;
+  Node *LoopSuccessor;
+  Node *SecondLoopSuccessor;
+  Node *SecondLoopLatch;
+};
+
+template<typename NodeType>
+static NonCanonicalAlternateLoopGraph<NodeType> createNCALGGraph() {
+  NonCanonicalAlternateLoopGraph<NodeType> NCALG;
+  auto &Graph = NCALG.Graph;
+
+  // Create nodes
+  NCALG.LoopHeader = Graph.addNode(1);
+  NCALG.SecondLoopHeader = Graph.addNode(2);
+  NCALG.LoopLatch = Graph.addNode(3);
+  NCALG.SecondLoopLatch = Graph.addNode(4);
+
+  // Create edges
+  NCALG.LoopHeader->addSuccessor(NCALG.SecondLoopHeader);
+  NCALG.SecondLoopHeader->addSuccessor(NCALG.LoopLatch);
+  NCALG.LoopLatch->addSuccessor(NCALG.SecondLoopLatch);
+  NCALG.LoopLatch->addSuccessor(NCALG.LoopHeader);
+  NCALG.SecondLoopLatch->addSuccessor(NCALG.SecondLoopHeader);
+  return NCALG;
+}
+
+template<typename NodeType>
+struct ReverseGraph {
+  using Node = NodeType;
+  GenericGraph<Node> Graph;
+  Node *InitialBlock;
+  Node *SmallerBlock;
+  Node *EndBlock;
+};
+
+template<typename NodeType>
+static ReverseGraph<NodeType> createRGraph() {
+  ReverseGraph<NodeType> RG;
+  auto &Graph = RG.Graph;
+
+  // Create nodes
+  RG.InitialBlock = Graph.addNode(1);
+  RG.SmallerBlock = Graph.addNode(2);
+  RG.EndBlock = Graph.addNode(3);
+
+  // Create edges
+  RG.InitialBlock->addSuccessor(RG.SmallerBlock);
+  RG.InitialBlock->addSuccessor(RG.EndBlock);
+  RG.SmallerBlock->addSuccessor(RG.EndBlock);
+  return RG;
+}
+
 BOOST_AUTO_TEST_CASE(GetBackedgesTest) {
   // Create the graph
-  using NodeType = ForwardNode<MyForwardNode>;
+  using NodeType = BidirectionalNode<MyBidirectionalNode>;
   auto LG = createLGGraph<NodeType>();
   using EdgeDescriptor = revng::detail::EdgeDescriptor<NodeType *>;
   using EdgeSet = llvm::SmallSetVector<EdgeDescriptor, 4>;
@@ -149,8 +245,130 @@ BOOST_AUTO_TEST_CASE(NestedLoopTest) {
   revng_check(Loops.size() == 2);
   revng_check(Loops[0][0] == NLG.LoopLatch);
   revng_check(Loops[0][1] == NLG.SecondLoopHeader);
-  revng_check(Loops[1][0] == NLG.SecondLoopLatch);
-  revng_check(Loops[1][1] == NLG.LoopHeader);
-  revng_check(Loops[1][2] == NLG.SecondLoopHeader);
-  revng_check(Loops[1][3] == NLG.LoopLatch);
+  revng_check(Loops[1][0] == NLG.LoopLatch);
+  revng_check(Loops[1][1] == NLG.SecondLoopHeader);
+  revng_check(Loops[1][2] == NLG.SecondLoopLatch);
+  revng_check(Loops[1][3] == NLG.LoopHeader);
+}
+
+BOOST_AUTO_TEST_CASE(NonCanonicalLoopTest) {
+  // Create the graph
+  using NodeType = BidirectionalNode<MyBidirectionalNode>;
+  auto NCLG = createNCLGGraph<NodeType>();
+  using EdgeDescriptor = revng::detail::EdgeDescriptor<NodeType *>;
+  using EdgeSet = llvm::SmallSetVector<EdgeDescriptor, 4>;
+  using BlockSet = llvm::SmallSetVector<NodeType *, 4>;
+  using BlockSetVect = llvm::SmallVector<BlockSet>;
+
+  // Compute the backedges set
+  EdgeSet Backedges = getBackedges(NCLG.LoopHeader);
+  revng_check(Backedges.size() == 2);
+  revng_check(Backedges[0].first == NCLG.LoopLatch);
+  revng_check(Backedges[0].second == NCLG.LoopHeader);
+  revng_check(Backedges[1].first == NCLG.SecondLoopLatch);
+  revng_check(Backedges[1].second == NCLG.SecondLoopHeader);
+
+  // Obtain the nodes reachable from the identified backedges
+  BlockSetVect Loops;
+  for (EdgeDescriptor Backedge : Backedges) {
+    BlockSet LoopNodes = nodesBetween(Backedge.second, Backedge.first);
+    Loops.push_back(std::move(LoopNodes));
+  }
+
+  // We want to test that the nodes reachable from the extremities of a
+  // backedge, compose the whole body of the loop. In particular, we want to
+  // ensure that both `LoopSuccessor` and `SecondLoopSuccessor` are correctly
+  // included in the first loop.
+  revng_check(Loops.size() == 2);
+
+  revng_check(Loops[0][0] == NCLG.SecondLoopHeader);
+  revng_check(Loops[0][1] == NCLG.SecondLoopLatch);
+  revng_check(Loops[0][2] == NCLG.LoopSuccessor);
+  revng_check(Loops[0][3] == NCLG.SecondLoopSuccessor);
+  revng_check(Loops[0][4] == NCLG.LoopLatch);
+  revng_check(Loops[0][5] == NCLG.LoopHeader);
+
+  revng_check(Loops[1][0] == NCLG.LoopSuccessor);
+  revng_check(Loops[1][1] == NCLG.LoopLatch);
+  revng_check(Loops[1][2] == NCLG.SecondLoopSuccessor);
+  revng_check(Loops[1][3] == NCLG.SecondLoopLatch);
+  revng_check(Loops[1][4] == NCLG.SecondLoopHeader);
+}
+
+BOOST_AUTO_TEST_CASE(NonCanonicalAlternateLoopTest) {
+  // Create the graph
+  using NodeType = BidirectionalNode<MyBidirectionalNode>;
+  auto NCALG = createNCALGGraph<NodeType>();
+  using EdgeDescriptor = revng::detail::EdgeDescriptor<NodeType *>;
+  using EdgeSet = llvm::SmallSetVector<EdgeDescriptor, 4>;
+  using BlockSet = llvm::SmallSetVector<NodeType *, 4>;
+  using BlockSetVect = llvm::SmallVector<BlockSet>;
+
+  // Compute the backedges set
+  EdgeSet Backedges = getBackedges(NCALG.LoopHeader);
+  revng_check(Backedges.size() == 2);
+  revng_check(Backedges[0].first == NCALG.LoopLatch);
+  revng_check(Backedges[0].second == NCALG.LoopHeader);
+  revng_check(Backedges[1].first == NCALG.SecondLoopLatch);
+  revng_check(Backedges[1].second == NCALG.SecondLoopHeader);
+
+  // Obtain the nodes reachable from the identified backedges
+  BlockSetVect Loops;
+  for (EdgeDescriptor Backedge : Backedges) {
+    BlockSet LoopNodes = nodesBetween(Backedge.second, Backedge.first);
+    Loops.push_back(std::move(LoopNodes));
+  }
+
+  // We want to test that the nodes reachable from the extremities of a
+  // backedge, compose the whole body of the loop. The two loops are partially
+  // overlapping, but we don't want to trepass the head of the loop when
+  // invoking the `nodesBetween`.
+  revng_check(Loops.size() == 2);
+
+  revng_check(Loops[0][0] == NCALG.SecondLoopHeader);
+  revng_check(Loops[0][1] == NCALG.LoopLatch);
+  revng_check(Loops[0][2] == NCALG.LoopHeader);
+
+  revng_check(Loops[1][0] == NCALG.LoopLatch);
+  revng_check(Loops[1][1] == NCALG.SecondLoopLatch);
+  revng_check(Loops[1][2] == NCALG.SecondLoopHeader);
+}
+
+BOOST_AUTO_TEST_CASE(ReverseTest) {
+  // Create the graph
+  using NodeType = BidirectionalNode<MyBidirectionalNode>;
+  auto RG = createRGraph<NodeType>();
+  using EdgeDescriptor = revng::detail::EdgeDescriptor<NodeType *>;
+  using EdgeSet = llvm::SmallSetVector<EdgeDescriptor, 4>;
+  using BlockSet = llvm::SmallSetVector<NodeType *, 4>;
+
+  // Compute the backedges set
+  EdgeSet Backedges = getBackedges(RG.InitialBlock);
+  revng_check(Backedges.size() == 0);
+
+  // Test the reverse `nodesBetween`
+  BlockSet ReachableSet = nodesBetweenReverse(RG.SmallerBlock, RG.InitialBlock);
+  revng_check(ReachableSet.size() == 2);
+  revng_check(ReachableSet[0] == RG.InitialBlock);
+  revng_check(ReachableSet[1] == RG.SmallerBlock);
+}
+
+BOOST_AUTO_TEST_CASE(NullTargetTest) {
+  // Create the graph
+  using NodeType = BidirectionalNode<MyBidirectionalNode>;
+  auto RG = createRGraph<NodeType>();
+  using EdgeDescriptor = revng::detail::EdgeDescriptor<NodeType *>;
+  using EdgeSet = llvm::SmallSetVector<EdgeDescriptor, 4>;
+  using BlockSet = llvm::SmallSetVector<NodeType *, 4>;
+
+  // Compute the backedges set
+  EdgeSet Backedges = getBackedges(RG.InitialBlock);
+  revng_check(Backedges.size() == 0);
+
+  // Test the reverse `nodesBetween`
+  BlockSet ReachableSet = findReachableNodes(RG.InitialBlock);
+  revng_check(ReachableSet.size() == 3);
+  revng_check(ReachableSet[0] == RG.InitialBlock);
+  revng_check(ReachableSet[1] == RG.SmallerBlock);
+  revng_check(ReachableSet[2] == RG.EndBlock);
 }


### PR DESCRIPTION
During the DFS exploration performed in the `nodesBetweenImpl` implementation, when we encounter a node that has been already visited (and therefore inserted in `VisitStack`), we save all the nodes on the current exploration stack, so that later, during the post-processing of the identified reachable nodes, we are able to insert them as reachable nodes if the encountered already visited node, will eventually became part of the reachable nodes.

This widen the previous criterion, which perfomed this operation only for nodes that were on the exploration stack when encountered.

Unit test to check this new behavior have been added.