### PR TITLE
Introduce `Undirected` `GraphTraits` for `GenericGraph`

### DIFF
--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -15,6 +15,7 @@
 
 #include "revng/ADT/STLExtras.h"
 #include "revng/Support/Debug.h"
+#include "revng/Support/Undirected.h"
 
 /// GenericGraph is our implementation of a universal graph architecture.
 /// First and foremost, it's tailored for the revng codebase, but maybe you
@@ -996,6 +997,46 @@ public:
     return llvm::make_range(predecessors_begin(), predecessors_end());
   }
 
+public:
+  // TODO: The following methods could, in principle, be implemented using just
+  //       the `GraphTraits`, and become available for any implementer of
+  //       `GraphTraits` and not just for `GenericGraph`
+  auto undirected_children() {
+    using ResultIterator = UndirectedChildIterator<SuccessorIterator,
+                                                   PredecessorIterator,
+                                                   EdgeView>;
+    return llvm::make_range(ResultIterator::begin(successors(), predecessors()),
+                            ResultIterator::end(successors(), predecessors()));
+  }
+
+  auto undirected_children() const {
+    using ResultIterator = UndirectedChildIterator<ConstSuccessorIterator,
+                                                   ConstPredecessorIterator,
+                                                   EdgeView>;
+    return llvm::make_range(ResultIterator::begin(successors(), predecessors()),
+                            ResultIterator::end(successors(), predecessors()));
+  }
+
+  auto undirected_child_edges() {
+    using ResultIterator = UndirectedChildIterator<SuccessorEdgeIterator,
+                                                   PredecessorEdgeIterator,
+                                                   EdgeView>;
+    return llvm::make_range(ResultIterator::begin(successor_edges(),
+                                                  predecessor_edges()),
+                            ResultIterator::end(successor_edges(),
+                                                predecessor_edges()));
+  }
+
+  auto undirected_child_edges() const {
+    using ResultIterator = UndirectedChildIterator<ConstSuccessorEdgeIterator,
+                                                   ConstPredecessorEdgeIterator,
+                                                   EdgeView>;
+    return llvm::make_range(ResultIterator::begin(successor_edges(),
+                                                  predecessor_edges()),
+                            ResultIterator::end(successor_edges(),
+                                                predecessor_edges()));
+  }
+
 private:
   template<typename IteratorType>
   static auto findImpl(DerivedType const *N,
@@ -1577,6 +1618,41 @@ public:
 
   static T *edge_dest(EdgeRef Edge) { return &Edge.Neighbor; }
   static T *getEntryNode(llvm::Inverse<T *> N) { return N.Graph; };
+};
+
+/// Specializes GraphTraits<llvm::Undirected<MutableEdgeNode<...> *>>
+template<StrictSpecializationOfMutableEdgeNode T>
+struct GraphTraits<llvm::Undirected<T *>> {
+public:
+  using NodeRef = T *;
+  using EdgeRef = typename T::EdgeView;
+
+public:
+  static auto child_begin(NodeRef N) {
+    return N->undirected_children().begin();
+  }
+
+  static auto child_end(NodeRef N) { return N->undirected_children().end(); }
+
+  static auto child_edge_begin(NodeRef N) {
+    return N->undirected_child_edges().begin();
+  }
+
+  static auto child_edge_end(NodeRef N) {
+    return N->undirected_child_edges().end();
+  }
+
+  static NodeRef edge_dest(EdgeRef Edge) { return Edge.Neighbor; }
+
+  static NodeRef getEntryNode(llvm::Undirected<NodeRef> N) { return N.Graph; }
+
+public:
+  // We infer the `ChildIteratorType` directly from the `child_begin` method
+  using ChildIteratorType = decltype(child_begin(NodeRef{ nullptr }));
+
+  // We infer the `ChildEdgeIteratorType` directly from the `child_edge_begin`
+  // method
+  using ChildEdgeIteratorType = decltype(child_edge_begin(NodeRef{ nullptr }));
 };
 
 /// Specializes GraphTraits<GenericGraph<...> *>>

