### PR TITLE
IDS on multiple Divergent Scopes

### DIFF
--- a/include/revng/RestructureCFG/ScopeGraphUtils.h
+++ b/include/revng/RestructureCFG/ScopeGraphUtils.h
@@ -41,19 +41,19 @@ public:
   ScopeGraphBuilder(llvm::Function *F);
 
 public:
-  void makeGoto(llvm::BasicBlock *GotoBlock);
-  void eraseGoto(llvm::BasicBlock *GotoBlock);
-  void addScopeCloser(llvm::BasicBlock *Source, llvm::BasicBlock *Target);
+  void makeGoto(llvm::BasicBlock *GotoBlock) const;
+  void eraseGoto(llvm::BasicBlock *GotoBlock) const;
+  void addScopeCloser(llvm::BasicBlock *Source, llvm::BasicBlock *Target) const;
 
   /// Helper method which erase a `scope_closer`, and returns the block which
   /// was target of the `scope_closer`
-  llvm::BasicBlock *eraseScopeCloser(llvm::BasicBlock *Source);
+  llvm::BasicBlock *eraseScopeCloser(llvm::BasicBlock *Source) const;
 
   /// With the usage of this helper,  all the successor in the `Terminator` of
   /// the `Source` block pointing to `Target` will be redirected to the newly
   /// inserted `goto` block
   llvm::BasicBlock *makeGotoEdge(llvm::BasicBlock *Source,
-                                 llvm::BasicBlock *Target);
+                                 llvm::BasicBlock *Target) const;
 };
 
 template<ConstOrNot<llvm::BasicBlock> BasicBlockType>

