### PR TITLE
JumpTargetManager: improve `rebuildDispatcher`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(TUPLE_TREE_GENERATOR_EMIT_TRACKING_DEBUG OFF)
 
+# Uncomment the following line if errors like `Couldn't find method
+# SomeType::method` make debugging hard
+#
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-limit-debug-info")
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_flag_if_available("-Wno-unused-local-typedefs")
 endif()


### PR DESCRIPTION
Improve the way in which we connect the non reachable `JumpTargets` when rebuilding the dispatcher for non `SemanticsPreserving` `CFGForm`s.

When connecting group of jump targets that are currently not reachable from the entry dispatcher, we elect the jump target with the lowest program counter value, as the one to be connected to the dispatcher. We also mark the jump targets now transitively reachable from the elected one, as reachables, in order to avoid adding other unnecessary edges from the dispatcher.