### PR TITLE
Introduce the MaterializeTrivialGoto pass

### DIFF
--- a/include/revng/ADT/EagerMaterializationRangeIterator.h
+++ b/include/revng/ADT/EagerMaterializationRangeIterator.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include <compare>

--- a/include/revng/RestructureCFG/DAGifyPass.h
+++ b/include/revng/RestructureCFG/DAGifyPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/include/revng/RestructureCFG/EnforceSingleExitPass.h
+++ b/include/revng/RestructureCFG/EnforceSingleExitPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/include/revng/RestructureCFG/GenericRegion.h
+++ b/include/revng/RestructureCFG/GenericRegion.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include <map>

--- a/include/revng/RestructureCFG/GenericRegionInfo.h
+++ b/include/revng/RestructureCFG/GenericRegionInfo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include <map>

--- a/include/revng/RestructureCFG/GenericRegionPass.h
+++ b/include/revng/RestructureCFG/GenericRegionPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/include/revng/RestructureCFG/InlineDivergentScopesPass.h
+++ b/include/revng/RestructureCFG/InlineDivergentScopesPass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/include/revng/RestructureCFG/MaterializeTrivialGotoPass.h
+++ b/include/revng/RestructureCFG/MaterializeTrivialGotoPass.h
@@ -1,0 +1,20 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+class MaterializeTrivialGotoPass : public llvm::FunctionPass {
+public:
+  static char ID;
+
+public:
+  MaterializeTrivialGotoPass() : llvm::FunctionPass(ID) {}
+
+  bool runOnFunction(llvm::Function &F) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+};

--- a/include/revng/RestructureCFG/ScopeGraphAlgorithms.h
+++ b/include/revng/RestructureCFG/ScopeGraphAlgorithms.h
@@ -1,0 +1,22 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/SetVector.h"
+#include "llvm/IR/BasicBlock.h"
+
+/// Helper function to retrieve the successors of a block on the `ScopeGraph`
+llvm::SmallSetVector<llvm::BasicBlock *, 2>
+getScopeGraphSuccessors(llvm::BasicBlock *N);
+
+/// Helper function to retrieve the predecessors of a block on the `ScopeGraph`
+llvm::SmallSetVector<llvm::BasicBlock *, 2>
+getScopeGraphPredecessors(llvm::BasicBlock *N);
+
+/// Helper function to collect all the nodes, on the `ScopeGraph`, between a
+/// block and its immediate postdominator, using a _dfs_ext`
+llvm::SmallVector<llvm::BasicBlock *>
+getNodesInScope(llvm::BasicBlock *ScopeEntryBlock,
+                llvm::BasicBlock *PostDominator);

--- a/include/revng/RestructureCFG/ScopeGraphAlgorithms.h
+++ b/include/revng/RestructureCFG/ScopeGraphAlgorithms.h
@@ -20,3 +20,7 @@ getScopeGraphPredecessors(llvm::BasicBlock *N);
 llvm::SmallVector<llvm::BasicBlock *>
 getNodesInScope(llvm::BasicBlock *ScopeEntryBlock,
                 llvm::BasicBlock *PostDominator);
+
+/// Helper function which verifies the decidedness of the `ScopeGraph`
+/// employing the _absolute decidedness_ definition
+bool isScopeGraphDecided(llvm::Function &F);

--- a/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
+++ b/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
+++ b/include/revng/RestructureCFG/ScopeGraphGraphTraits.h
@@ -20,6 +20,8 @@
 #include "revng/Support/Tag.h"
 #include "revng/Yield/FunctionEdgeType.h"
 
+namespace detail {
+
 // We use a template here in order to instantiate `BlockType` both as
 // `BasicBlock *` and `const BasicBlock *`
 template<ConstOrNot<llvm::BasicBlock> BlockType>
@@ -75,6 +77,8 @@ inline llvm::SmallVector<BlockType *> getScopeGraphPredecessors(BlockType *BB) {
   return Predecessors;
 }
 
+} // namespace detail
+
 /// This class is used as a marker class to tell the graph iterator to treat the
 /// underlying graph as a scope graph, i.e., considering also the scope closer
 /// edges as actual edges, and ignoring the goto edges. We require `GraphType`
