### PR TITLE
Introduce DecideWithGotos

### DIFF
--- a/include/revng/RestructureCFG/InlineDivergentScopesPass.h
+++ b/include/revng/RestructureCFG/InlineDivergentScopesPass.h
@@ -1,0 +1,20 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+class InlineDivergentScopesPass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  InlineDivergentScopesPass() : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};

--- a/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
+++ b/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
@@ -417,5 +417,5 @@ debug_function inline void dumpScopeGraph(llvm::Function &F) {
   // We also dump the `.dot` serialization of the `ScopeGraph` for debugging
   // purposes
   llvm::dbgs() << "Serializing the dot file representing the ScopeGraph\n";
-  llvm::WriteGraph<Scope<llvm::Function *>>(&F, "ScopeGraph");
+  llvm::WriteGraph<Scope<llvm::Function *>>(&F, "ScopeGraph-" + F.getName());
 }

--- a/include/revng/RestructureCFG/ScopeGraphUtils.h
+++ b/include/revng/RestructureCFG/ScopeGraphUtils.h
@@ -43,6 +43,12 @@ public:
 public:
   void makeGoto(llvm::BasicBlock *GotoBlock);
   void addScopeCloser(llvm::BasicBlock *Source, llvm::BasicBlock *Target);
+
+  /// With the usage of this helper,  all the successor in the `Terminator` of
+  /// the `Source` block pointing to `Target` will be redirected to the newly
+  /// inserted `goto` block
+  llvm::BasicBlock *makeGotoEdge(llvm::BasicBlock *Source,
+                                 llvm::BasicBlock *Target);
 };
 
 llvm::SmallVector<const llvm::Instruction *, 2>

--- a/include/revng/RestructureCFG/SelectScopePass.h
+++ b/include/revng/RestructureCFG/SelectScopePass.h
@@ -1,0 +1,20 @@
+#pragma once
+
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+class SelectScopePass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  SelectScopePass() : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};

--- a/include/revng/Support/GraphAlgorithms.h
+++ b/include/revng/Support/GraphAlgorithms.h
@@ -309,7 +309,7 @@ findReachableNodesImpl(GraphT Source, GraphT Stop = nullptr) {
 }
 
 template<class GraphT, class GT = llvm::GraphTraits<GraphT>>
-inline llvm::SmallSetVector<GraphT, 4>
+inline llvm::SmallSetVector<typename llvm::GraphTraits<GraphT>::NodeRef, 4>
 findReachableNodes(GraphT Source, GraphT Stop = nullptr) {
   return findReachableNodesImpl<GraphT, GT>(Source, Stop);
 }
@@ -379,13 +379,13 @@ nodesBetweenImpl(GraphT Source, GraphT Target) {
 }
 
 template<class GraphT>
-inline llvm::SmallSetVector<GraphT, 4>
+inline llvm::SmallSetVector<typename llvm::GraphTraits<GraphT>::NodeRef, 4>
 nodesBetween(GraphT Source, GraphT Destination) {
   return nodesBetweenImpl<GraphT, GraphT>(Source, Destination);
 }
 
 template<class GraphT>
-inline llvm::SmallSetVector<GraphT, 4>
+inline llvm::SmallSetVector<typename llvm::GraphTraits<GraphT>::NodeRef, 4>
 nodesBetweenReverse(GraphT Source, GraphT Destination) {
   using namespace llvm;
   return nodesBetweenImpl<GraphT, Inverse<GraphT>>(Source, Destination);

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -20,6 +20,7 @@ revng_add_analyses_library_internal(
   GenericRegionInfo.cpp
   GenericRegionPass.cpp
   InlineDispatcherSwitch.cpp
+  InlineDivergentScopesPass.cpp
   MetaRegion.cpp
   PromoteCallNoReturn.cpp
   RegionCFGTree.cpp

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -25,6 +25,7 @@ revng_add_analyses_library_internal(
   RegionCFGTree.cpp
   RemoveDeadCode.cpp
   RestructureCFG.cpp
+  SelectScopePass.cpp
   SimplifyCompareNode.cpp
   SimplifyDualSwitch.cpp
   SimplifyHybridNot.cpp

--- a/lib/RestructureCFG/DAGifyPass.cpp
+++ b/lib/RestructureCFG/DAGifyPass.cpp
@@ -52,12 +52,6 @@ static void processRetreating(const revng::detail::EdgeDescriptor<BasicBlock *>
   SGBuilder.makeGotoEdge(Source, Target);
 }
 
-char DAGifyPass::ID = 0;
-
-static constexpr const char *Flag = "dagify";
-using Reg = llvm::RegisterPass<DAGifyPass>;
-static Reg X(Flag, "Perform the DAGify pass on the ScopeGrapgh");
-
 class DAGifyPassImpl {
   Function &F;
 
@@ -138,6 +132,11 @@ public:
     return ModuleModified;
   }
 };
+
+char DAGifyPass::ID = 0;
+static constexpr const char *Flag = "dagify";
+using Reg = llvm::RegisterPass<DAGifyPass>;
+static Reg X(Flag, "Perform the DAGify pass on the ScopeGrapgh");
 
 bool DAGifyPass::runOnFunction(llvm::Function &F) {
   // Log the function name

--- a/lib/RestructureCFG/DAGifyPass.cpp
+++ b/lib/RestructureCFG/DAGifyPass.cpp
@@ -104,7 +104,7 @@ public:
         // edges during the processing of nested `GenericRegion`s.
         // We collect the retreating edges, performing an exploration that
         // starts from the elected `Head` of each identified `GenericRegion`.
-        llvm::SmallPtrSet<BasicBlock *, 4> RegionNodes;
+        SmallPtrSet<BasicBlock *, 4> RegionNodes;
         for (auto &RegionNode : Region->blocks()) {
           RegionNodes.insert(RegionNode);
         }

--- a/lib/RestructureCFG/DAGifyPass.cpp
+++ b/lib/RestructureCFG/DAGifyPass.cpp
@@ -48,29 +48,8 @@ static void processRetreating(const revng::detail::EdgeDescriptor<BasicBlock *>
                               return Elem == Target;
                             }));
 
-  // We create a new block which contains only the `goto`, this is an
-  // invariant needed in the `ScopeGraph`
-  LLVMContext &Context = getContext(F);
-  BasicBlock *GotoBlock = BasicBlock::Create(Context,
-                                             "goto_" + Target->getName().str(),
-                                             F);
-
-  // Connect the `goto` block with the original target
-  IRBuilder<> Builder(Context);
-  Builder.SetInsertPoint(GotoBlock);
-  Builder.CreateBr(Target);
-
-  // Redirect the `Source`->`Target` (may be multiple) edge/s to
-  // `Source`->`GotoBlock`. This means that if multiple edges, which are
-  // retreating, exist, we will connect them to a single `goto` block,
-  // representing the removed retreating. This means that we will need explicit
-  // support in the `clifter` pass in order to match this specific topology.
-  Instruction *SourceTerminator = Source->getTerminator();
-  SourceTerminator->replaceSuccessorWith(Target, GotoBlock);
-
-  // Insert the `goto_block` marker in the `ScopeGraph`
   ScopeGraphBuilder SGBuilder(F);
-  SGBuilder.makeGoto(GotoBlock);
+  SGBuilder.makeGotoEdge(Source, Target);
 }
 
 char DAGifyPass::ID = 0;

