### PR TITLE
Introduce backend failure handling

### DIFF
--- a/include/revng/RestructureCFG/ASTTree.h
+++ b/include/revng/RestructureCFG/ASTTree.h
@@ -69,7 +69,13 @@ private:
   links_container_expr CondExprList = {};
 
 public:
-  ASTTree() = default;
+  ASTTree() :
+    ASTNodeList(),
+    BBASTMap(),
+    ASTBBMap(),
+    RootNode(nullptr),
+    IDCounter(0),
+    CondExprList() {}
 
   // Default movable
   ASTTree(ASTTree &&) = default;

--- a/include/revng/RestructureCFG/GenerateAst.h
+++ b/include/revng/RestructureCFG/GenerateAst.h
@@ -443,7 +443,7 @@ createSwitchTile(RegionCFG<NodeT> &Graph,
   return Tile;
 }
 
-inline void
+inline bool
 generateAst(RegionCFG<llvm::BasicBlock *> &Region,
             ASTTree &AST,
             std::map<RegionCFG<llvm::BasicBlock *> *, ASTTree> &CollapsedMap) {
@@ -461,7 +461,10 @@ generateAst(RegionCFG<llvm::BasicBlock *> &Region,
   Region.weave();
 
   // Invoke the inflate function.
-  Region.inflate();
+  if (not Region.inflate())
+
+    // We propagate the failure upwards
+    return false;
 
   // After we are done with the combing, we need to pre-compute the weight of
   // the current RegionCFG, so that during the untangle phase of other
@@ -999,6 +1002,9 @@ generateAst(RegionCFG<llvm::BasicBlock *> &Region,
   revng_assert(Root);
   ASTNode *RootNode = AST.findASTNode(Root);
   AST.setRoot(RootNode);
+
+  // We return true to notify that no `generateAST` failure arose
+  return true;
 }
 
 inline void normalize(ASTTree &AST, const llvm::Function &F) {

--- a/include/revng/RestructureCFG/RegionCFGTree.h
+++ b/include/revng/RestructureCFG/RegionCFGTree.h
@@ -62,6 +62,12 @@ class RegionCFG {
 
   static_assert(std::is_same_v<decltype(&getConstPointer), getConstPointerT>);
 
+  enum class PurgeDummyReturnCode {
+    NoSimplification,
+    Simplification,
+    Failure
+  };
+
 public:
   using BasicBlockNodeT = typename BBNodeT::BasicBlockNodeT;
   using BasicBlockNodeType = typename BasicBlockNodeT::Type;
@@ -362,9 +368,9 @@ public:
                      const std::string &FolderName,
                      const std::string &FileName) const;
 
-  bool purgeTrivialDummies();
+  PurgeDummyReturnCode purgeTrivialDummies();
 
-  bool purgeIfTrivialDummy(BBNodeT *Dummy);
+  PurgeDummyReturnCode purgeIfTrivialDummy(BBNodeT *Dummy);
 
   void purgeVirtualSink(BBNodeT *Sink);
 
@@ -374,7 +380,7 @@ public:
   void untangle();
 
   /// Apply comb to the region.
-  void inflate();
+  bool inflate();
 
   void removeNotReachables();
 

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -1476,5 +1476,6 @@ bool restructureCFG(Function &F, ASTTree &AST) {
                  << UntanglePerformedCounter << "," << InitialWeight << "\n";
   }
 
-  return false;
+  // We return true to notify that not restructuring error arose
+  return true;
 }

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -1330,6 +1330,7 @@ bool restructureCFG(Function &F, ASTTree &AST) {
                                     DeduplicatedDummies);
       ParentMetaRegion = ParentMetaRegion->getParent();
     }
+    LogMetaRegions(OrderedMetaRegions, "MetaRegions after update");
 
     // Replace the pointers inside SCS.
     Meta->replaceNodes(CollapsedGraph.getNodes());

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -1421,7 +1421,10 @@ bool restructureCFG(Function &F, ASTTree &AST) {
 
   // Invoke the AST generation for the root region.
   std::map<RegionCFG<llvm::BasicBlock *> *, ASTTree> CollapsedMap;
-  generateAst(RootCFG, AST, CollapsedMap);
+  if (not generateAst(RootCFG, AST, CollapsedMap))
+
+    // We propagate the failure upwards
+    return false;
 
   // Scorporated this part which was previously inside the `generateAst` to
   // avoid having it run twice or more (it was run inside the recursive step

--- a/lib/RestructureCFG/RestructureCFG.cpp
+++ b/lib/RestructureCFG/RestructureCFG.cpp
@@ -773,7 +773,13 @@ bool restructureCFG(Function &F, ASTTree &AST) {
       // retreating edges in the `ContinueBackedges` set, checking that they
       // point to the `Entry` node
       for (EdgeDescriptor R : Retreatings) {
-        revng_assert(R.second == Entry);
+
+        // The following should be an assert, but since the backend is in
+        // maintenance mode, we have an early return to propagate an early
+        // failure
+        if (not(R.second == Entry))
+          return false;
+
         ContinueBackedges.push_back(R);
       }
     }


### PR DESCRIPTION
Handle a backend decompilation failure by printing an error message in place of the function body.

Also, fix a minor logic bug on exit dispatcher deduplication.