### PR TITLE
Change file opening mode to not fail on write

### DIFF
--- a/python/revng/support/artifacts.py
+++ b/python/revng/support/artifacts.py
@@ -63,7 +63,7 @@ class Artifact:
         return self._data
 
     def write_to_disk(self, path: Union[str, Path]):
-        with open(path, "rb") as f:
+        with open(path, "wb") as f:
             f.write(self._data)
 
 


### PR DESCRIPTION
In artifacts.py a file is opened in read mode even though the only operation ever performed is a write.
The code can be triggered with:
```
from revng.project import CLIProject
from revng.support import get_example_binary_path
binary_path = get_example_binary_path()
project.import_and_analyze(binary_path)
ir = project.model.get_artifact("cleanup-ir")
ir.write_to_disk("foo.bar")
```
if foo.bar does not exist it fails because it tries to open a file that does not exist. If it does exist it fails with `UnsupportedOperation: write`