### PR TITLE
ScopeGraph: introduce the `ScopeGraph`

### DIFF
--- a/include/revng/ADT/GeneratorIterator.h
+++ b/include/revng/ADT/GeneratorIterator.h
@@ -1,0 +1,151 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+
+#include "revng/Support/Debug.h"
+#include "revng/Support/Generator.h"
+#include "revng/Support/IRHelpers.h"
+
+// Define a custom concept for restricting the T type
+template<typename T>
+concept TriviallyCopyable = std::is_trivially_copyable_v<T>
+                            and std::is_copy_constructible_v<T>
+                            and std::is_copy_assignable_v<T>;
+
+// Iterator class that generates the next element on increment, holding a
+// cppcoro::generator.
+//
+// We restrict the `T` type so that is a trivially copyable object
+template<TriviallyCopyable T>
+class GeneratorIterator {
+public:
+  // We need the specification of the following `iterator_traits` so that
+  // `llvm::GraphWriter` doesn't complain in trying to perform `std::distance`
+  // over the `child_begin`/`child_end` traits
+  using difference_type = ssize_t;
+  using value_type = T;
+  using pointer = T *;
+  using reference = T &;
+  using iterator_category = typename std::forward_iterator_tag;
+
+  using inner_iterator = decltype(cppcoro::generator<T>().begin());
+
+private:
+  mutable cppcoro::generator<T> Generator;
+  mutable inner_iterator Begin;
+
+  // Optional field is used when constructing a snapshotted iterator, i.e. a
+  // special iterator state which can only be dereferenced.
+  mutable std::optional<T> Snapshot;
+
+public:
+  // Constructor building an empty coroutine, with no snapshots.
+  // This is basically a coroutine that is already ended, representing an empty
+  // range.
+  GeneratorIterator() : Generator(), Begin(), Snapshot(std::nullopt) {}
+
+  // Standard constructor providing an input generator, that will be used under
+  // the hood to generate the iterators.
+  GeneratorIterator(cppcoro::generator<T> &&TheGenerator) :
+    Generator(std::move(TheGenerator)),
+    Begin(Generator.begin()),
+    Snapshot(std::nullopt) {}
+
+  ~GeneratorIterator() = default;
+
+private:
+  // Constructor used for a snapshotted iterator.
+  // This constructor is private since it's only invoked in the postincrement
+  // operator, and doesn't really make sense as public API.
+  GeneratorIterator(const T &Value) : Generator(), Begin(), Snapshot(Value) {}
+
+public:
+  // Copy assignment.
+  GeneratorIterator &operator=(const GeneratorIterator &Other) {
+    if (this != &Other) {
+      this->Snapshot = Other.Snapshot;
+
+      // We move the coroutine, even if we're in the copy constructor, because
+      // the coroutine is not copyable.
+      // In principle we wouldn't like to define this copy constructor at all,
+      // but there's come code in LLVM we depend upon that requires it and that
+      // we don't control.
+      // So we have to make sure that the coroutine is never copied and is in
+      // fact moved.
+      this->Generator = std::move(Other.Generator);
+      this->Begin = std::move(Other.Begin);
+      Other.Begin = {};
+
+      // In the copy constructor, we want to transition the `Other` object to
+      // the snapshot state, if it is not already a snapshot, and if the
+      // internal generator iterator is in a valid state (not at the end). If
+      // that's the case, we formally leave `Other` as a non snapshot
+      // `GeneratorIterator`, but that cannot be dereferenced, which reflects
+      // the semantics of trying to copy a `GeneratorIterator` that cannot be
+      // dereferenced itself.
+      if (not Other.Snapshot and this->Begin != this->Generator.end()) {
+        Other.Snapshot = *this->Begin;
+      }
+    }
+    return *this;
+  }
+
+  // Copy constructor which uses the copy assignment
+  GeneratorIterator(const GeneratorIterator &Other) { *this = Other; }
+
+  // Move assignment
+  GeneratorIterator &operator=(GeneratorIterator &&Other) {
+    if (this != &Other) {
+      this->Snapshot = std::move(Other.Snapshot);
+      this->Generator = std::move(Other.Generator);
+      this->Begin = std::move(Other.Begin);
+    }
+    return *this;
+  }
+
+  // Move constructor which uses the move assignment
+  GeneratorIterator(GeneratorIterator &Other) { *this = std::move(Other); }
+
+public:
+  bool isSnapshot() const { return Snapshot.has_value(); }
+
+public:
+  bool operator==(const GeneratorIterator &Other) const {
+    // It's not legal to compare iterators in snapshot state.
+    revng_assert(not this->isSnapshot() and not Other.isSnapshot());
+
+    return this->Begin == Other.Begin;
+  }
+
+  GeneratorIterator &operator++() {
+    // It's not legal to increment an iterator in snapshot state.
+    revng_assert(not isSnapshot());
+    ++Begin;
+    return *this;
+  }
+
+  GeneratorIterator operator++(int) {
+    // It's not legal to increment an iterator in snapshot state.
+    revng_assert(not isSnapshot());
+
+    // We return an iterator in the snapshot state, that can only be
+    // dereferenced to obtain the snapshotted value.
+    GeneratorIterator TakenSnapshot(*Begin);
+    ++*this;
+    return TakenSnapshot;
+  }
+
+  T operator*() const {
+    if (Snapshot.has_value()) {
+      return Snapshot.value();
+    } else {
+      return *Begin;
+    }
+  }
+};