@@ -101,7 +105,7 @@ public:
 public:
   static ChildIteratorType child_begin(NodeRef N) {
     return EagerMaterializationRangeIterator<
-      llvm::BasicBlock *>(getScopeGraphSuccessors(N));
+      llvm::BasicBlock *>(::detail::getScopeGraphSuccessors(N));
   }
 
   static ChildIteratorType child_end(NodeRef N) {
@@ -127,7 +131,7 @@ public:
 public:
   static ChildIteratorType child_begin(NodeRef N) {
     return EagerMaterializationRangeIterator<
-      const llvm::BasicBlock *>(getScopeGraphSuccessors(N));
+      const llvm::BasicBlock *>(::detail::getScopeGraphSuccessors(N));
   }
 
   static ChildIteratorType child_end(NodeRef N) {
@@ -155,7 +159,7 @@ public:
 public:
   static ChildIteratorType child_begin(NodeRef N) {
     return EagerMaterializationRangeIterator<
-      llvm::BasicBlock *>(getScopeGraphPredecessors(N));
+      llvm::BasicBlock *>(::detail::getScopeGraphPredecessors(N));
   }
 
   static ChildIteratorType child_end(NodeRef N) {
@@ -183,7 +187,7 @@ public:
 public:
   static ChildIteratorType child_begin(NodeRef N) {
     return EagerMaterializationRangeIterator<
-      const llvm::BasicBlock *>(getScopeGraphPredecessors(N));
+      const llvm::BasicBlock *>(::detail::getScopeGraphPredecessors(N));
   }
 
   static ChildIteratorType child_end(NodeRef N) {

--- a/include/revng/RestructureCFG/ScopeGraphUtils.h
+++ b/include/revng/RestructureCFG/ScopeGraphUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "revng/ADT/Concepts.h"

--- a/include/revng/RestructureCFG/ScopeGraphUtils.h
+++ b/include/revng/RestructureCFG/ScopeGraphUtils.h
@@ -42,7 +42,12 @@ public:
 
 public:
   void makeGoto(llvm::BasicBlock *GotoBlock);
+  void eraseGoto(llvm::BasicBlock *GotoBlock);
   void addScopeCloser(llvm::BasicBlock *Source, llvm::BasicBlock *Target);
+
+  /// Helper method which erase a `scope_closer`, and returns the block which
+  /// was target of the `scope_closer`
+  llvm::BasicBlock *eraseScopeCloser(llvm::BasicBlock *Source);
 
   /// With the usage of this helper,  all the successor in the `Terminator` of
   /// the `Source` block pointing to `Target` will be redirected to the newly
@@ -51,11 +56,18 @@ public:
                                  llvm::BasicBlock *Target);
 };
 
-llvm::SmallVector<const llvm::Instruction *, 2>
-getLast2InstructionsBeforeTerminator(const llvm::BasicBlock *BB);
+template<ConstOrNot<llvm::BasicBlock> BasicBlockType>
+llvm::SmallVector<std::conditional_t<std::is_const_v<BasicBlockType>,
+                                     const llvm::Instruction,
+                                     llvm::Instruction> *,
+                  2>
+getLast2InstructionsBeforeTerminator(BasicBlockType *BB);
 
 /// Helper function to retrieve the `BasicBlock` target of the marker
 llvm::BasicBlock *getScopeCloserTarget(const llvm::BasicBlock *BB);
+
+/// Helper function to determine if `BB` contains a `scope_closer` marker
+bool isScopeCloserBlock(const llvm::BasicBlock *BB);
 
 /// Helper function to determine if `BB` contains a `goto_block` marker
 bool isGotoBlock(const llvm::BasicBlock *BB);

--- a/include/revng/RestructureCFG/SelectScopePass.h
+++ b/include/revng/RestructureCFG/SelectScopePass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/lib/FunctionIsolation/StripDebugInfoFromHelpers.cpp
+++ b/lib/FunctionIsolation/StripDebugInfoFromHelpers.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/DebugInfo.h"

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -26,6 +26,7 @@ revng_add_analyses_library_internal(
   RegionCFGTree.cpp
   RemoveDeadCode.cpp
   RestructureCFG.cpp
+  ScopeGraphAlgorithms.cpp
   SelectScopePass.cpp
   SimplifyCompareNode.cpp
   SimplifyDualSwitch.cpp

--- a/lib/RestructureCFG/CMakeLists.txt
+++ b/lib/RestructureCFG/CMakeLists.txt
@@ -21,6 +21,7 @@ revng_add_analyses_library_internal(
   GenericRegionPass.cpp
   InlineDispatcherSwitch.cpp
   InlineDivergentScopesPass.cpp
+  MaterializeTrivialGotoPass.cpp
   MetaRegion.cpp
   PromoteCallNoReturn.cpp
   RegionCFGTree.cpp

--- a/lib/RestructureCFG/DAGifyPass.cpp
+++ b/lib/RestructureCFG/DAGifyPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/GraphTraits.h"

--- a/lib/RestructureCFG/EnforceSingleExitPass.cpp
+++ b/lib/RestructureCFG/EnforceSingleExitPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/GraphTraits.h"

--- a/lib/RestructureCFG/GenericRegionInfo.cpp
+++ b/lib/RestructureCFG/GenericRegionInfo.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/lib/RestructureCFG/GenericRegionPass.cpp
+++ b/lib/RestructureCFG/GenericRegionPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "revng/RestructureCFG/GenericRegionInfo.h"

--- a/lib/RestructureCFG/InlineDivergentScopesPass.cpp
+++ b/lib/RestructureCFG/InlineDivergentScopesPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/SmallVector.h"

--- a/lib/RestructureCFG/MaterializeTrivialGotoPass.cpp
+++ b/lib/RestructureCFG/MaterializeTrivialGotoPass.cpp
@@ -1,0 +1,134 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/IR/Function.h"
+#include "llvm/Support/GenericDomTree.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+#include "revng/ADT/ReversePostOrderTraversal.h"
+#include "revng/RestructureCFG/MaterializeTrivialGotoPass.h"
+#include "revng/RestructureCFG/ScopeGraphAlgorithms.h"
+#include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
+#include "revng/RestructureCFG/ScopeGraphUtils.h"
+#include "revng/Support/Debug.h"
+#include "revng/Support/GraphAlgorithms.h"
+
+using namespace llvm;
+
+// Debug logger
+Logger<> MaterializeTrivialGotoLogger("materialize-trivial-goto");
+
+static void eraseGoto(ScopeGraphBuilder &SGBuilder, BasicBlock &BB) {
+
+  // If `BB` is a `GotoBlock`, it must have as terminator an unconditional
+  // branch, which points to the `goto` target block.
+  Instruction *GotoTerminator = BB.getTerminator();
+  BranchInst *Branch = cast<BranchInst>(GotoTerminator);
+  revng_assert(Branch->isUnconditional());
+
+  // We erase the `goto_block` marker
+  SGBuilder.eraseGoto(&BB);
+}
+
+static BasicBlock *eraseScopeCloser(ScopeGraphBuilder &SGBuilder,
+                                    BasicBlock &BB) {
+
+  // If the `GotoBlock` also contains a `scope_closer` edge, we also need
+  // to remove it, and to restore it in case we need to rollback the
+  // transformation. We return it so that it can be later restored
+  BasicBlock *ScopeCloserTarget = nullptr;
+  if (isScopeCloserBlock(&BB)) {
+    ScopeCloserTarget = SGBuilder.eraseScopeCloser(&BB);
+  }
+  return ScopeCloserTarget;
+}
+
+static void rollbackScopeGraph(ScopeGraphBuilder &SGBuilder,
+                               BasicBlock &BB,
+                               BasicBlock *ScopeCloserTarget) {
+  SGBuilder.makeGoto(&BB);
+
+  // If there was also a `scope_closer` in addition to the `GotoBlock`, we need
+  // to restore it too
+  if (ScopeCloserTarget) {
+    SGBuilder.addScopeCloser(&BB, ScopeCloserTarget);
+  }
+}
+
+class MaterializeTrivialGotoPassImpl {
+  Function &F;
+  ScopeGraphBuilder SGBuilder;
+
+public:
+  MaterializeTrivialGotoPassImpl(Function &F) : F(F), SGBuilder(&F) {}
+
+public:
+  bool run() {
+    bool FunctionModified = false;
+
+    // We store a `SmallVector` of the `GotoBlocks` whose `goto`s are removed,
+    // so that we can simplify them all away at the end
+    llvm::SmallVector<BasicBlock *> SimplifiedGotoBlocks;
+
+    // We iterate over all the blocks in the function, searching for `goto`
+    // blocks
+    for (BasicBlock &BB : F) {
+      if (isGotoBlock(&BB)) {
+
+        // We remove the `goto_block` marker (and the `scope_closer` if
+        // present)
+        eraseGoto(SGBuilder, BB);
+        BasicBlock *ScopeCloserTarget = eraseScopeCloser(SGBuilder, BB);
+
+        // We rollback the changes if either:
+        // 1) The obtained `ScopeGraph` becomes cyclic
+        // 2) The obtained `ScopeGraph` becomes undecided
+        Scope<Function *> ScopeGraph(&F);
+        if (not isDAG(ScopeGraph) or not isScopeGraphDecided(F)) {
+
+          // We rollback to the original situation
+          rollbackScopeGraph(SGBuilder, BB, ScopeCloserTarget);
+        } else {
+
+          // If we do not rollback, it means that the `TrivialGoto`
+          // `Materialization` operation stuck, and therefore the `LLVMIR` has
+          // been modified
+          FunctionModified = true;
+
+          // The `GotoBlock` is at this point useless, we save it for possibly
+          // simplifying them later
+          SimplifiedGotoBlocks.push_back(&BB);
+        }
+      }
+    }
+
+    // We try to batch remove all the `GotoBlock`s which are not `goto` anymore
+    for (BasicBlock *GotoBlock : SimplifiedGotoBlocks) {
+      MergeBlockIntoPredecessor(GotoBlock);
+    }
+
+    return FunctionModified;
+  }
+};
+
+char MaterializeTrivialGotoPass::ID = 0;
+static constexpr const char *Flag = "materialize-trivial-goto";
+using Reg = llvm::RegisterPass<MaterializeTrivialGotoPass>;
+static Reg X(Flag, "Perform the MaterializeTrivialGoto pass on the ScopeGraph");
+
+bool MaterializeTrivialGotoPass::runOnFunction(llvm::Function &F) {
+
+  // Instantiate and call the `Impl` class
+  MaterializeTrivialGotoPassImpl MaterializeTrivialGotoImpl(F);
+  bool FunctionModified = MaterializeTrivialGotoImpl.run();
+
+  // This pass may transform the CFG by transforming some `goto` edges into
+  // standard edges. We propagate the information computed by the `Impl` class.
+  return FunctionModified;
+}
+
+void MaterializeTrivialGotoPass::getAnalysisUsage(llvm::AnalysisUsage &AU)
+  const {
+  // This pass does not preserve the CFG
+}

--- a/lib/RestructureCFG/ScopeGraphAlgorithms.cpp
+++ b/lib/RestructureCFG/ScopeGraphAlgorithms.cpp
@@ -1,0 +1,65 @@
+/// \file ScopeGraphAlgorithms.cpp
+/// Helpers for the `ScopeGraph` building
+///
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/SetVector.h"
+#include "llvm/IR/BasicBlock.h"
+
+#include "revng/ADT/ReversePostOrderTraversal.h"
+#include "revng/RestructureCFG/ScopeGraphAlgorithms.h"
+#include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
+
+using namespace llvm;
+
+SmallSetVector<BasicBlock *, 2> getScopeGraphSuccessors(BasicBlock *N) {
+  // We employ a `SetVector` so that we do not take into account
+  // multiplicity for edges out of a conditional
+  SmallSetVector<BasicBlock *, 2> ConditionalSuccessors;
+  for (BasicBlock *Successor : children<Scope<BasicBlock *>>(N)) {
+    ConditionalSuccessors.insert(Successor);
+  }
+
+  return ConditionalSuccessors;
+}
+
+SmallSetVector<BasicBlock *, 2> getScopeGraphPredecessors(BasicBlock *N) {
+  // It is important that we use a `SetVector` here in order to
+  // deduplicate the successors outputted by the `llvm::children` range
+  // iterator
+  SmallSetVector<BasicBlock *, 2> Predecessors;
+  for (auto *Predecessor : children<Inverse<Scope<BasicBlock *>>>(N)) {
+    Predecessors.insert(Predecessor);
+  }
+
+  return Predecessors;
+}
+
+SmallVector<BasicBlock *> getNodesInScope(BasicBlock *ScopeEntryBlock,
+                                          BasicBlock *PostDominator) {
+  // We exploit the `Visited` set, by passing it to
+  // `ReversePostOrderTraversalExt`, in order to stop the visit at the
+  // `PostDominator`
+  std::set<BasicBlock *> Visited;
+  Visited.insert(PostDominator);
+
+  // We collect all the nodes between the `Conditional` and its
+  // immediate postdominator, by using the `ReversePostOrderTraversalExt`
+  SmallVector<BasicBlock *> NodesToProcess;
+  for (BasicBlock *RPONode :
+       ReversePostOrderTraversalExt<Scope<BasicBlock *>>(ScopeEntryBlock,
+                                                         Visited)) {
+    NodesToProcess.push_back(RPONode);
+  }
+
+  // From the collected nodes, we need to remove the first node, which
+  // corresponds to the `Conditional`, which should not be processed in this
+  // round
+  revng_assert(NodesToProcess.front() == ScopeEntryBlock);
+  NodesToProcess.erase(NodesToProcess.begin());
+
+  return NodesToProcess;
+}

--- a/lib/RestructureCFG/SelectScopePass.cpp
+++ b/lib/RestructureCFG/SelectScopePass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/ADT/DepthFirstIterator.h"

--- a/share/revng/pipelines/revng-pipelines.yml
+++ b/share/revng/pipelines/revng-pipelines.yml
@@ -679,9 +679,11 @@ Branches:
               - dagify
               - inline-divergent-scopes
               - enforce-single-exit
+              - materialize-trivial-goto
               - select-scope
               - inline-divergent-scopes
               - enforce-single-exit
+              - materialize-trivial-goto
         Artifacts:
           Container: module.bc.zstd
           Kind: stack-accesses-segregated

--- a/tests/unit/ScopeGraphLoggerPass.cpp
+++ b/tests/unit/ScopeGraphLoggerPass.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright rev.ng Labs Srl. See LICENSE.md for details.
+// This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
 #include "llvm/IR/Function.h"

--- a/tests/unit/llvm_lit_tests/DAGify.ll
+++ b/tests/unit/llvm_lit_tests/DAGify.ll
@@ -1,5 +1,5 @@
 ;
-; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.md for details.
 ;
 
 ; RUN: %revngopt %s -dagify -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/DAGify.ll
+++ b/tests/unit/llvm_lit_tests/DAGify.ll
@@ -5,10 +5,10 @@
 ; RUN: %revngopt %s -dagify -S -o - | FileCheck %s
 
 ; function tags metadata needed for all the tests
-declare !revng.tags !0 void @scope-closer(ptr)
-declare !revng.tags !1 void @goto-block()
-!0 = !{!"scope-closer"}
-!1 = !{!"goto-block"}
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
 
 ; simple loop test
 
@@ -41,7 +41,7 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_b:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b
 
 ; nested loops test
@@ -85,10 +85,10 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_f:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_f
 ; CHECK: goto_block_b:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b
 
 ; late entry loop test
@@ -122,7 +122,7 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_c:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_c
 
 ; nested loops same head test
@@ -166,10 +166,10 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_b:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b
 ; CHECK: goto_block_b1:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b
 
 ; nested loops same tail test
@@ -219,10 +219,10 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_f:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_f
 ; CHECK: goto_block_b:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b
 
 ; simple loop double retreating test
@@ -264,5 +264,5 @@ block_e:
 ; CHECK: block_e:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_b:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_b

--- a/tests/unit/llvm_lit_tests/EnforceSingleExit.ll
+++ b/tests/unit/llvm_lit_tests/EnforceSingleExit.ll
@@ -5,10 +5,10 @@
 ; RUN: %revngopt %s -enforce-single-exit -S -o - | FileCheck %s
 
 ; function tags metadata needed for all the tests
-declare !revng.tags !0 void @scope-closer(ptr)
-declare !revng.tags !1 void @goto-block()
-!0 = !{!"scope-closer"}
-!1 = !{!"goto-block"}
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
 
 ; two trivial exits test
 
@@ -34,7 +34,7 @@ block_d:
 ; CHECK: block_c:
 ; CHECK-NEXT: br i1 undef, label %block_b, label %block_d
 ; CHECK: block_d:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@f, %block_b))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@f, %block_b))
 ; CHECK-NEXT: ret void
 
 ; one trivial, one non-trivial exit test