--- a/lib/RestructureCFG/EnforceSingleExitPass.cpp
+++ b/lib/RestructureCFG/EnforceSingleExitPass.cpp
@@ -55,9 +55,10 @@ static bool isInfiniteLoop(const scc_iterator<Scope<BasicBlock *>> &SCCIt) {
 /// blocks, and infinite loops too.
 class EnforceSingleExitPassImpl {
   Function &F;
+  const ScopeGraphBuilder SGBuilder;
 
 public:
-  EnforceSingleExitPassImpl(Function &F) : F(F) {}
+  EnforceSingleExitPassImpl(Function &F) : F(F), SGBuilder(&F) {}
 
 public:
   bool run() {
@@ -157,7 +158,6 @@ public:
     if (TrivialExits.size() != 0) {
       for (BasicBlock *TrivialExit : skip_front(TrivialExits)) {
         revng_assert(TrivialExit != OneTrueExit);
-        ScopeGraphBuilder SGBuilder(TrivialExit->getParent());
         SGBuilder.addScopeCloser(TrivialExit, OneTrueExit);
       }
     }
@@ -167,7 +167,6 @@ public:
 
       // Build a `scope_closer` edge from each identified exit block to the
       // `sink_block`
-      ScopeGraphBuilder SGBuilder(NonTrivialExit->getParent());
       SGBuilder.addScopeCloser(NonTrivialExit, OneTrueExit);
     }
 

--- a/lib/RestructureCFG/InlineDivergentScopesPass.cpp
+++ b/lib/RestructureCFG/InlineDivergentScopesPass.cpp
@@ -11,6 +11,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/GenericDomTree.h"
 
+#include "revng/ADT/Concepts.h"
 #include "revng/RestructureCFG/InlineDivergentScopesPass.h"
 #include "revng/RestructureCFG/ScopeGraphGraphTraits.h"
 #include "revng/RestructureCFG/ScopeGraphUtils.h"
@@ -49,7 +50,7 @@ static bool isConditional(BasicBlock *Node) {
   }
 }
 
-/// Helper function which detects
+/// Helper function which detects if `Node` is an exit for the `ScopeGraph`
 static bool isExit(BasicBlock *Node) {
   auto Successors = children<Scope<BasicBlock *>>(Node);
   return std::ranges::empty(Successors);
@@ -120,6 +121,26 @@ getImmediateDominator(BasicBlock *N,
     return Node->getBlock();
   } else {
     return nullptr;
+  }
+}
+
+/// Define a concept to restrict the usage of `replaceSuccessors` over a
+/// `SuccessorsToRemove` parameter of type the `SmallSet`s and `SmallVector`
+template<typename T, typename ValueType>
+concept IterableOfBasicBlockPtrs = requires(T Container) {
+  { std::begin(Container) } -> std::input_iterator;
+  { std::end(Container) };
+  { *std::begin(Container) } -> std::convertible_to<ValueType>;
+};
+
+/// Helper function which substitutes some successors in the `Terminator` with
+/// `NewTarget`
+template<IterableOfBasicBlockPtrs<BasicBlock *> Container>
+static void replaceSuccessors(Instruction *Terminator,
+                              Container &SuccessorsToRemove,
+                              BasicBlock *NewTarget) {
+  for (BasicBlock *Successor : SuccessorsToRemove) {
+    Terminator->replaceSuccessorWith(Successor, NewTarget);
   }
 }
 
@@ -280,15 +301,15 @@ electDivergence(BasicBlock *Candidate,
 }
 
 /// Helper function that performs the IDS transformation
-static void performIDS(DivergenceDescriptor &DivergenceDescriptor,
-                       BasicBlock *PlaceHolderTarget) {
+static void
+performMultipleIDS(const ScopeGraphBuilder &SGBuilder,
+                   SmallVector<DivergenceDescriptor> &MultipleDivergences,
+                   BasicBlock *PlaceHolderTarget) {
 
   // Create the new `BasicBlock` representing the `C'` conditional
   // inserted by the IDS transformation. We will refer to this block as the
   // `Tail` (of the IDS group of nodes).
-  BasicBlock *Conditional = DivergenceDescriptor.Conditional;
-  auto DivergentSuccessors = DivergenceDescriptor.DivergentSuccessors;
-  BasicBlock *Exit = DivergenceDescriptor.Exit;
+  BasicBlock *Conditional = MultipleDivergences[0].Conditional;
   LLVMContext &Context = getContext(Conditional);
   Function *F = Conditional->getParent();
   BasicBlock *Tail = BasicBlock::Create(Context,
@@ -305,6 +326,14 @@ static void performIDS(DivergenceDescriptor &DivergenceDescriptor,
   IRBuilder<> TailBuilder(Tail);
   TailBuilder.Insert(TailTerminator);
 
+  // Populate the `DivergentSuccessors` summing all ones present in each
+  // `DivergenceDescriptor`
+  SmallSet<BasicBlock *, 4> DivergentSuccessors;
+  for (auto Divergence : MultipleDivergences) {
+    DivergentSuccessors.insert(Divergence.DivergentSuccessors.begin(),
+                               Divergence.DivergentSuccessors.end());
+  }
+
   // We connect the `Conditional` to `Tail`, by making sure that all
   // the previous slots and cases going to the nondivergent exits, are now
   // connected to the `Tail` block, in order to preserve the original semantics.
@@ -316,11 +345,43 @@ static void performIDS(DivergenceDescriptor &DivergenceDescriptor,
       NonDivergentSuccessors.push_back(Successor);
     }
   }
-  revng_assert(not DivergentSuccessors.empty()
-               and not NonDivergentSuccessors.empty());
-  for (BasicBlock *Successor : NonDivergentSuccessors) {
-    ConditionalTerminator->replaceSuccessorWith(Successor, Tail);
+
+  revng_assert(not DivergentSuccessors.empty());
+
+  // It may be that for a specific `Conditional` we elected all the exits as
+  // divergent. In this case, we need to arbitrarily elect one exit as the `one
+  // true exit`, and we do this by electing the last element in
+  // `MultipleDivergences`.
+  if (NonDivergentSuccessors.empty()) {
+    revng_assert(MultipleDivergences.size() > 1);
+
+    // The fact that we elect the last element in `MultipleDivergences` as the
+    // only non divergent exit, is very important, due to how the `exit` blocks
+    // are enqueued in `MupltipleDivergences`. If present, the `Goto` exit will
+    // be in the first positions, followed by the original exit blocks. In this
+    // way, if present, we always elect a original exit as the non divergent
+    // exit.
+    size_t LastElementIndex = MultipleDivergences.size() - 1;
+
+    // The first element in `MultipleDivergencies` is arbitrarily elected as the
+    // component not going to a divergent exit
+    NonDivergentSuccessors
+      .append(MultipleDivergences[LastElementIndex].DivergentSuccessors.begin(),
+              MultipleDivergences[LastElementIndex].DivergentSuccessors.end());
+
+    // We remove the `Successor`s from the `DivergentSuccessors`
+    for (BasicBlock *Successor :
+         MultipleDivergences[LastElementIndex].DivergentSuccessors) {
+      DivergentSuccessors.erase(Successor);
+    }
+
+    // We erase the first `DivergenceDescriptor` from the `MultipleDivergences`
+    MultipleDivergences.erase(MultipleDivergences.begin() + LastElementIndex);
   }
+
+  // Move the `NonDivergentSuccessors` outgoing edges from `Conditional` so that
+  // they point to `Tail`
+  replaceSuccessors(ConditionalTerminator, NonDivergentSuccessors, Tail);
 
   // We remove from the `Terminator` of `Tail`, all the edges that
   // target `DivergentSuccessor`, since it will be only reached by
@@ -328,30 +389,128 @@ static void performIDS(DivergenceDescriptor &DivergenceDescriptor,
   // successor with `PlaceHolderTarget`, and then we invoke
   // `simplifyTerminator`, which will take care of simplifying away the
   // unnecessary successors, both for `brcond`s and `switch`es.
-  for (BasicBlock *Successor : DivergentSuccessors) {
-    TailTerminator->replaceSuccessorWith(Successor, PlaceHolderTarget);
-  }
+  replaceSuccessors(TailTerminator, DivergentSuccessors, PlaceHolderTarget);
   simplifyTerminator(Tail, PlaceHolderTarget);
 
   // We add a `scope_closer` edge between the divergent exit node and
-  // the `Tail` node
-  ScopeGraphBuilder SGBuilder(F);
-  SGBuilder.addScopeCloser(Exit, Tail);
+  // the `Tail` node for all the exits
+  for (auto Divergence : MultipleDivergences) {
+    SGBuilder.addScopeCloser(Divergence.Exit, Tail);
+  }
+}
+
+/// Helper function which returns if a `DivergenceDescriptor` is compatible with
+/// all the ones already present in a `Collection`. Being compatible means that
+/// they insist on the same conditional, have non-overlapping `Exit` blocks, and
+/// do not have any overlapping `DivergentSuccessors`. We currently use this
+/// helper only in an assertion to double check that the `Divergencies`
+/// collected respect the compatibility criterion.
+static bool isCompatible(const SmallVector<DivergenceDescriptor> &Collection,
+                         const DivergenceDescriptor &NewDescriptor) {
+
+  // A new element is always compatible with an empty `Collection`
+  if (Collection.empty())
+    return true;
+
+  // A new element is compatible when it shares the `Conditional` with the ones
+  // already in the `Collection`
+  if (Collection[0].Conditional != NewDescriptor.Conditional)
+    return false;
+
+  // All the `DivergenceDescriptor`s involving a certain `Conditional`, must
+  // partition, so that there is no overlap: 1: the divergent `Exit` reached by
+  // each `DivergenceDescriptor` 2: the set of the `DivergentSuccessors`
+  for (const auto &Existing : Collection) {
+    if (Existing.Exit == NewDescriptor.Exit) {
+      return false;
+    }
+
+    for (BasicBlock *ExistingSucc : Existing.DivergentSuccessors) {
+      for (BasicBlock *NewSucc : NewDescriptor.DivergentSuccessors) {
+        if (ExistingSucc == NewSucc) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+/// Helper function which attempts to perform multiple IDS transformations
+static bool
+tryMultipleIDS(const ScopeGraphBuilder &SGBuilder,
+               const SmallVector<DivergenceDescriptor> &DivergenceDescriptors,
+               BasicBlock *PlaceHolderTarget) {
+
+  // We attempt to perform multiple IDS transformations all at once
+  // We start by collecting all the `Conditional`s involved in at least one
+  // divergence
+  SmallSetVector<BasicBlock *, 4> Conditionals;
+  for (auto DivergenceDescriptor : DivergenceDescriptors) {
+    Conditionals.insert(DivergenceDescriptor.Conditional);
+  }
+
+  // For each `Conditional`, we collect all the multiple divergences involving
+  // it
+  for (BasicBlock *Conditional : Conditionals) {
+    SmallVector<DivergenceDescriptor> CompatibleDivergenceDescriptors;
+    for (auto DivergenceDescriptor : DivergenceDescriptors) {
+      if (DivergenceDescriptor.Conditional == Conditional) {
+
+        // As a safeguard, we assert that all the `DivergenceDescriptor`s are
+        // compatible, i.e., they partition correctly the divergencies insisting
+        // on a certain `Conditional`
+        revng_assert(isCompatible(CompatibleDivergenceDescriptors,
+                                  DivergenceDescriptor));
+        CompatibleDivergenceDescriptors.push_back(DivergenceDescriptor);
+      }
+    }
+
+    // We must find at least one `DivergenceDescriptor` for each `Conditional`,
+    // since we previously selected only `Conditional`s involved in at least one
+    // `Divergence`
+    revng_assert(CompatibleDivergenceDescriptors.size() >= 1);
+    performMultipleIDS(SGBuilder,
+                       CompatibleDivergenceDescriptors,
+                       PlaceHolderTarget);
+
+    // When we perform an IDS transformation, it means that we changed the
+    // `ScopeGraph`, and therefore we may have unlocked new IDS opportunities,
+    // so we need to perform another round
+    return true;
+  }
+
+  // If we reach this point, it means that no change has been applied during
+  // this round of IDS, so we do not need to run it again
+  return false;
 }
 
 /// This helper function is used to attempt the IDS process, and returns `true`
 /// or `false` depending on whether a change is performed
-static bool tryIDS(Function &F, BasicBlock *PlaceHolderTarget) {
+static bool tryIDS(const ScopeGraphBuilder &SGBuilder,
+                   Function &F,
+                   BasicBlock *PlaceHolderTarget) {
 
   // The main need for recomputing the `DomTree` is that we insert the new
   // `IDS` block and redirect edges over the `ScopeGraph`
   DomTreeOnView<BasicBlock, Scope> DomTree;
   DomTree.recalculate(F);
 
+  SmallVector<DivergenceDescriptor> DivergenceDescriptors;
+
   // Collect the exit nodes
   SmallVector<BasicBlock *> Exits = getExits(F, PlaceHolderTarget);
 
-  // Attempt IDS on each exit node
+  // Collect all the IDS opportunities.
+  // We iterate over all the `Exit`s, and then search for a `Candidate`
+  // conditional node for which such `Exit` is divergent wrt. We do this by
+  // walking upward the dominator tree until we find (if it is present) the
+  // divergent `Conditional`. An alternative, which would also make the code
+  // more straightforward, would be to iterate over the `Conditional`s and start
+  // the search from there, but this would mean to perform multiple visits to
+  // the `Exit`s. With out techniques instead, even if less intuitive, we
+  // collect all the `DivergenceDescriptor`s in one sweep.
   for (BasicBlock *Exit : Exits) {
 
     // Here we go up in the `ScopeGraph`, hopping through the immediate
@@ -366,31 +525,28 @@ static bool tryIDS(Function &F, BasicBlock *PlaceHolderTarget) {
       std::optional<DivergenceDescriptor>
         DivergenceDescriptor = electDivergence(Candidate, Exit, DomTree);
 
-      // If we have found a divergence for the exit under analysis, we proceed
-      // to perform IDS
+      // If we have found a divergence for the exit under analysis, we add it to
+      // the `DivergenceDescriptors`
       if (DivergenceDescriptor) {
-        performIDS(*DivergenceDescriptor, PlaceHolderTarget);
+        DivergenceDescriptors.push_back(*DivergenceDescriptor);
 
-        // Empirically, we have found that restarting the analysis, by
-        // recollecting the exit nodes in the `ScopeGraph`, is faster than
-        // continuing with the processing of all the exits already collected.
-        // Therefore, we should not really try to optimize this, unless we
-        // find new evidence that this is better.
-        return true;
+        // We have found a `Divergence` for the current `Exit`, so we can move
+        // to the next one
+        break;
       }
     }
   }
 
-  // If no change has been performed, we return `false` to signal this fact
-  return false;
+  return tryMultipleIDS(SGBuilder, DivergenceDescriptors, PlaceHolderTarget);
 }
 
 /// Implementation class used to run the `IDS` transformation
 class InlineDivergentScopesImpl {
   Function &F;
+  const ScopeGraphBuilder SGBuilder;
 
 public:
-  InlineDivergentScopesImpl(Function &F) : F(F) {}
+  InlineDivergentScopesImpl(Function &F) : F(F), SGBuilder(&F) {}
 
 public:
   bool run() {
@@ -409,7 +565,7 @@ public:
     // continuing with the processing of all the exits already collected.
     // Therefore, we should not really try to optimize this, unless we find new
     // evidence that this is better.
-    while (tryIDS(F, *PlaceHolderTarget)) {
+    while (tryIDS(SGBuilder, F, *PlaceHolderTarget)) {
 
       // As soon as one IDS change is performed, we mark the current `Function`
       // as modified

--- a/lib/RestructureCFG/ScopeGraphUtils.cpp
+++ b/lib/RestructureCFG/ScopeGraphUtils.cpp
@@ -91,7 +91,7 @@ ScopeGraphBuilder::ScopeGraphBuilder(Function *F) :
   GotoBlockFunction(getOrCreateGotoBlockFunction(F->getParent())) {
 }
 
-void ScopeGraphBuilder::makeGoto(BasicBlock *GotoBlock) {
+void ScopeGraphBuilder::makeGoto(BasicBlock *GotoBlock) const {
   // We must have a `GotoBlock`
   revng_assert(GotoBlock);
 
@@ -106,7 +106,7 @@ void ScopeGraphBuilder::makeGoto(BasicBlock *GotoBlock) {
   Builder.CreateCall(GotoBlockFunction, {});
 }
 
-void ScopeGraphBuilder::eraseGoto(BasicBlock *GotoBlock) {
+void ScopeGraphBuilder::eraseGoto(BasicBlock *GotoBlock) const {
   // We must have a `GotoBlock`
   revng_assert(GotoBlock);
 
@@ -124,7 +124,8 @@ void ScopeGraphBuilder::eraseGoto(BasicBlock *GotoBlock) {
   }
 }
 
-void ScopeGraphBuilder::addScopeCloser(BasicBlock *Source, BasicBlock *Target) {
+void ScopeGraphBuilder::addScopeCloser(BasicBlock *Source,
+                                       BasicBlock *Target) const {
   // We must have an insertion point
   revng_assert(Source);
 
@@ -137,7 +138,7 @@ void ScopeGraphBuilder::addScopeCloser(BasicBlock *Source, BasicBlock *Target) {
   Builder.CreateCall(ScopeCloserFunction, BasicBlockAddressTarget);
 }
 
-BasicBlock *ScopeGraphBuilder::eraseScopeCloser(BasicBlock *Source) {
+BasicBlock *ScopeGraphBuilder::eraseScopeCloser(BasicBlock *Source) const {
 
   // We save the `Target` of the `scope_closer`, which will be returned by the
   // method, for eventual later restoring
@@ -155,7 +156,7 @@ BasicBlock *ScopeGraphBuilder::eraseScopeCloser(BasicBlock *Source) {
 }
 
 BasicBlock *ScopeGraphBuilder::makeGotoEdge(BasicBlock *Source,
-                                            BasicBlock *Target) {
+                                            BasicBlock *Target) const {
   Function *F = Source->getParent();
 
   // Create the `goto` block, and connect it with the `Target`

--- a/lib/RestructureCFG/ScopeGraphUtils.cpp
+++ b/lib/RestructureCFG/ScopeGraphUtils.cpp
@@ -169,8 +169,7 @@ BasicBlock *ScopeGraphBuilder::makeGotoEdge(BasicBlock *Source,
   Builder.CreateBr(Target);
 
   // Insert the `goto_block` marker in the `ScopeGraph`
-  ScopeGraphBuilder SGBuilder(F);
-  SGBuilder.makeGoto(GotoBlock);
+  makeGoto(GotoBlock);
 
   // Redirect all the edges `Source` -> `Target` to `Source` -> `GotoBlock`
   auto SourceTerminator = Source->getTerminator();

--- a/lib/RestructureCFG/SelectScopePass.cpp
+++ b/lib/RestructureCFG/SelectScopePass.cpp
@@ -77,12 +77,13 @@ static size_t electMaxScopeID(SmallSetVector<BasicBlock *, 2> &Predecessors,
 class SelectScopePassImpl {
   Function &F;
   PostDomTreeOnView<BasicBlock, Scope> PDT;
+  const ScopeGraphBuilder SGBuilder;
 
   // We keep a boolean field to track whether the `Function` was modified
   bool FunctionModified = false;
 
 public:
-  SelectScopePassImpl(Function &F) : F(F) {}
+  SelectScopePassImpl(Function &F) : F(F), SGBuilder(&F) {}
 
 public:
   void processConditionalNode(BasicBlock *ConditionalNode) {
@@ -188,7 +189,6 @@ public:
           // assigned to `Candidate`, we need to transform the edge into a
           // `goto` edge, in order to respect the decidedness definition.
           if (PredecessorScopeID != ElectedScopeID) {
-            ScopeGraphBuilder SGBuilder(&F);
             SGBuilder.makeGotoEdge(Predecessor, Candidate);
 
             // We mark the CFG as modified

--- a/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
+++ b/tests/unit/llvm_lit_tests/InlineDivergentScopes.ll
@@ -40,6 +40,8 @@ block_e:
 ; CHECK: block_c_ids:
 ; CHECK-NEXT:   br label %block_b
 
+; IDS on switch test
+
 define void @g(i1 noundef %a, i32 noundef %b) {
 
 block_a:
@@ -67,7 +69,7 @@ block_f:
 ; CHECK: block_c:
 ; CHECK:   switch i32 %b, label %block_c_ids [
 ; CHECK:     i32 0, label %block_e
-; CHECK:     i32 1, label %block_c_ids
+; CHECK:     i32 1, label %block_f
 ; CHECK:   ]
 ; CHECK: block_b:
 ; CHECK:   ret void
@@ -75,12 +77,8 @@ block_f:
 ; CHECK:   call void @scope_closer(ptr blockaddress(@g, %block_c_ids))
 ; CHECK:   ret void
 ; CHECK: block_f:
-; CHECK:   call void @scope_closer(ptr blockaddress(@g, %block_c_ids_ids))
+; CHECK:   call void @scope_closer(ptr blockaddress(@g, %block_c_ids))
 ; CHECK:   ret void
 ; CHECK: block_c_ids:
-; CHECK:   switch i32 %b, label %block_c_ids_ids [
-; CHECK:     i32 1, label %block_f
-; CHECK:   ]
-; CHECK: block_c_ids_ids:
 ; CHECK:   switch i32 %b, label %block_b [
 ; CHECK:   ]


### PR DESCRIPTION
Implement IDS performing the Divergent Scopes Inlining for multiple scopes at the same time. This improves both the performances of the pass and the layout of the resulting `ScopeGraph`.

Prepended to the PR, some commits that are targeted to improve the performances by reducing the instances of `ScopeGraphBuilder`s across various cfg restructuring passes.