--- a/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
+++ b/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
@@ -1,0 +1,174 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/GraphTraits.h"
+
+#include "revng/ADT/GeneratorIterator.h"
+#include "revng/RestructureCFG/ScopeGraphUtils.h"
+
+// We use a template here in order to instantiate `BlockType` both as
+// `BasicBlock *` and `const BasicBlock *`
+template<typename BlockType>
+inline cppcoro::generator<BlockType> getNextScopeGraphSuccessor(BlockType BB) {
+
+  //  First of all, we return all the standard successors of `BB`, but only if
+  //  the current block does not contain the `goto_block` marker. If that is the
+  //  case, since we have the constraint that a `goto_block` can only exists in
+  //  a block with a single successor (which is the `goto` target).
+  if (not isGotoBlock(BB)) {
+    for (auto *Successor : successors(BB)) {
+      co_yield Successor;
+    }
+  }
+
+  // We then move to returning the additional successor represented by the
+  // `ScopeCloser` edge, if present at all
+  BlockType ScopeCloserTarget = getScopeCloserTarget(BB);
+  if (ScopeCloserTarget) {
+    co_yield ScopeCloserTarget;
+  }
+
+  co_return;
+}
+
+/// This class is used as a marker class to tell the graph iterator to treat the
+/// underlying graph as a scope graph, i.e., considering also the scope closer
+/// edges as actual edges, and ignoring the goto edges
+template<class GraphType>
+struct Scope {
+  const GraphType &Graph;
+
+  inline Scope(const GraphType &G) : Graph(G) {}
+};
+
+/// Specializes `GraphTraits<Scope<llvm::BasicBlock *>>`
+template<>
+struct llvm::GraphTraits<Scope<llvm::BasicBlock *>> {
+public:
+  using NodeRef = llvm::BasicBlock *;
+  using ChildIteratorType = GeneratorIterator<llvm::BasicBlock *>;
+
+public:
+  static ChildIteratorType child_begin(NodeRef N) {
+    return GeneratorIterator<llvm::BasicBlock *>(getNextScopeGraphSuccessor(N));
+  }
+
+  static ChildIteratorType child_end(NodeRef N) {
+    return GeneratorIterator<llvm::BasicBlock *>();
+  }
+
+  // In the implementation for `llvm::BasicBlock *` trait we simply return
+  // `this`
+  static NodeRef getEntryNode(Scope<NodeRef> N) { return N.Graph; }
+
+  // Add a verify method to the trait which checks that we have at maximum one
+  // occurrence of the marker call in each `BasicBlock`, in the correct position
+  static void verify(NodeRef N) { verifyScopeGraphAnnotations(N); }
+};
+
+template<>
+struct llvm::GraphTraits<Scope<const llvm::BasicBlock *>> {
+public:
+  using NodeRef = const llvm::BasicBlock *;
+  using ChildIteratorType = GeneratorIterator<const llvm::BasicBlock *>;
+
+public:
+  static ChildIteratorType child_begin(NodeRef N) {
+    return GeneratorIterator<
+      const llvm::BasicBlock *>(getNextScopeGraphSuccessor(N));
+  }
+
+  static ChildIteratorType child_end(NodeRef N) {
+    return GeneratorIterator<const llvm::BasicBlock *>();
+  }
+
+  // In the implementation for `llvm::BasicBlock *` trait we simply return
+  // `this`
+  static NodeRef getEntryNode(Scope<NodeRef> N) { return N.Graph; }
+
+  // Add a verify method to the trait which checks that we have at maximum one
+  // occurrence of the marker call in each `BasicBlock`, in the correct position
+  static void verify(NodeRef N) { verifyScopeGraphAnnotations(N); }
+};
+
+template<>
+struct llvm::GraphTraits<Scope<llvm::Function *>>
+  : public llvm::GraphTraits<Scope<typename llvm::BasicBlock *>> {
+  using NodeRef = llvm::BasicBlock *;
+  using nodes_iterator = pointer_iterator<Function::iterator>;
+
+  static NodeRef getEntryNode(Scope<llvm::Function *> G) {
+    return &G.Graph->getEntryBlock();
+  }
+
+  static nodes_iterator nodes_begin(Scope<llvm::Function *> G) {
+    return nodes_iterator(G.Graph->begin());
+  }
+
+  static nodes_iterator nodes_end(Scope<llvm::Function *> G) {
+    return nodes_iterator(G.Graph->end());
+  }
+
+  static size_t size(Scope<llvm::Function *> G) { return G.Graph->size(); }
+
+  // Add a verify method to the trait which invokes the `verify` of the
+  // `BasicBlock *` trait for each node in the graph
+  static void verify(Scope<llvm::Function *> G) {
+    for (auto &N : *G.Graph) {
+      llvm::GraphTraits<Scope<llvm::BasicBlock *>>::verify(&N);
+    }
+  }
+};
+
+template<>
+struct llvm::GraphTraits<Scope<const llvm::Function *>>
+  : public llvm::GraphTraits<Scope<const typename llvm::BasicBlock *>> {
+  using NodeRef = const llvm::BasicBlock *;
+  using nodes_iterator = pointer_iterator<Function::const_iterator>;
+
+  static NodeRef getEntryNode(Scope<const llvm::Function *> G) {
+    return &G.Graph->getEntryBlock();
+  }
+
+  static nodes_iterator nodes_begin(Scope<const llvm::Function *> G) {
+    return nodes_iterator(G.Graph->begin());
+  }
+
+  static nodes_iterator nodes_end(Scope<const llvm::Function *> G) {
+    return nodes_iterator(G.Graph->end());
+  }
+
+  static size_t size(Scope<const llvm::Function *> G) {
+    return G.Graph->size();
+  }
+
+  // Add a verify method to the trait which invokes the `verify` of the
+  // `BasicBlock *` trait for each node in the graph
+  static void verify(Scope<const llvm::Function *> G) {
+    for (auto &N : *G.Graph) {
+      llvm::GraphTraits<Scope<const llvm::BasicBlock *>>::verify(&N);
+    }
+  }
+};
+
+// Debug function used dump a serialized representation of the `ScopeGraph` on a
+// stream
+debug_function inline void dumpScopeGraph(llvm::Function &F) {
+  llvm::dbgs() << "ScopeGraph of function: " << F.getName().str() << "\n";
+  for (llvm::BasicBlock &BB : F) {
+    llvm::dbgs() << "Block " << BB.getName().str() << " successors:\n";
+    for (auto *Succ : llvm::children<Scope<llvm::BasicBlock *>>(&BB)) {
+      llvm::dbgs() << " " << Succ->getName().str() << "\n";
+    }
+  }
+
+  // Iteration on the whole graph using a `llvm::depth_first` visit
+  llvm::dbgs() << "Depth first order:\n";
+  for (auto *DFSNode : llvm::depth_first(Scope<llvm::Function *>(&F))) {
+    llvm::dbgs() << DFSNode->getName().str() << "\n";
+  }
+}