@@ -61,7 +61,7 @@ block_d:
 ; CHECK: block_c:
 ; CHECK-NEXT: br label %block_d
 ; CHECK: block_d:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@g, %block_b))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@g, %block_b))
 ; CHECK-NEXT: br label %block_c
 
 ; one trivial, one non-trivial exit (self loop) test
@@ -83,10 +83,10 @@ block_c:
 ; CHECK: block_b:
 ; CHECK-NEXT: ret void
 ; CHECK: block_c:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@h, %block_b))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@h, %block_b))
 ; CHECK-NEXT: br label %block_c
 
-; two trivial exit, with one scope-closer edge already present test
+; two trivial exit, with one scope_closer edge already present test
 
 define void @i() {
 block_a:
@@ -96,7 +96,7 @@ block_b:
   ret void
 
 block_c:
-  call void @scope-closer(ptr blockaddress(@i, %block_b))
+  call void @scope_closer(ptr blockaddress(@i, %block_b))
   br label %block_d
 
 block_d:
@@ -109,13 +109,13 @@ block_d:
 ; CHECK: block_b:
 ; CHECK-NEXT: ret void
 ; CHECK: block_c:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@i, %block_b))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@i, %block_b))
 ; CHECK-NEXT: br label %block_d
 ; CHECK: block_d:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@i, %block_b))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@i, %block_b))
 ; CHECK-NEXT: ret void
 
