### PR TITLE
Allow multiple LLVM lit configuration files

### DIFF
--- a/libexec/revng/revng-check-conventions
+++ b/libexec/revng/revng-check-conventions
@@ -321,7 +321,7 @@ class MyPyPass(SingleCommandPass):
         script_files: List[Path] = []
         normal_files: List[Path] = []
         for filepath in files:
-            if str(filepath).startswith("python/scripts"):
+            if str(filepath).startswith("python/scripts") or filepath.name == "lit.cfg.py":
                 script_files.append(filepath)
             else:
                 normal_files.append(filepath)


### PR DESCRIPTION
revng check branch fails if there are multiple python modules with the same name. This commit explicitly turns off checks for modules with the same name as the configuration files of LLVM lit so that more than one can exists.