--- a/include/revng/RestructureCFG/ScopeGraphUtils.h
+++ b/include/revng/RestructureCFG/ScopeGraphUtils.h
@@ -1,0 +1,61 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "revng/ADT/Concepts.h"
+#include "revng/Support/FunctionTags.h"
+
+// We use a template here in order to instantiate `FunctionType` both as
+// `Function` and `const Function`
+template<ConstOrNot<llvm::Module> ModuleType>
+inline typename std::conditional_t<std::is_const_v<ModuleType>,
+                                   const llvm::Function,
+                                   llvm::Function> *
+getUniqueFunctionWithTag(FunctionTags::Tag &MarkerFunctionTag, ModuleType *M) {
+  using FunctionType = typename std::conditional_t<std::is_const_v<ModuleType>,
+                                                   const llvm::Function,
+                                                   llvm::Function>;
+  FunctionType *MarkerCallFunction = nullptr;
+
+  // We could early break from this loop but we would loose the ability of
+  // asserting that a single marker function is present
+  for (FunctionType &F : MarkerFunctionTag.functions(M)) {
+    revng_assert(not MarkerCallFunction);
+    MarkerCallFunction = &F;
+  }
+
+  revng_assert(MarkerCallFunction);
+  return MarkerCallFunction;
+}
+
+/// A class that wraps all the logic for injecting goto edges and scope closer
+/// edges on LLVM IR. Such edges are then necessary for the ScopeGraph view on
+/// LLVM IR
+class ScopeGraphBuilder {
+private:
+  llvm::Function *ScopeCloserFunction = nullptr;
+  llvm::Function *GotoBlockFunction = nullptr;
+
+public:
+  ScopeGraphBuilder(llvm::Function *F);
+
+public:
+  void makeGoto(llvm::BasicBlock *GotoBlock);
+  void addScopeCloser(llvm::BasicBlock *Source, llvm::BasicBlock *Target);
+};
+
+llvm::SmallVector<const llvm::Instruction *, 2>
+getLast2InstructionsBeforeTerminator(const llvm::BasicBlock *BB);
+
+/// Helper function to retrieve the `BasicBlock` target of the marker
+llvm::BasicBlock *getScopeCloserTarget(const llvm::BasicBlock *BB);
+
+/// Helper function to determine if `BB` contains a `goto_block` marker
+bool isGotoBlock(const llvm::BasicBlock *BB);
+
+void verifyScopeGraphAnnotationsImpl(FunctionTags::Tag &Tag,
+                                     const llvm::BasicBlock *BB);
+
+void verifyScopeGraphAnnotations(const llvm::BasicBlock *BB);

