### PR TITLE
Fix: isolated functions targets overappresented

### DIFF
--- a/lib/Pipes/TaggedFunctionKind.cpp
+++ b/lib/Pipes/TaggedFunctionKind.cpp
@@ -31,7 +31,7 @@ using namespace llvm;
 
 std::optional<pipeline::Target>
 TaggedFunctionKind::symbolToTarget(const llvm::Function &Symbol) const {
-  if (not Tag->isTagOf(&Symbol) or Symbol.isDeclaration())
+  if (not Tag->isExactTagOf(&Symbol) or Symbol.isDeclaration())
     return std::nullopt;
 
   auto Address = getMetaAddressOfIsolatedFunction(Symbol);


### PR DESCRIPTION
Isolated functions no longer show up in the content of the pipeline multiple times equal to the number of tags.