### PR TITLE
CMakeLists.txt: flag for `no-limit-debug-info`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(TUPLE_TREE_GENERATOR_EMIT_TRACKING_DEBUG OFF)
 
+# Uncomment the following line if errors like `Couldn't find method
+# SomeType::method` make debugging hard
+#
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-limit-debug-info")
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_flag_if_available("-Wno-unused-local-typedefs")
 endif()


### PR DESCRIPTION
Add a commented line in `CMakeLists.txt` to easily enable `no-limit-debug-info`, which is useful to make debugging easier when methods are missing from llvm classes.