--- a/include/revng/Support/FunctionTags.h
+++ b/include/revng/Support/FunctionTags.h
@@ -40,6 +40,8 @@ extern Tag UniquedByMetadata;
 extern Tag AllocatesLocalVariable;
 extern Tag ReturnsPolymorphic;
 extern Tag IsRef;
+extern Tag ScopeCloserMarker;
+extern Tag GotoBlockMarker;
 
 /// This struct can be used as a key of an OpaqueFunctionsPool where both
 /// the return type and one of the arguments are needed to identify a function

--- a/include/revng/Support/IRHelpers.h
+++ b/include/revng/Support/IRHelpers.h
@@ -864,7 +864,7 @@ inline bool isCallTo(const llvm::Value *I, llvm::StringRef Name) {
   return Callee != nullptr && Callee->getName() == Name;
 }
 
-inline bool isCallTo(const llvm::Value *I, llvm::Function *F) {
+inline bool isCallTo(const llvm::Value *I, const llvm::Function *F) {
   revng_assert(I != nullptr);
 
   auto *Call = llvm::dyn_cast<llvm::Instruction>(I);
@@ -898,7 +898,7 @@ inline const llvm::CallInst *getCallTo(const llvm::Instruction *I,
 }
 
 inline const llvm::CallInst *getCallTo(const llvm::Instruction *I,
-                                       llvm::Function *F) {
+                                       const llvm::Function *F) {
   if (isCallTo(I, F))
     return llvm::cast<llvm::CallInst>(I);
   else

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -2,6 +2,10 @@
 # This file is distributed under the MIT License. See LICENSE.md for details.
 #
 
+# We need an additional library because we link this also for unit tests
+revng_add_library_internal(revngScopeGraphUtils ScopeGraphUtils.cpp)
+target_link_libraries(revngScopeGraphUtils revngSupport ${LLVM_LIBRARIES})
+
 revng_add_analyses_library_internal(
   revngRestructureCFG
   ASTNode.cpp
@@ -24,5 +28,5 @@ revng_add_analyses_library_internal(
   SimplifyHybridNot.cpp
   SimplifyImplicitStatement.cpp)
 
-target_link_libraries(revngRestructureCFG revngSupport revngModel revngPipeline
-                      ${LLVM_LIBRARIES})
+target_link_libraries(revngRestructureCFG revngScopeGraphUtils revngSupport
+                      revngModel revngPipeline ${LLVM_LIBRARIES})

--- a/lib/RestructureCFG/ScopeGraphUtils.cpp
+++ b/lib/RestructureCFG/ScopeGraphUtils.cpp
@@ -1,0 +1,186 @@
+/// \file ScopeGraphUtils.cpp
+/// Helpers for the `ScopeGraph` building
+///
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+
+#include "revng/RestructureCFG/ScopeGraphUtils.h"
+#include "revng/Support/IRHelpers.h"
+
+using namespace llvm;
+
+// Helper function which set the attributes for the created function
+// prototypes
+static void setFunctionAttributes(Function *F, FunctionTags::Tag &Tag) {
+  F->setLinkage(GlobalValue::ExternalLinkage);
+  F->addFnAttr(Attribute::OptimizeNone);
+  F->addFnAttr(Attribute::NoInline);
+  F->addFnAttr(Attribute::NoMerge);
+  F->addFnAttr(Attribute::NoUnwind);
+  F->addFnAttr(Attribute::WillReturn);
+  F->setMemoryEffects(MemoryEffects::inaccessibleMemOnly());
+
+  // Add the tag to the `Function`
+  Tag.addTo(F);
+}
+
+static Function *getOrCreateScopeCloserFunction(Module *M) {
+  FunctionTags::Tag &Tag = FunctionTags::ScopeCloserMarker;
+  Function *Result = getUniqueFunctionWithTag(Tag, M);
+
+  // Create the `ScopeCloserMarker` function if it doesn't exists
+  if (not Result) {
+    auto *FT = FunctionType::get(Type::getVoidTy(getContext(M)), {}, false);
+    Result = cast<Function>(M->getOrInsertFunction(Tag.name(), FT).getCallee());
+    setFunctionAttributes(Result, Tag);
+  }
+  revng_assert(Result != nullptr);
+  return Result;
+}
+
+static Function *getOrCreateGotoBlockFunction(Module *M) {
+  FunctionTags::Tag &Tag = FunctionTags::GotoBlockMarker;
+  Function *Result = getUniqueFunctionWithTag(Tag, M);
+
+  // Create the `ScopeCloserMarker` function if it doesn't exists
+  if (not Result) {
+    PointerType *BlockAddressTy = Type::getInt8PtrTy(getContext(M));
+    auto *FT = FunctionType::get(Type::getVoidTy(getContext(M)),
+                                 { BlockAddressTy },
+                                 false);
+    Result = cast<Function>(M->getOrInsertFunction(Tag.name(), FT).getCallee());
+    setFunctionAttributes(Result, Tag);
+  }
+  revng_assert(Result != nullptr);
+  return Result;
+}
+
+ScopeGraphBuilder::ScopeGraphBuilder(Function *F) :
+  ScopeCloserFunction(getOrCreateScopeCloserFunction(F->getParent())),
+  GotoBlockFunction(getOrCreateGotoBlockFunction(F->getParent())) {
+}
+
+void ScopeGraphBuilder::makeGoto(BasicBlock *GotoBlock) {
+  // We must have a `GotoBlock`
+  revng_assert(GotoBlock);
+
+  // We assume that when inserting a `goto` edge, the original block had a
+  // single regular successor on the CFG
+  Instruction *Terminator = GotoBlock->getTerminator();
+  revng_assert(Terminator->getNumSuccessors() == 1);
+
+  // We always insert the marker as the penultimate instruction in a
+  // `BasicBlock`
+  IRBuilder<> Builder(Terminator);
+  LLVMContext &C = getContext(GotoBlock);
+  PointerType *BlockAddressTy = Type::getInt8PtrTy(C);
+  auto *NullBasicBlockAddress = ConstantPointerNull::get(BlockAddressTy);
+  Builder.CreateCall(GotoBlockFunction, NullBasicBlockAddress);
+}
+
+void ScopeGraphBuilder::addScopeCloser(BasicBlock *Source, BasicBlock *Target) {
+  // We must have an insertion point
+  revng_assert(Source);
+
+  // We always insert the marker as the penultimate instruction in a
+  // `BasicBlock`
+  Instruction *Terminator = Source->getTerminator();
+  IRBuilder<> Builder(Terminator);
+  auto *BasicBlockAddressTarget = BlockAddress::get(Target);
+  revng_assert(BasicBlockAddressTarget);
+  Builder.CreateCall(ScopeCloserFunction, BasicBlockAddressTarget);
+}
+
+SmallVector<const Instruction *, 2>
+getLast2InstructionsBeforeTerminator(const BasicBlock *BB) {
+  SmallVector<const Instruction *, 2> Result;
+  for (const auto &Group : enumerate(reverse(*BB))) {
+    if (Group.index() > 2) {
+      return Result;
+    }
+    const Instruction &I = Group.value();
+    if (not I.isTerminator())
+      Result.push_back(&I);
+  }
+  return Result;
+}
+
+BasicBlock *getScopeCloserTarget(const BasicBlock *BB) {
+
+  // We must be provided with a `BasicBlock` where to search for the marker
+  revng_assert(BB);
+
+  // We search for the `scope_closer` marker in the last but one and last buttwo
+  // instructions in `BB`
+  for (const Instruction *I : getLast2InstructionsBeforeTerminator(BB)) {
+    if (const CallInst
+          *MarkerCall = getCallToTagged(I, FunctionTags::ScopeCloserMarker)) {
+      auto *Operand = MarkerCall->getArgOperand(0);
+      auto *TargetBlockAddress = cast<BlockAddress>(Operand);
+      auto *TargetBB = TargetBlockAddress->getBasicBlock();
+      return TargetBB;
+    }
+  }
+
+  return nullptr;
+}
+
+bool isGotoBlock(const BasicBlock *BB) {
+
+  // We must be provided with a `BasicBlock` where to search for the marker
+  revng_assert(BB);
+
+  // We search for the `scope_closer` marker in the last but one and last buttwo
+  // instructions in `BB`
+  for (const Instruction *I : getLast2InstructionsBeforeTerminator(BB)) {
+    if (const CallInst
+          *MarkerCall = getCallToTagged(I, FunctionTags::GotoBlockMarker)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void verifyScopeGraphAnnotationsImpl(FunctionTags::Tag &Tag,
+                                     const BasicBlock *BB) {
+  // We should find at maximum one occurrence of the call to the marker
+  // function in either the last but one or last but two position in the
+  // `BasicBlock`
+  bool MarkerFound = false;
+  for (const Instruction *I : getLast2InstructionsBeforeTerminator(BB)) {
+    if (const CallInst *MarkerCall = getCallToTagged(I, Tag)) {
+      revng_assert(MarkerFound == false, "Duplicate Marker Call");
+      MarkerFound = true;
+    }
+  }
+
+  // In the rest of the `BasicBlock`, we should not find any call to the marker
+  // function
+  for (const auto &Group : enumerate(reverse(*BB))) {
+    if (Group.index() <= 2)
+      continue;
+    if (const CallInst *MarkerCall = getCallToTagged(&Group.value(), Tag)) {
+      revng_abort("No ScopeGraph Marker Call expected in this portion of the "
+                  "BasicBlock");
+    }
+  }
+
+  // Additionally, the `ScopeGraph` has the requirement of permitting a single
+  // successor for a `BasicBlock` which contains the `goto_block` marker
+  if (MarkerFound and &Tag == &FunctionTags::GotoBlockMarker) {
+    const Instruction *Terminator = BB->getTerminator();
+    revng_assert(Terminator->getNumSuccessors() == 1);
+  }
+}
+
+void verifyScopeGraphAnnotations(const BasicBlock *BB) {
+  verifyScopeGraphAnnotationsImpl(FunctionTags::ScopeCloserMarker, BB);
+  verifyScopeGraphAnnotationsImpl(FunctionTags::GotoBlockMarker, BB);
+}

--- a/lib/Support/FunctionTags.cpp
+++ b/lib/Support/FunctionTags.cpp
@@ -16,7 +16,7 @@ Tag CSVsPromoted("csvs-promoted", ABIEnforced);
 Tag Exceptional("exceptional");
 Tag StructInitializer("struct-initializer");
 Tag OpaqueCSVValue("opaque-csv-value");
-Tag FunctionDispatcher("functin-dispatcher");
+Tag FunctionDispatcher("function-dispatcher");
 Tag Root("root");
 Tag IsolatedRoot("isolated-root");
 Tag CSVsAsArgumentsWrapper("csvs-as-arguments-wrapper");

--- a/lib/Support/FunctionTags.cpp
+++ b/lib/Support/FunctionTags.cpp
@@ -37,6 +37,9 @@ Tag AllocatesLocalVariable("allocates-local-variable");
 Tag ReturnsPolymorphic("returns-polymorphic");
 Tag IsRef("is-ref");
 
+Tag ScopeCloserMarker("scope-closer");
+Tag GotoBlockMarker("goto-block");
+
 FunctionPoolTag<TypePair>
   AddressOf("address-of",
             { llvm::Attribute::NoUnwind,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -598,3 +598,13 @@ target_link_libraries(
   Boost::unit_test_framework
   ${LLVM_LIBRARIES})
 add_test(NAME test_pointer_array_emission COMMAND test_pointer_array_emission)
+
+#
+# compile a pass
+#
+
+# We use the plain `add_library` and not the revng version
+# (revng_add_library_internal) in order to not get this installed into `lib`
+add_library(test_scopegraph SHARED "${SRC}/ScopeGraphLoggerPass.cpp")
+target_link_libraries(test_scopegraph revngScopeGraphUtils revngSupport
+                      ${LLVM_LIBRARIES})

--- a/tests/unit/ScopeGraphLoggerPass.cpp
+++ b/tests/unit/ScopeGraphLoggerPass.cpp
@@ -1,0 +1,57 @@
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+#include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
+
+using namespace llvm;
+
+class ScopeGraphLoggerPassImpl {
+  llvm::Function &F;
+
+public:
+  ScopeGraphLoggerPassImpl(llvm::Function &F) : F(F) {}
+
+public:
+  bool run() {
+    dumpScopeGraph(F);
+
+    return false; // The function was not modified
+  }
+};
+
+// We declare this pass directly in the `.cpp` file since we only need it for
+// the tests
+class ScopeGraphLoggerPass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  ScopeGraphLoggerPass() : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};
+
+char ScopeGraphLoggerPass::ID = 0;
+
+static constexpr const char *Flag = "scope-graph-logger";
+using Reg = llvm::RegisterPass<ScopeGraphLoggerPass>;
+static Reg X(Flag, "Dump edge information on the `ScopeGraph`");
+
+bool ScopeGraphLoggerPass::runOnFunction(llvm::Function &F) {
+
+  // Instantiate and call the `Impl` class
+  ScopeGraphLoggerPassImpl SGLPImpl(F);
+  return SGLPImpl.run();
+}
+
+void ScopeGraphLoggerPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+
+  // This is a read only analysis, that does not touch the IR
+  AU.setPreservesAll();
+}

--- a/tests/unit/llvm_lit_tests/ScopeGraph.ll
+++ b/tests/unit/llvm_lit_tests/ScopeGraph.ll
@@ -1,0 +1,176 @@
+;
+; This file is distributed under the MIT License. See LICENSE.md for details.
+;
+
+; RUN: %revngopt -load tests/unit/libtest_scopegraph.so %s -scope-graph-logger -o /dev/null |& FileCheck %s
+
+; function tags metadata needed for all the tests
+declare !revng.tags !0 void @scope-closer(ptr)
+declare !revng.tags !1 void @goto-block()
+!0 = !{!"scope-closer"}
+!1 = !{!"goto-block"}
+
+; no dashed edge test
+
+define void @f() {
+block_a:
+  br i1 undef, label %block_b, label %block_c
+
+block_b:
+  ret void
+
+block_c:
+  br i1 undef, label %block_b, label %block_e
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: ScopeGraph of function: f
+; CHECK-NEXT: Block block_a successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_c
+; CHECK-NEXT: Block block_b successors:
+; CHECK-NEXT: Block block_c successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_e successors:
+; CHECK-NEXT: Depth first order:
+; CHECK-NEXT: block_a
+; CHECK-NEXT: block_b
+; CHECK-NEXT: block_c
+; CHECK-NEXT: block_e
+
+; scope edge test, scope closer b->b is seen in the scopegraph
+
+define void @g() {
+block_a:
+  br i1 undef, label %block_b, label %block_c
+
+block_b:
+  call void @scope-closer(ptr blockaddress(@g, %block_b))
+  ret void
+
+block_c:
+  br i1 undef, label %block_b, label %block_e
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: ScopeGraph of function: g
+; CHECK-NEXT: Block block_a successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_c
+; CHECK-NEXT: Block block_b successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT: Block block_c successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_e successors:
+; CHECK-NEXT: Depth first order:
+; CHECK-NEXT: block_a
+; CHECK-NEXT: block_b
+; CHECK-NEXT: block_c
+; CHECK-NEXT: block_e
+
+; goto edge test, b->c is not seen in the scopegraph
+
+define void @h() {
+block_a:
+  br i1 undef, label %block_b, label %block_c
+
+block_b:
+  call void @goto-block()
+  br label %block_c
+
+block_c:
+  br i1 undef, label %block_b, label %block_e
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: ScopeGraph of function: h
+; CHECK-NEXT: Block block_a successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_c
+; CHECK-NEXT: Block block_b successors:
+; CHECK-NEXT: Block block_c successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_e successors:
+; CHECK-NEXT: Depth first order:
+; CHECK-NEXT: block_a
+; CHECK-NEXT: block_b
+; CHECK-NEXT: block_c
+; CHECK-NEXT: block_e
+
+; goto edge test, edge b->c is not seen in the scopegraph, but scope closer b->b
+; is correctly seen
+
+define void @i() {
+block_a:
+  br i1 undef, label %block_b, label %block_c
+
+block_b:
+  call void @goto-block()
+  call void @scope-closer(ptr blockaddress(@i, %block_b))
+  br label %block_c
+
+block_c:
+  br i1 undef, label %block_b, label %block_e
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: ScopeGraph of function: i
+; CHECK-NEXT: Block block_a successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_c
+; CHECK-NEXT: Block block_b successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT: Block block_c successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_e successors:
+; CHECK-NEXT: Depth first order:
+; CHECK-NEXT: block_a
+; CHECK-NEXT: block_b
+; CHECK-NEXT: block_c
+; CHECK-NEXT: block_e
+
+; depth first test with different order on scopegraph wrt. cfg. The plain DFS on
+; the cfg, would lead to a,b,c,e, while on the scopegraph we obtain a,b,e,c.
+
+define void @l() {
+block_a:
+  br i1 undef, label %block_b, label %block_c
+
+block_b:
+  call void @scope-closer(ptr blockaddress(@l, %block_e))
+  ret void
+
+block_c:
+  br i1 undef, label %block_b, label %block_e
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: ScopeGraph of function: l
+; CHECK-NEXT: Block block_a successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_c
+; CHECK-NEXT: Block block_b successors:
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_c successors:
+; CHECK-NEXT:   block_b
+; CHECK-NEXT:   block_e
+; CHECK-NEXT: Block block_e successors:
+; CHECK-NEXT: Depth first order:
+; CHECK-NEXT: block_a
+; CHECK-NEXT: block_b
+; CHECK-NEXT: block_e
+; CHECK-NEXT: block_c


### PR DESCRIPTION
Introduce the `scope-closer` and `goto-block` annotations in the IR, and the relative necessary machinery, needed to handle scope closer and goto edges for the new backend.

A specialization of the `llvm::GraphTraits`, called `ScopeGraph`, that is able to handle both the above mentioned annotations is provided.

For the `llvm::GraphTraits` implementation, we introduce the `GeneratorIterator` class, which uses a coroutine to store the status of the iteration.

A debug logger pass is added, so that we are able to test the functionality with `FileCheck`.