-; SCC composed by a `scope-closer` edge test
+; SCC composed by a `scope_closer` edge test
 
 define void @l() {
 block_a:
@@ -125,7 +125,7 @@ block_b:
   br i1 undef, label %block_e, label %block_d
 
 block_c:
-  call void @scope-closer(ptr blockaddress(@l, %block_d))
+  call void @scope_closer(ptr blockaddress(@l, %block_d))
   unreachable
 
 block_d:
@@ -141,10 +141,10 @@ block_e:
 ; CHECK: block_b:
 ; CHECK-NEXT: br i1 undef, label %block_e, label %block_d
 ; CHECK: block_c:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@l, %block_d))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@l, %block_d))
 ; CHECK-NEXT: unreachable
 ; CHECK: block_d:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@l, %block_e))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@l, %block_e))
 ; CHECK-NEXT: br label %block_c
 ; CHECK: block_e:
 ; CHECK-NEXT: ret void
@@ -170,7 +170,7 @@ block_c:
 ; CHECK: block_b:
 ; CHECK-NEXT: br label %block_c
 ; CHECK: block_c:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@m, %sink_block))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@m, %sink_block))
 ; CHECK-NEXT: br label %block_b
 ; CHECK: sink_block:
 ; CHECK-NEXT: unreachable