--- a/include/revng/ADT/GenericGraph.h
+++ b/include/revng/ADT/GenericGraph.h
@@ -1460,10 +1460,10 @@ public:
 
   using EdgeRef = typename T::Edge &;
   template<typename Ty, typename True, typename False>
-  using if_const = std::conditional_t<std::is_const_v<Ty>, True, False>;
-  using ChildEdgeIteratorType = if_const<T,
-                                         typename T::const_edge_iterator,
-                                         typename T::edge_iterator>;
+  using if_const_t = std::conditional_t<std::is_const_v<Ty>, True, False>;
+  using ChildEdgeIteratorType = if_const_t<T,
+                                           typename T::const_edge_iterator,
+                                           typename T::edge_iterator>;
 
 public:
   static ChildIteratorType child_begin(NodeRef N) {
@@ -1496,6 +1496,13 @@ public:
                                                typename T::const_child_iterator,
                                                typename T::child_iterator>;
 
+  using EdgeRef = typename T::Edge &;
+  template<typename Ty, typename True, typename False>
+  using if_const_t = std::conditional_t<std::is_const_v<Ty>, True, False>;
+  using ChildEdgeIteratorType = if_const_t<T,
+                                           typename T::const_edge_iterator,
+                                           typename T::edge_iterator>;
+
 public:
   static ChildIteratorType child_begin(NodeRef N) {
     return N->predecessors().begin();
@@ -1504,6 +1511,16 @@ public:
   static ChildIteratorType child_end(NodeRef N) {
     return N->predecessors().end();
   }
+
+  static ChildEdgeIteratorType child_edge_begin(NodeRef N) {
+    return N->predecessor_edges().begin();
+  }
+
+  static ChildEdgeIteratorType child_edge_end(NodeRef N) {
+    return N->predecessor_edges().end();
+  }
+
+  static NodeRef edge_dest(EdgeRef Edge) { return Edge.Neighbor; }
 
   static NodeRef getEntryNode(llvm::Inverse<NodeRef> N) { return N.Graph; };
 };

--- a/include/revng/Support/Undirected.h
+++ b/include/revng/Support/Undirected.h
@@ -1,0 +1,147 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/iterator.h"
+
+#include "revng/Support/Assert.h"
+
+namespace llvm {
+
+/// This class is used as a marker class to tell the graph iterator to treat the
+/// underlying graph as an undirected one
+template<class GraphType>
+struct Undirected {
+  const GraphType &Graph;
+
+  inline Undirected(const GraphType &G) : Graph(G) {}
+};
+
+} // namespace llvm
+
+/// Custom child iterator which iterates over the concatenation of the
+/// successors and predecessors of a node. This is used for the `Undirected`
+/// `GraphTraits` specialization. This is done taking inspiration from the
+/// internals of `llvm::concat` implementation, but overcomes one of its
+/// limitations. The limitation is caused by the fact that internally, the `*`
+/// operator of `llvm::concat` (and more specifically the `getHelper`), first
+/// dereferences the internal iterator that is being concatenated, and then
+/// takes and returns its pointer (`&*It`). If the iterator used internally,
+/// when dereferenced, returns a temporary object with a limited lifetime, which
+/// goes out of scope before its used by the user of `llvm::concat`, we have a
+/// problem. Instead here, we artificially extend the lifetime of the object
+/// pointed to by the internal iterator, wrapping it into the `Proxy` struct.
+/// When dereferenciation happens, no problems of lifetime happen.
+// TODO: Drop this once we adopt C++26
+//       (https://en.cppreference.com/w/cpp/ranges/concat_view) or if we adopt
+//       range-v3
+//       (https://ericniebler.github.io/range-v3/structranges_1_1views_1_1concat
+//        __fn.html).
+//       In such case, we can drop the below custom iterator, and use the
+//       `concat`  directly in the body of the `struct
+//       GraphTraits<llvm::Undirected<T *>>` implementation.
+template<typename SuccessorIterator,
+         typename PredecessorIterator,
+         typename ValueType>
+class UndirectedChildIterator : public llvm::iterator_facade_base<
+                                  UndirectedChildIterator<SuccessorIterator,
+                                                          PredecessorIterator,
+                                                          ValueType>,
+                                  std::forward_iterator_tag,
+                                  ValueType> {
+private:
+  SuccessorIterator SBegin;
+  SuccessorIterator SEnd;
+  PredecessorIterator PBegin;
+  PredecessorIterator PEnd;
+
+  explicit UndirectedChildIterator(SuccessorIterator SBegin,
+                                   SuccessorIterator SEnd,
+                                   PredecessorIterator PBegin,
+                                   PredecessorIterator PEnd) :
+    SBegin(SBegin), SEnd(SEnd), PBegin(PBegin), PEnd(PEnd) {}
+
+public:
+  static UndirectedChildIterator<SuccessorIterator,
+                                 PredecessorIterator,
+                                 ValueType>
+  begin(llvm::iterator_range<SuccessorIterator> Successors,
+        llvm::iterator_range<PredecessorIterator> Predecessors) {
+    return UndirectedChildIterator<SuccessorIterator,
+                                   PredecessorIterator,
+                                   ValueType>(std::begin(Successors),
+                                              std::end(Successors),
+                                              std::begin(Predecessors),
+                                              std::end(Predecessors));
+  }
+  static UndirectedChildIterator<SuccessorIterator,
+                                 PredecessorIterator,
+                                 ValueType>
+  end(llvm::iterator_range<SuccessorIterator> Successors,
+      llvm::iterator_range<PredecessorIterator> Predecessors) {
+    return UndirectedChildIterator<SuccessorIterator,
+                                   PredecessorIterator,
+                                   ValueType>(std::end(Successors),
+                                              std::end(Successors),
+                                              std::end(Predecessors),
+                                              std::end(Predecessors));
+  }
+
+  using UndirectedChildIterator::iterator_facade_base::operator++;
+
+  UndirectedChildIterator &operator++() {
+    if (SBegin != SEnd) {
+      ++SBegin;
+      return *this;
+    }
+
+    if (PBegin != PEnd) {
+      ++PBegin;
+      return *this;
+    }
+
+    revng_abort("Attempted to increment an end iterator!");
+  }
+
+  decltype(auto) operator*() {
+    if (SBegin != SEnd)
+      return *SBegin;
+
+    if (PBegin != PEnd)
+      return *PBegin;
+
+    revng_abort("Attempted to dereference an end iterator!");
+  }
+  decltype(auto) operator*() const {
+    if (SBegin != SEnd)
+      return *SBegin;
+
+    if (PBegin != PEnd)
+      return *PBegin;
+
+    revng_abort("Attempted to dereference an end iterator!");
+  }
+
+  struct Proxy {
+    Proxy(ValueType Value) : Temporary(std::move(Value)) {}
+    ValueType *const operator->() { return &Temporary; }
+    ValueType const *const operator->() const { return &Temporary; }
+
+  private:
+    ValueType Temporary;
+  };
+
+  Proxy operator->() { return operator*(); }
+  Proxy operator->() const { return operator*(); }
+
+  bool operator==(const UndirectedChildIterator &Another) const {
+    auto This = std::tie(SBegin, SEnd, PBegin, PEnd);
+    auto That = std::tie(Another.SBegin,
+                         Another.SEnd,
+                         Another.PBegin,
+                         Another.PEnd);
+    return This == That;
+  }
+};


### PR DESCRIPTION
Introduce the `Undirected` GraphTraits, which treat a `Bidirectional` `GenericGraph` as an undirected graph.