--- a/lib/RestructureCFG/EnforceSingleExitPass.cpp
+++ b/lib/RestructureCFG/EnforceSingleExitPass.cpp
@@ -178,7 +178,7 @@ public:
 
 char EnforceSingleExitPass::ID = 0;
 
-static constexpr const char *Flag = "ese";
+static constexpr const char *Flag = "enforce-single-exit";
 using Reg = llvm::RegisterPass<EnforceSingleExitPass>;
 static Reg X(Flag, "Enforce the Single Exit Property on the ScopeGraph");
 

--- a/lib/RestructureCFG/InlineDivergentScopesPass.cpp
+++ b/lib/RestructureCFG/InlineDivergentScopesPass.cpp
@@ -1,0 +1,404 @@
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/Support/GenericDomTree.h"
+
+#include "revng/RestructureCFG/InlineDivergentScopesPass.h"
+#include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
+#include "revng/Support/Assert.h"
+#include "revng/Support/GraphAlgorithms.h"
+#include "revng/Support/IRHelpers.h"
+
+using namespace llvm;
+
+/// Manager class to automatically handle the creation and clean up of the
+/// `PlaceHolderTarget`
+class PlaceHolderTargetManager {
+private:
+  BasicBlock *PlaceHolderTarget;
+
+public:
+  PlaceHolderTargetManager(Function &F) {
+    LLVMContext &Context = getContext(&F);
+    PlaceHolderTarget = BasicBlock::Create(Context,
+                                           "placeholder_destination",
+                                           &F);
+  }
+
+  ~PlaceHolderTargetManager() { PlaceHolderTarget->eraseFromParent(); }
+
+  BasicBlock *operator*() const { return PlaceHolderTarget; }
+};
+
+static bool isConditional(BasicBlock *Node) {
+  auto Successors = children<Scope<BasicBlock *>>(Node);
+  size_t NumSuccessors = std::distance(Successors.begin(), Successors.end());
+  if (NumSuccessors >= 2) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/// Helper function which detects
+static bool isExit(BasicBlock *Node) {
+  auto Successors = children<Scope<BasicBlock *>>(Node);
+  return std::ranges::empty(Successors);
+}
+
+/// Helper function to collect all the exit nodes on the `ScopeGraph`
+static SmallVector<BasicBlock *> getExits(Function &F,
+                                          BasicBlock *PlaceHolderTarget) {
+  SmallVector<BasicBlock *> Exits;
+  Scope<Function *> ScopeGraph(&F);
+  for (BasicBlock *BB : nodes(ScopeGraph)) {
+
+    // We need to exclude the `PlaceHolderTarget` which is a temporary block
+    // which incidentally happens to be an exit, but will be removed before the
+    // end of the pass
+    if (BB != PlaceHolderTarget and isExit(BB)) {
+      Exits.push_back(BB);
+    }
+  }
+
+  return Exits;
+}
+
+/// Helper to obtain the immediate dominator `BasicBlock`, if present
+static BasicBlock *
+getImmediateDominator(BasicBlock *N,
+                      DomTreeOnView<BasicBlock, Scope> &DomTree) {
+  auto *Node = DomTree.getNode(N)->getIDom();
+  if (Node) {
+    return Node->getBlock();
+  } else {
+    return nullptr;
+  }
+}
+
+/// Helper function which simplifies all the terminators containing
+/// `PlaceHolderTarget`, by removing it
+static void simplifyTerminator(BasicBlock *BB,
+                               const BasicBlock *PlaceHolderTarget) {
+  Instruction *Terminator = BB->getTerminator();
+
+  if (auto *Branch = dyn_cast<BranchInst>(Terminator)) {
+    if (Branch->isConditional()) {
+
+      // We want to transform a conditional branch with one of the destination
+      // set to `PlaceHolderTarget` to a non conditional branch
+      BasicBlock *SingleDestination = nullptr;
+
+      if (Branch->getSuccessor(0) == PlaceHolderTarget) {
+        SingleDestination = Branch->getSuccessor(1);
+        revng_assert(SingleDestination != PlaceHolderTarget);
+      } else if (Branch->getSuccessor(1) == PlaceHolderTarget) {
+        SingleDestination = Branch->getSuccessor(0);
+        revng_assert(SingleDestination != PlaceHolderTarget);
+      }
+
+      // If we found a `BranchInst` candidate for promotion, we substitute it
+      // with an unconditional branch
+      if (SingleDestination) {
+        IRBuilder<> Builder(Terminator);
+        Builder.CreateBr(SingleDestination);
+
+        // We remove the old conditional branch
+        Terminator->eraseFromParent();
+      }
+    }
+  } else if (auto *Switch = dyn_cast<SwitchInst>(Terminator)) {
+
+    // Handle the simplification when `PlaceHolderTager` is the default
+    // destination of the `SwitchInst`
+    BasicBlock *DefaultTarget = Switch->getDefaultDest();
+    if (DefaultTarget == PlaceHolderTarget) {
+
+      // We promote the first case, not pointing to `PlaceHolderTarget`. If we
+      // promote a case already pointing to `PlaceHolderTarget`, this would, in
+      // turn, cause the `default` case to not be simplified ever.
+      for (auto CaseIt = Switch->case_begin(); CaseIt != Switch->case_end();
+           ++CaseIt) {
+        if (CaseIt->getCaseSuccessor() != PlaceHolderTarget) {
+          Switch->setDefaultDest(CaseIt->getCaseSuccessor());
+          Switch->removeCase(CaseIt);
+          break;
+        }
+      }
+    }
+
+    // Handle the simplification when `PlaceHolderTarget` is part the standard
+    // `case`s
+    for (auto CaseIt = Switch->case_begin(); CaseIt != Switch->case_end();) {
+      if (CaseIt->getCaseSuccessor() == PlaceHolderTarget) {
+
+        // We do not want to have a situation where the `PlaceHolderTarget` is
+        // both the `default` successor of a `switch` and one of its standard
+        // case
+        CaseIt = Switch->removeCase(CaseIt);
+      } else {
+        ++CaseIt;
+      }
+    }
+
+    // It should never be the case that we end up with a `switch` having only
+    // `PlaceHolderTarget` as its successor
+    if (Switch->getNumCases() == 0
+        and Switch->getDefaultDest() == PlaceHolderTarget) {
+      revng_abort();
+    }
+  }
+}
+
+/// Helper function which collects all the nodes reachable from a vector of
+/// nodes (`Successors`)
+static MapVector<BasicBlock *, SmallSet<BasicBlock *, 4>>
+getReachablesFromSuccessor(BasicBlock *N) {
+
+  using ScopeBlock = Scope<BasicBlock *>;
+  SetVector<BasicBlock *> Successors;
+  for (BasicBlock *Successor : children<ScopeBlock>(N)) {
+    Successors.insert(Successor);
+  }
+
+  MapVector<BasicBlock *, SmallSet<BasicBlock *, 4>> ReachablesFromSuccessor;
+  for (auto *Successor : Successors) {
+    SmallSet<BasicBlock *, 4> ReachableExits;
+
+    // Explore all the exits that are reachable from each Successor.
+    // For having a divergent exit, we need to find a set of
+    // successors that reach only the exit under analysis
+    auto &Reachables = ReachablesFromSuccessor[Successor];
+    for (auto *DFSNode : depth_first(Scope<BasicBlock *>(Successor))) {
+      if (isExit(DFSNode)) {
+        Reachables.insert(DFSNode);
+      }
+    }
+  }
+
+  return ReachablesFromSuccessor;
+}
+
+/// We define a `Descriptor` for the information needed to identify a
+/// `Divergence`. Specifically, the divergence is composed by the conditional
+/// where divergence originates, a set of divergent successors, and by the exit
+/// node which is divergent wrt. those divergent successors.
+struct DivergenceDescriptor {
+  BasicBlock *Conditional;
+  SmallSet<BasicBlock *, 4> DivergentSuccessors;
+  BasicBlock *Exit;
+};
+
+/// Helper function that tries to identify a `DivergenceDescriptor`
+static std::optional<DivergenceDescriptor>
+electDivergence(BasicBlock *Candidate,
+                BasicBlock *Exit,
+                DomTreeOnView<BasicBlock, Scope> &DomTree) {
+
+  // Check if it is the conditional making it a divergent node
+  if (isConditional(Candidate)) {
+    revng_assert(DomTree.dominates(Candidate, Exit));
+
+    MapVector<BasicBlock *, SmallSet<BasicBlock *, 4>>
+      ReachablesFromSuccessor = getReachablesFromSuccessor(Candidate);
+    size_t SuccessorsSize = ReachablesFromSuccessor.size();
+
+    SmallSet<BasicBlock *, 4> DivergentSuccessors;
+    for (const auto &[Successor, ReachableExits] : ReachablesFromSuccessor) {
+      if (ReachableExits.size() == 1 and *ReachableExits.begin() == Exit) {
+        DivergentSuccessors.insert(Successor);
+      } else if (ReachableExits.contains(Exit)) {
+
+        // If we reach `Exit` from a successor which is not a candidate for
+        // being divergent, it means that `Exit` is reached also by a non
+        // divergent successor, and this contradicts the definition, so we
+        // cannot find a divergence here, and we return a `nullopt`
+        return std::nullopt;
+      }
+    }
+
+    // We proceed only if there are some divergent exits and some
+    // non divergent exits, it doesn't make sense to transform a situation where
+    // all the edges are all divergent or all non-divergent
+    if (DivergentSuccessors.size() < SuccessorsSize) {
+
+      // We employ this `std::optional` as return value, in order to signal if
+      // we identified a candidate for IDS
+      return DivergenceDescriptor{ Candidate, DivergentSuccessors, Exit };
+    }
+  }
+
+  // When no divergence was found, we signal it by returning `nullopt`
+  return std::nullopt;
+}
+
+/// Helper function that performs the IDS transformation
+static void performIDS(DivergenceDescriptor &DivergenceDescriptor,
+                       BasicBlock *PlaceHolderTarget) {
+
+  // Create the new `BasicBlock` representing the `C'` conditional
+  // inserted by the IDS transformation. We will refer to this block as the
+  // `Tail` (of the IDS group of nodes).
+  BasicBlock *Conditional = DivergenceDescriptor.Conditional;
+  auto DivergentSuccessors = DivergenceDescriptor.DivergentSuccessors;
+  BasicBlock *Exit = DivergenceDescriptor.Exit;
+  LLVMContext &Context = getContext(Conditional);
+  Function *F = Conditional->getParent();
+  BasicBlock *Tail = BasicBlock::Create(Context,
+                                        Conditional->getName() + "_ids",
+                                        F);
+
+  revng_assert(Tail->empty());
+
+  // We clone the terminator already present in `BasicBlock` `Conditional`, so
+  // that a superset of the correct final successors are already connected to
+  // `Tail`.
+  Instruction *ConditionalTerminator = Conditional->getTerminator();
+  Instruction *TailTerminator = ConditionalTerminator->clone();
+  IRBuilder<> TailBuilder(Tail);
+  TailBuilder.Insert(TailTerminator);
+
+  // We connect the `Conditional` to `Tail`, by making sure that all
+  // the previous slots and cases going to the nondivergent exits, are now
+  // connected to the `Tail` block, in order to preserve the original semantics.
+  // The original paths going to the nondivergent exits, are preserved by the
+  // the fact that the `Terminator` has been cloned into `Tail`.
+  SmallVector<BasicBlock *> NonDivergentSuccessors;
+  for (BasicBlock *Successor : children<Scope<BasicBlock *>>(Conditional)) {
+    if (not DivergentSuccessors.contains(Successor)) {
+      NonDivergentSuccessors.push_back(Successor);
+    }
+  }
+  revng_assert(not DivergentSuccessors.empty()
+               and not NonDivergentSuccessors.empty());
+  for (BasicBlock *Successor : NonDivergentSuccessors) {
+    ConditionalTerminator->replaceSuccessorWith(Successor, Tail);
+  }
+
+  // We remove from the `Terminator` of `Tail`, all the edges that
+  // target `DivergentSuccessor`, since it will be only reached by
+  // `Conditional`. We do this in two steps, we first substitute the original
+  // successor with `PlaceHolderTarget`, and then we invoke
+  // `simplifyTerminator`, which will take care of simplifying away the
+  // unnecessary successors, both for `brcond`s and `switch`es.
+  for (BasicBlock *Successor : DivergentSuccessors) {
+    TailTerminator->replaceSuccessorWith(Successor, PlaceHolderTarget);
+  }
+  simplifyTerminator(Tail, PlaceHolderTarget);
+
+  // We add a `scope_closer` edge between the divergent exit node and
+  // the `Tail` node
+  ScopeGraphBuilder SGBuilder(F);
+  SGBuilder.addScopeCloser(Exit, Tail);
+}
+
+/// This helper function is used to attempt the IDS process, and returns `true`
+/// or `false` depending on whether a change is performed
+static bool tryIDS(Function &F, BasicBlock *PlaceHolderTarget) {
+
+  // The main need for recomputing the `DomTree` is that we insert the new
+  // `IDS` block and redirect edges over the `ScopeGraph`
+  DomTreeOnView<BasicBlock, Scope> DomTree;
+  DomTree.recalculate(F);
+
+  // Collect the exit nodes
+  SmallVector<BasicBlock *> Exits = getExits(F, PlaceHolderTarget);
+
+  // Attempt IDS on each exit node
+  for (BasicBlock *Exit : Exits) {
+
+    // Here we go up in the `ScopeGraph`, hopping through the immediate
+    // dominators of the `Exit` block with the goal of finding the divergent
+    // conditional
+    BasicBlock *Candidate = Exit;
+    while ((Candidate = getImmediateDominator(Candidate, DomTree))) {
+
+      // We use the following `std::optional` in order to contain the
+      // divergent node candidate, with all the object needed to perform the
+      // transformation
+      std::optional<DivergenceDescriptor>
+        DivergenceDescriptor = electDivergence(Candidate, Exit, DomTree);
+
+      // If we have found a divergence for the exit under analysis, we proceed
+      // to perform IDS
+      if (DivergenceDescriptor) {
+        performIDS(*DivergenceDescriptor, PlaceHolderTarget);
+
+        // Empirically, we have found that restarting the analysis, by
+        // recollecting the exit nodes in the `ScopeGraph`, is faster than
+        // continuing with the processing of all the exits already collected.
+        // Therefore, we should not really try to optimize this, unless we
+        // find new evidence that this is better.
+        return true;
+      }
+    }
+  }
+
+  // If no change has been performed, we return `false` to signal this fact
+  return false;
+}
+
+/// Implementation class used to run the `IDS` transformation
+class InlineDivergentScopesImpl {
+  Function &F;
+
+public:
+  InlineDivergentScopesImpl(Function &F) : F(F) {}
+
+public:
+  bool run() {
+
+    // We keep a boolean variable to track whether the `Function` was modified
+    bool FunctionModified = false;
+
+    // Manager object for the creation and deletion of the `PlaceHolderTarget`
+    PlaceHolderTargetManager PlaceHolderTarget(F);
+
+    // Every time we perform a change due to the IDS restructuring, we may have
+    // unlocked the potential to perform new IDS closures in nested subtree
+    // where the last modification was performed, therefore we need to retry
+    // IDS. Empirically, we have found that restarting the analysis, by
+    // recollecting the exit nodes in the `ScopeGraph`, is faster than
+    // continuing with the processing of all the exits already collected.
+    // Therefore, we should not really try to optimize this, unless we find new
+    // evidence that this is better.
+    while (tryIDS(F, *PlaceHolderTarget)) {
+
+      // As soon as one IDS change is performed, we mark the current `Function`
+      // as modified
+      FunctionModified = true;
+    }
+
+    return FunctionModified;
+  }
+};
+
+char InlineDivergentScopesPass::ID = 0;
+static constexpr const char *Flag = "inline-divergent-scopes";
+using Reg = llvm::RegisterPass<InlineDivergentScopesPass>;
+static Reg X(Flag,
+             "Perform the inline of divergent scopes canonicalization process");
+
+bool InlineDivergentScopesPass::runOnFunction(llvm::Function &F) {
+
+  // Instantiate and call the `Impl` class
+  InlineDivergentScopesImpl IDSImpl(F);
+  bool FunctionModified = IDSImpl.run();
+
+  // This pass may transform the CFG by assign some blocks to perform the IDS
+  // canonicalization and by redirecting edges on the `ScopeGraph`
+  return FunctionModified;
+}
+
+void InlineDivergentScopesPass::getAnalysisUsage(llvm::AnalysisUsage &AU)
+  const {
+  // This pass does not preserve the CFG
+}

--- a/lib/RestructureCFG/SelectScopePass.cpp
+++ b/lib/RestructureCFG/SelectScopePass.cpp
@@ -1,0 +1,294 @@
+//
+// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/GenericDomTree.h"
+
+#include "revng/ADT/ReversePostOrderTraversal.h"
+#include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
+#include "revng/RestructureCFG/ScopeGraphUtils.h"
+#include "revng/RestructureCFG/SelectScopePass.h"
+#include "revng/Support/Debug.h"
+#include "revng/Support/GraphAlgorithms.h"
+#include "revng/Support/IRHelpers.h"
+
+using namespace llvm;
+
+// Debug logger
+static Logger<> Log("select-scope");
+
+static SetVector<BasicBlock *> getConditionalSuccessors(BasicBlock *N) {
+  // We employ a `SetVector` so that we do not take into account
+  // multiplicity for edges out of a conditional
+  SetVector<BasicBlock *> ConditionalSuccessors;
+  for (BasicBlock *Successor : children<Scope<BasicBlock *>>(N)) {
+    ConditionalSuccessors.insert(Successor);
+  }
+
+  return ConditionalSuccessors;
+}
+
+static SetVector<BasicBlock *> getPredecessors(BasicBlock *N) {
+  // It is important that we use a `SetVector` here in order to
+  // deduplicate the successors outputted by the `llvm::children` range
+  // iterator
+  SetVector<BasicBlock *> Predecessors;
+  for (auto *Predecessor : children<Inverse<Scope<BasicBlock *>>>(N)) {
+    revng_log(Log, "  Predecessor: " + Predecessor->getName().str());
+    Predecessors.insert(Predecessor);
+  }
+
+  return Predecessors;
+}
+
+static SmallVector<BasicBlock *> getNodesToProcess(BasicBlock *Conditional,
+                                                   BasicBlock *PostDominator) {
+  // We exploit the `Visited` set, by passing it to
+  // `ReversePostOrderTraversalExt`, in order to stop the visit at the
+  // `PostDominator`
+  std::set<BasicBlock *> Visited;
+  Visited.insert(PostDominator);
+
+  // We collect all the nodes between the `Conditional` and its
+  // immediate postdominator, by using the `ReversePostOrderTraversalExt`
+  SmallVector<BasicBlock *> NodesToProcess;
+  for (BasicBlock *RPONode :
+       ReversePostOrderTraversalExt<Scope<BasicBlock *>>(Conditional,
+                                                         Visited)) {
+    NodesToProcess.push_back(RPONode);
+  }
+
+  // From the collected nodes, we need to remove the first node, which
+  // corresponds to the `Conditional`, which should not be processed in this
+  // round
+  revng_assert(NodesToProcess.front() == Conditional);
+  NodesToProcess.erase(NodesToProcess.begin());
+
+  return NodesToProcess;
+}
+
+static std::map<BasicBlock *, size_t>
+initializeScopeMap(SetVector<BasicBlock *> &ConditionalSuccessors) {
+  std::map<BasicBlock *, size_t> ScopeMap;
+
+  // We initialize the `ScopeMap` for each `ConditionalSuccessor`
+  for (const auto &[Index, ConditionalSuccessor] :
+       enumerate(ConditionalSuccessors)) {
+    if (not ScopeMap.contains(ConditionalSuccessor)) {
+      ScopeMap[ConditionalSuccessor] = Index;
+    }
+  }
+  return ScopeMap;
+}
+
+/// Helper function used to elect the `ScopeID` for a node, electing the
+/// `ScopeID` for which we have the highest number of predecessors having such
+/// `ScopeID`
+static size_t electMaxScopeID(SetVector<BasicBlock *> &Predecessors,
+                              std::map<BasicBlock *, size_t> &ScopeMap) {
+  // In the map, we store the how frequent a `ScopeID` is in the
+  // predecessors of `Candidate`, in order to elect the one with the most
+  // common `ScopeID`
+  DenseMap<size_t, size_t> PredecessorsScopeCounter;
+  for (auto *Predecessor : Predecessors) {
+    auto ScopeMapIt = ScopeMap.find(Predecessor);
+    if (ScopeMapIt != ScopeMap.end()) {
+      size_t PredecessorScopeID = ScopeMapIt->second;
+      PredecessorsScopeCounter[PredecessorScopeID]++;
+    }
+  }
+
+  // We must have found at least a predecessor with an assigned `ScopeID`
+  revng_assert(PredecessorsScopeCounter.size() > 0);
+
+  // We elect the `ScopeID` for which we have the maximum number of predecessors
+  // having such `ScopeID`
+  size_t MaxOccurencies = PredecessorsScopeCounter.begin()->second;
+  size_t MaxScopeID = PredecessorsScopeCounter.begin()->first;
+  for (const auto &[Key, Value] : PredecessorsScopeCounter) {
+    if (Value > MaxOccurencies) {
+      MaxOccurencies = Value;
+      MaxScopeID = Key;
+    }
+  }
+
+  return MaxScopeID;
+}
+
+class SelectScopePassImpl {
+  Function &F;
+  PostDomTreeOnView<BasicBlock, Scope> PDT;
+
+  // We keep a boolean field to track whether the `Function` was modified
+  bool FunctionModified = false;
+
+public:
+  SelectScopePassImpl(Function &F) : F(F) {}
+
+public:
+  void processConditionalNode(BasicBlock *ConditionalNode) {
+    SetVector<BasicBlock *>
+      ConditionalSuccessors = getConditionalSuccessors(ConditionalNode);
+
+    // We skip all the nodes which are not conditional
+    if (ConditionalSuccessors.size() <= 1) {
+      return;
+    }
+
+    revng_log(Log,
+              "Processing conditional " << ConditionalNode->getName().str()
+                                        << "\n");
+
+    BasicBlock *PostDominator = PDT[ConditionalNode]->getIDom()->getBlock();
+    revng_assert(PostDominator);
+    revng_log(Log,
+              "The identified postdominator is "
+                << PostDominator->getName().str() << "\n");
+
+    SmallVector<BasicBlock *>
+      NodesToProcess = getNodesToProcess(ConditionalNode, PostDominator);
+    revng_log(Log,
+              "Nodes between conditional and its postdominator, in reverse "
+              "post order:\n");
+    for (auto DFSNode : NodesToProcess) {
+      revng_log(Log, "  " << DFSNode->getName().str());
+    }
+
+    // Initialize the `ScopeMap`
+    std::map<BasicBlock *, size_t>
+      ScopeMap = initializeScopeMap(ConditionalSuccessors);
+
+    // Process each node in the zone of interest
+    for (BasicBlock *Candidate : NodesToProcess) {
+      revng_log(Log,
+                "Analyzing candidate: " + Candidate->getName().str() << "\n");
+
+      // We precompute the predecessors to avoid invalidation due to graph
+      // changes. It is fundamental that we always traverse the `ScopeGraph`
+      // view of the CFG, or we may end up with some inconsistencies in terms
+      // of the visited nodes.
+      revng_log(Log, "The candidate predecessors are:\n");
+      SetVector<BasicBlock *> Predecessors = getPredecessors(Candidate);
+
+      // `Candidate`, could be itself a immediate successor of a conditional
+      // node, and therefore correspond to a `ScopeID`. We therefore need to
+      // take into consideration it when assigning the final scope for each
+      // `Candidate`.
+      // We can do this by always enqueuing `Candidate` as a predecessor of
+      // itself, this can lead to two situations:
+      // 1) `Candidate` is not a successor of the conditional, therefore no
+      //    corresponding entry in `ScopeMap` will be present, and this
+      //    will not influence the decision on the `ScopeID` which will be
+      //    finally assigned.
+      // 2) `Candidate` is a successor of the conditional, therefore a
+      //    corresponding entry in `ScopeMap` will be present, and it
+      //    will be correctly taken into account for the `ScopeID` decision
+      //    process.
+      // Alternatively, we could pre-assign the `ScopeID`, in the
+      // `ScopeMap`, for each successor of a conditional node during
+      // the initialization. This, however, would tie us to the decision of
+      // always assigning the successor of a conditional node to the `ScopeID`
+      // opening in the successor itself, while, in principle, we could
+      // alternatively disconnect the edge connecting the conditional and the
+      // successor, by making it a `goto` edge.
+      Predecessors.insert(Candidate);
+
+      std::optional<size_t> ElectedScopeID;
+
+      // If we already assigned the `ScopeID` for the current node, we maintain
+      // that one. This is necessary for the `Candidate`s that are successors of
+      // the `ConditionalNode` itself, for which the decision is mandatory
+      // (being assigned to the `ScopeID` they themselves open).
+      auto CandidateScopeMapIt = ScopeMap.find(Candidate);
+      if (CandidateScopeMapIt != ScopeMap.end()) {
+        ElectedScopeID = CandidateScopeMapIt->second;
+      } else {
+
+        // We elect the `ScopeID` for `Candidate` electing the `ScopeID` for
+        // which we have the maximum number of predecessors having a certain
+        // `ScopeID`
+        ElectedScopeID = electMaxScopeID(Predecessors, ScopeMap);
+      }
+      revng_assert(ElectedScopeID);
+
+      for (auto *Predecessor : Predecessors) {
+        auto ScopeMapIt = ScopeMap.find(Predecessor);
+
+        // We may have two situations: 1) There is an entry for `Predecessor`
+        // in the `ScopeMap`, it means that there is a path connecting
+        // the `Conditional` and `Candidate`. 2) There is no entry for
+        // `Predecessor`, therefore such node wasn't visited during the
+        // current exploration of the zone of interest, and therefore it does
+        // not lie on any path between the `Conditional` and the
+        // `Candidate` node.
+        if (ScopeMapIt != ScopeMap.end()) {
+          size_t PredecessorScopeID = ScopeMapIt->second;
+
+          // If the `PredecessorScopeID` is different from the one already
+          // assigned to `Candidate`, we need to transform the edge into a
+          // `goto` edge, in order to respect the decidedness definition.
+          if (PredecessorScopeID != ElectedScopeID) {
+            ScopeGraphBuilder SGBuilder(&F);
+            SGBuilder.makeGotoEdge(Predecessor, Candidate);
+
+            // We mark the CFG as modified
+            FunctionModified = true;
+          }
+        }
+      }
+
+      // We insert in the `ScopeMap` a new entry once we assigned the
+      // final `ScopeID` to `Candidate`, reflecting the final `ScopeID` that
+      // we elected in the above process
+      ScopeMap[Candidate] = *ElectedScopeID;
+    }
+  }
+
+  bool run() {
+    Scope<Function *> ScopeGraph(&F);
+
+    // We compute the `PostDominatorTree` at the beginning of the pass, and we
+    // do not update it, as per design, in order not to take into consideration
+    // the changing PDT (changes caused by insertion of new exit nodes,
+    // represented by the `goto` blocks)
+    PDT.recalculate(F);
+
+    // We iterate over the conditional nodes in the `ScopeGraph` in post order,
+    // and we apply the `SelectScope` transformation for each conditional
+    for (BasicBlock *ConditionalNode : post_order(ScopeGraph)) {
+      processConditionalNode(ConditionalNode);
+    }
+
+    return FunctionModified;
+  }
+};
+
+char SelectScopePass::ID = 0;
+static constexpr const char *Flag = "select-scope";
+using Reg = llvm::RegisterPass<SelectScopePass>;
+static Reg X(Flag, "Perform the SelectScope pass on the ScopeGraph");
+
+bool SelectScopePass::runOnFunction(llvm::Function &F) {
+
+  // Instantiate and call the `Impl` class
+  SelectScopePassImpl SelectScopeImpl(F);
+  bool FunctionModified = SelectScopeImpl.run();
+
+  // This pass may change the CFG by transforming some edges into `goto` edges,
+  // therefore creating some additional `goto_block`s. We propagate the
+  // information computed by the `Impl` class.
+  return FunctionModified;
+}
+
+void SelectScopePass::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+  // This pass does not preserve the CFG
+}