@@ -202,12 +202,12 @@ block_e:
 ; CHECK: block_b:
 ; CHECK-NEXT: br label %block_c
 ; CHECK: block_c:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@n, %sink_block))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@n, %sink_block))
 ; CHECK-NEXT: br label %block_b
 ; CHECK: block_d:
 ; CHECK-NEXT: br label %block_e
 ; CHECK: block_e:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@n, %sink_block))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@n, %sink_block))
 ; CHECK-NEXT: br label %block_d
 ; CHECK: sink_block:
 ; CHECK-NEXT: unreachable
@@ -264,7 +264,7 @@ block_d:
 ; CHECK: block_c:
 ; CHECK-NEXT: br i1 undef, label %block_b, label %block_d
 ; CHECK: block_d:
-; CHECK-NEXT: call void @scope-closer(ptr blockaddress(@p, %sink_block))
+; CHECK-NEXT: call void @scope_closer(ptr blockaddress(@p, %sink_block))
 ; CHECK-NEXT: br label %block_b
 ; CHECK: sink_block:
 ; CHECK-NEXT: unreachable

--- a/tests/unit/llvm_lit_tests/GenericRegion.ll
+++ b/tests/unit/llvm_lit_tests/GenericRegion.ll
@@ -1,5 +1,5 @@
 ;
-; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.md for details.
 ;
 
 ; RUN: %revngopt %s -generic-region-info -debug-log=generic-region-info -o /dev/null |& FileCheck %s

--- a/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
+++ b/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
@@ -5,10 +5,10 @@
 ; RUN: %revngopt %s -inline-divergent-scopes -S -o - | FileCheck %s
 
 ; function tags metadata needed for all the tests
-declare !revng.tags !0 void @scope-closer(ptr)
-declare !revng.tags !1 void @goto-block()
-!0 = !{!"scope-closer"}
-!1 = !{!"goto-block"}
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
 
 ; IDS on if test
 
@@ -35,7 +35,7 @@ block_e:
 ; CHECK: block_b:
 ; CHECK-NEXT:   ret void
 ; CHECK: block_e:
-; CHECK-NEXT:   call void @scope-closer(ptr blockaddress(@f, %block_c_ids))
+; CHECK-NEXT:   call void @scope_closer(ptr blockaddress(@f, %block_c_ids))
 ; CHECK-NEXT:   ret void
 ; CHECK: block_c_ids:
 ; CHECK-NEXT:   br label %block_b
@@ -72,10 +72,10 @@ block_f:
 ; CHECK: block_b:
 ; CHECK:   ret void
 ; CHECK: block_e:
-; CHECK:   call void @scope-closer(ptr blockaddress(@g, %block_c_ids))
+; CHECK:   call void @scope_closer(ptr blockaddress(@g, %block_c_ids))
 ; CHECK:   ret void
 ; CHECK: block_f:
-; CHECK:   call void @scope-closer(ptr blockaddress(@g, %block_c_ids_ids))
+; CHECK:   call void @scope_closer(ptr blockaddress(@g, %block_c_ids_ids))
 ; CHECK:   ret void
 ; CHECK: block_c_ids:
 ; CHECK:   switch i32 %b, label %block_c_ids_ids [

--- a/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
+++ b/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
@@ -1,5 +1,5 @@
 ;
-; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.md for details.
 ;
 
 ; RUN: %revngopt %s -inline-divergent-scopes -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/InlineDivergentScopesAndMaterializeTrivialGoto.ll
+++ b/tests/unit/llvm_lit_tests/InlineDivergentScopesAndMaterializeTrivialGoto.ll
@@ -1,0 +1,69 @@
+;
+; This file is distributed under the MIT License. See LICENSE.md for details.
+;
+
+; RUN: %revngopt %s -inline-divergent-scopes -materialize-trivial-goto -S -o - | FileCheck %s
+
+; function tags metadata needed for all the tests
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
+
+; trivial goto simplification enabled by correct IDS processing ordering
+
+define void @f(i1 noundef %a, i1 noundef %b, i1 noundef %c) {
+
+block_e:
+  br i1 %a, label %block_c, label %block_a
+
+block_a:
+  br i1 %b, label %block_goto_y, label %block_goto_x
+
+block_goto_y:
+  call void @goto_block()
+  br label %block_y
+
+block_goto_x:
+  call void @goto_block()
+  br label %block_x
+
+block_c:
+  br label %block_x
+
+block_x:
+  br i1 %b, label %block_w, label %block_y
+
+block_w:
+  br label %block_p
+
+block_y:
+  br label %block_p
+
+block_p:
+  ret void
+}
+
+; CHECK-LABEL: define void @f(i1 noundef %a, i1 noundef %b, i1 noundef %c)
+; CHECK: block_e:
+; CHECK-NEXT:   br i1 %a, label %block_e_ids, label %block_a
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %b, label %block_goto_y, label %block_a_ids
+; CHECK: block_goto_y:
+; CHECK-NEXT:   call void @goto_block()
+; CHECK-NEXT:   call void @scope_closer(ptr blockaddress(@f, %block_a_ids))
+; CHECK-NEXT:   br label %block_y
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_x
+; CHECK: block_x:
+; CHECK-NEXT:   br i1 %b, label %block_w, label %block_y
+; CHECK: block_w:
+; CHECK-NEXT:   br label %block_p
+; CHECK: block_y:
+; CHECK-NEXT:   br label %block_p
+; CHECK: block_p:
+; CHECK-NEXT:   ret void
+; CHECK: block_a_ids:
+; CHECK-NEXT:   br label %block_x
+; CHECK: block_e_ids:
+; CHECK-NEXT:   br label %block_c

--- a/tests/unit/llvm_lit_tests/MaterializeTrivialGoto.ll
+++ b/tests/unit/llvm_lit_tests/MaterializeTrivialGoto.ll
@@ -1,0 +1,173 @@
+;
+; This file is distributed under the MIT License. See LICENSE.md for details.
+;
+
+; RUN: %revngopt %s -materialize-trivial-goto -S -o - | FileCheck %s
+
+; function tags metadata needed for all the tests
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
+
+; MTGoTo on if without scope closer
+
+define void @f(i1 noundef %a) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br label %block_d
+
+block_c:
+  br label %goto_block_d
+
+goto_block_d:
+  call void @goto_block()
+  br label %block_d
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @f(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_d:
+; CHECK-NEXT:   ret void
+
+; MTGoTo on if with a scope closer
+
+define void @g(i1 noundef %a) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br label %block_d
+
+block_c:
+br label %goto_block_d
+
+goto_block_d:
+  call void @scope_closer(ptr blockaddress(@g, %block_b))
+  call void @goto_block()
+  br label %block_d
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @g(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_d:
+; CHECK-NEXT:   ret void
+
+; MTGoTo on autoloop (which should fail and rollback)
+
+define void @h(i1 noundef %a) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br label %block_d
+
+block_c:
+  call void @goto_block()
+  br label %block_c
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @h(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_c:
+; CHECK-NEXT:   call void @goto_block()
+; CHECK-NEXT:   br label %block_c
+; CHECK: block_d:
+; CHECK-NEXT:   ret void
+
+; MTGoTo on autoloop with scope closer (which should fail and rollback)
+
+define void @i(i1 noundef %a) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br label %block_d
+
+block_c:
+  call void @goto_block()
+  call void @scope_closer(ptr blockaddress(@i, %block_b))
+  br label %block_c
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @i(i1 noundef %a)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_c:
+; CHECK-NEXT:   call void @goto_block()
+; CHECK-NEXT:   call void @scope_closer(ptr blockaddress(@i, %block_b))
+; CHECK-NEXT:   br label %block_c
+; CHECK: block_d:
+; CHECK-NEXT:   ret void
+
+; MTGoTo on scopegraph with two separately materializable gotos, but whose
+; simplifications are mutually exclusive
+
+define void @l(i1 noundef %a, i1 noundef %b) {
+
+block_a:
+  br i1 %a, label %block_b, label %block_c
+
+block_b:
+  br i1 %b, label %block_d, label %goto_block_c
+
+goto_block_c:
+  call void @scope_closer(ptr blockaddress(@l, %block_d))
+  call void @goto_block()
+  br label %block_c
+
+block_c:
+  call void @scope_closer(ptr blockaddress(@l, %block_b))
+  call void @goto_block()
+  br label %block_d
+
+block_d:
+  ret void
+}
+
+; CHECK-LABEL: define void @l(i1 noundef %a, i1 noundef %b)
+; CHECK: block_a:
+; CHECK-NEXT:   br i1 %a, label %block_b, label %block_c
+; CHECK: block_b:
+; CHECK-NEXT:   br i1 %b, label %block_d, label %goto_block_c
+; CHECK: goto_block_c:
+; CHECK-NEXT:   call void @goto_block()
+; CHECK-NEXT:   call void @scope_closer(ptr blockaddress(@l, %block_d))
+; CHECK-NEXT:   br label %block_c
+; CHECK: block_c:
+; CHECK-NEXT:   br label %block_d
+; CHECK: block_d:
+; CHECK-NEXT:   ret void

--- a/tests/unit/llvm_lit_tests/ScopeGraph.ll
+++ b/tests/unit/llvm_lit_tests/ScopeGraph.ll
@@ -5,10 +5,10 @@
 ; RUN: %revngopt -load tests/unit/libtest_scopegraph.so %s -scope-graph-logger -o /dev/null |& FileCheck %s
 
 ; function tags metadata needed for all the tests
-declare !revng.tags !0 void @scope-closer(ptr)
-declare !revng.tags !1 void @goto-block()
-!0 = !{!"scope-closer"}
-!1 = !{!"goto-block"}
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
 
 ; no dashed edge test
 
@@ -64,7 +64,7 @@ block_a:
   br i1 undef, label %block_b, label %block_c
 
 block_b:
-  call void @scope-closer(ptr blockaddress(@g, %block_b))
+  call void @scope_closer(ptr blockaddress(@g, %block_b))
   ret void
 
 block_c:
@@ -112,7 +112,7 @@ block_a:
   br i1 undef, label %block_b, label %block_c
 
 block_b:
-  call void @goto-block()
+  call void @goto_block()
   br label %block_c
 
 block_c:
@@ -160,8 +160,8 @@ block_a:
   br i1 undef, label %block_b, label %block_c
 
 block_b:
-  call void @goto-block()
-  call void @scope-closer(ptr blockaddress(@i, %block_b))
+  call void @goto_block()
+  call void @scope_closer(ptr blockaddress(@i, %block_b))
   br label %block_c
 
 block_c:
@@ -210,7 +210,7 @@ block_a:
   br i1 undef, label %block_b, label %block_c
 
 block_b:
-  call void @scope-closer(ptr blockaddress(@l, %block_e))
+  call void @scope_closer(ptr blockaddress(@l, %block_e))
   ret void
 
 block_c:
@@ -260,12 +260,12 @@ block_a:
   br i1 %a, label %goto_c, label %block_b
 
 goto_c:
-  call void @goto-block()
-  call void @scope-closer(ptr blockaddress(@m, %block_b))
+  call void @goto_block()
+  call void @scope_closer(ptr blockaddress(@m, %block_b))
   br label %block_c
 
 block_b:
-  call void @scope-closer(ptr blockaddress(@m, %block_e))
+  call void @scope_closer(ptr blockaddress(@m, %block_e))
   br label %block_c
 
 block_c:
@@ -275,8 +275,8 @@ block_d:
   br i1 %b, label %goto_b, label %block_e
 
 goto_b:
-  call void @goto-block()
-  call void @scope-closer(ptr blockaddress(@m, %block_e))
+  call void @goto_block()
+  call void @scope_closer(ptr blockaddress(@m, %block_e))
   br label %block_b
 
 block_e:

--- a/tests/unit/llvm_lit_tests/SelectScope.ll
+++ b/tests/unit/llvm_lit_tests/SelectScope.ll
@@ -1,5 +1,5 @@
 ;
-; Copyright rev.ng Labs Srl. See LICENSE.md for details.
+; This file is distributed under the MIT License. See LICENSE.md for details.
 ;
 
 ; RUN: %revngopt %s -select-scope -S -o - | FileCheck %s

--- a/tests/unit/llvm_lit_tests/SelectScope.ll
+++ b/tests/unit/llvm_lit_tests/SelectScope.ll
@@ -5,10 +5,10 @@
 ; RUN: %revngopt %s -select-scope -S -o - | FileCheck %s
 
 ; function tags metadata needed for all the tests
-declare !revng.tags !0 void @scope-closer(ptr)
-declare !revng.tags !1 void @goto-block()
-!0 = !{!"scope-closer"}
-!1 = !{!"goto-block"}
+declare !revng.tags !0 void @scope_closer(ptr)
+declare !revng.tags !1 void @goto_block()
+!0 = !{!"marker", !"scope-closer"}
+!1 = !{!"marker", !"goto-block"}
 
 ; decided diamond test
 
@@ -82,10 +82,10 @@ block_f:
 ; CHECK: block_f:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_e:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_e
 ; CHECK: goto_block_d:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_d
 
 ; double edge if test
@@ -177,7 +177,7 @@ block_f:
 ; CHECK: block_f:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_e:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_e
 
 ; short-circuit with decided tail
@@ -236,5 +236,5 @@ block_l:
 ; CHECK: block_l:
 ; CHECK-NEXT:   ret void
 ; CHECK: goto_block_e:
-; CHECK-NEXT:   call void @goto-block()
+; CHECK-NEXT:   call void @goto_block()
 ; CHECK-NEXT:   br label %block_e


### PR DESCRIPTION
The MaterializeTrivialGoto pass, tries to remove superfluous `goto` from the `ScopeGraph`, by verifying that the resulting `ScopeGraph` does not become cyclic or undecided, in which case, it rolls back the changes.

Various other improvements, mainly license fix, using `snake_case` for `ScopeGraph` `Marker`s, and improving the IDS matching criterion to find more `MaterializeTrivialGoto` opportunities.