### PR TITLE
Import sections into segment's struct

### DIFF
--- a/share/revng/test/tests/model/import/types/types.c.model.yml
+++ b/share/revng/test/tests/model/import/types/types.c.model.yml
@@ -4,7 +4,7 @@
 
 ---
 Segments:
-  - Type: "/Types/12084688553483582712-StructType"
+  - Type: "/Types/1815-StructType"
 Types:
   - Kind: PrimitiveType
     ID: 513
@@ -19,7 +19,16 @@ Types:
     PrimitiveKind: Generic
     Size: 8
   - Kind: StructType
-    ID: 12084688553483582712
+    ID: 1815
+    Size: 92
+    Fields:
+      - Offset: 0
+        CustomName: "unreserved__custom_data"
+        OriginalName: .custom_data
+        Type:
+          UnqualifiedType: "/Types/1816-StructType"
+  - Kind: StructType
+    ID: 1816
     Size: 92
     Fields:
       - Offset: 0


### PR DESCRIPTION
Each model::Segment is associated to a model::StructType. Now we also create sub-`structs` for sections, if available.