--- a/share/revng/pipelines/revng-pipelines.yml
+++ b/share/revng/pipelines/revng-pipelines.yml
@@ -676,6 +676,12 @@ Branches:
               - dce
               - exit-ssa
               - switch-to-statements
+              - dagify
+              - inline-divergent-scopes
+              - enforce-single-exit
+              - select-scope
+              - inline-divergent-scopes
+              - enforce-single-exit
         Artifacts:
           Container: module.bc.zstd
           Kind: stack-accesses-segregated

--- a/tests/unit/llvm_lit_tests/EnforceSingleExit.ll
+++ b/tests/unit/llvm_lit_tests/EnforceSingleExit.ll
@@ -2,7 +2,7 @@
 ; This file is distributed under the MIT License. See LICENSE.md for details.
 ;
 
-; RUN: %revngopt %s -ese -S -o - | FileCheck %s
+; RUN: %revngopt %s -enforce-single-exit -S -o - | FileCheck %s
 
 ; function tags metadata needed for all the tests
 declare !revng.tags !0 void @scope-closer(ptr)

--- a/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
+++ b/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
@@ -1,0 +1,86 @@
+;
+; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+;
+
+; RUN: %revngopt %s -inline-divergent-scopes -S -o - | FileCheck %s
+
+; function tags metadata needed for all the tests
+declare !revng.tags !0 void @scope-closer(ptr)
+declare !revng.tags !1 void @goto-block()
+!0 = !{!"scope-closer"}
+!1 = !{!"goto-block"}
+
+; IDS on if test
+
+define void @f(i1 noundef %a, i1 noundef %b) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_c:
+  br i1 %b, label %block_b, label %block_e
+
+block_b:
+  ret void
+
+block_e:
+  ret void
+}
+
+; CHECK-LABEL: define void @f(i1 noundef %a, i1 noundef %b)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_c:
+; CHECK-NEXT:   br i1 %b, label %block_c_ids, label %block_e
+; CHECK: block_b:
+; CHECK-NEXT:   ret void
+; CHECK: block_e:
+; CHECK-NEXT:   call void @scope-closer(ptr blockaddress(@f, %block_c_ids))
+; CHECK-NEXT:   ret void
+; CHECK: block_c_ids:
+; CHECK-NEXT:   br label %block_b
+
+define void @g(i1 noundef %a, i32 noundef %b) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_c:
+  switch i32 %b, label %block_b [
+    i32 0, label %block_e
+    i32 1, label %block_f
+  ]
+
+block_b:
+  ret void
+
+block_e:
+  ret void
+
+block_f:
+  ret void
+}
+
+; CHECK: define void @g(i1 noundef %a, i32 noundef %b)
+; CHECK: block_a:
+; CHECK:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_c:
+; CHECK:   switch i32 %b, label %block_c_ids [
+; CHECK:     i32 0, label %block_e
+; CHECK:     i32 1, label %block_c_ids
+; CHECK:   ]
+; CHECK: block_b:
+; CHECK:   ret void
+; CHECK: block_e:
+; CHECK:   call void @scope-closer(ptr blockaddress(@g, %block_c_ids))
+; CHECK:   ret void
+; CHECK: block_f:
+; CHECK:   call void @scope-closer(ptr blockaddress(@g, %block_c_ids_ids))
+; CHECK:   ret void
+; CHECK: block_c_ids:
+; CHECK:   switch i32 %b, label %block_c_ids_ids [
+; CHECK:     i32 1, label %block_f
+; CHECK:   ]
+; CHECK: block_c_ids_ids:
+; CHECK:   switch i32 %b, label %block_b [
+; CHECK:   ]

--- a/tests/unit/llvm_lit_tests/SelectScope.ll
+++ b/tests/unit/llvm_lit_tests/SelectScope.ll
@@ -1,0 +1,240 @@
+;
+; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+;
+
+; RUN: %revngopt %s -select-scope -S -o - | FileCheck %s
+
+; function tags metadata needed for all the tests
+declare !revng.tags !0 void @scope-closer(ptr)
+declare !revng.tags !1 void @goto-block()
+!0 = !{!"scope-closer"}
+!1 = !{!"goto-block"}
+
+; decided diamond test
+
+define void @f(i1 noundef %a) {
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br label %block_d
+
+block_d:
+  br label %block_f
+
+block_c:
+  br label %block_e
+
+block_e:
+  br label %block_f
+
+block_f:
+  ret void
+}
+
+; CHECK-LABEL: define void @f(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_d:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_e
+; CHECK: block_e:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_f:
+; CHECK-NEXT:   ret void
+
+; crossed diamonds test
+
+define void @g(i1 noundef %a, i1 noundef %b, i1 noundef %c) {
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br i1 %b, label %block_d, label %block_e
+
+block_d:
+  br label %block_f
+
+block_c:
+  br i1 %c, label %block_e, label %block_d
+
+block_e:
+  br label %block_f
+
+block_f:
+  ret void
+}
+
+; CHECK-LABEL: define void @g(i1 noundef %a, i1 noundef %b, i1 noundef %c)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br i1 %b, label %block_d, label %block_e
+; CHECK: block_d:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_c:
+; CHECK-NEXT:   br i1 %c, label %goto_block_e, label %goto_block_d
+; CHECK: block_e:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_f:
+; CHECK-NEXT:   ret void
+; CHECK: goto_block_e:
+; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   br label %block_e
+; CHECK: goto_block_d:
+; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   br label %block_d
+
+; double edge if test
+
+define void @h(i1 noundef %a) {
+block_a:
+  br i1 %a, label %block_b, label %block_b
+
+block_b:
+  br label %block_c
+
+block_c:
+  ret void
+}
+
+; CHECK-LABEL: define void @h(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_b
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_c
+; CHECK: block_c:
+; CHECK-NEXT:   ret void
+
+; double edge switch test
+
+define void @i(i1 noundef %a) {
+block_a:
+  switch i1 %a, label %block_b [
+    i1 0, label %block_c
+    i1 1, label %block_c
+  ]
+
+block_b:
+  br label %block_d
+
+block_c:
+  br label %block_d
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @i(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   switch i1 %a, label %block_b [
+; CHECK-NEXT:     i1 false, label %block_c
+; CHECK-NEXT:     i1 true, label %block_c
+; CHECK-NEXT:   ]
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_d:
+; CHECK-NEXT:   ret void
+
+; short-circuit test
+
+define void @l(i1 noundef %a, i1 noundef %b) {
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br i1 %b, label %block_d, label %block_e
+
+block_d:
+  br label %block_f
+
+block_c:
+  br label %block_e
+
+block_e:
+  br label %block_f
+
+block_f:
+  ret void
+}
+
+; CHECK-LABEL: define void @l(i1 noundef %a, i1 noundef %b)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br i1 %b, label %block_d, label %block_e
+; CHECK: block_d:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_c:
+; CHECK-NEXT:   br label %goto_block_e
+; CHECK: block_e:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_f:
+; CHECK-NEXT:   ret void
+; CHECK: goto_block_e:
+; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   br label %block_e
+
+; short-circuit with decided tail
+
+define void @m(i1 noundef %a, i1 noundef %b, i1 noundef %c) {
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br i1 %b, label %block_d, label %block_e
+
+block_d:
+  br label %block_f
+
+block_c:
+  br label %block_e
+
+block_e:
+  br label %block_f
+
+block_f:
+  br label %block_g
+
+block_g:
+  br i1 %c, label %block_h, label %block_i
+
+block_h:
+  br label %block_l
+
+block_i:
+  br label %block_l
+
+block_l:
+  ret void
+}
+
+; CHECK: define void @m(i1 noundef %a, i1 noundef %b, i1 noundef %c)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br i1 %b, label %block_d, label %block_e
+; CHECK: block_d:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_c:
+; CHECK-NEXT:   br label %goto_block_e
+; CHECK: block_e:
+; CHECK-NEXT:   br label %block_f
+; CHECK: block_f:
+; CHECK-NEXT:   br label %block_g
+; CHECK: block_g:
+; CHECK-NEXT:   br i1 %c, label %block_h, label %block_i
+; CHECK: block_h:
+; CHECK-NEXT:   br label %block_l
+; CHECK: block_i:
+; CHECK-NEXT:   br label %block_l
+; CHECK: block_l:
+; CHECK-NEXT:   ret void
+; CHECK: goto_block_e:
+; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   br label %block_e


### PR DESCRIPTION
Introduce `select-scope` and `inline-divergent-scopes` passes, which, when run in sequence, amount to `DecideWithGotos`.

- `select-scope` is in charge of enforcing the relative decidedness property for all the nodes in the `ScopeGraph`, wrt. to all the conditional nodes. It does this by applying the definition, electing one scope for each conditional node in the graph, and by transforming all the edges that would violate the property into `goto` edges.
- `inline-divergent-scopes` is in charge of reconstructing a single exit `ScopeGraph`, starting from the state left by `select-scope`, where each `goto` edge, by construction, left a _dandling_ exit node (the `goto` node itself). We have the guarantee that `inline-divergent-scopes` is able to remove all the exit nodes left around by `select-scope`.