### PR TITLE
tuple_tree.ts: Fix invalid instanceof check with generics

### DIFF
--- a/typescript/tuple_tree.ts
+++ b/typescript/tuple_tree.ts
@@ -44,7 +44,7 @@ export class Reference<T, M> {
     }
 
     equals(other: unknown): boolean {
-        if (other instanceof Reference<T, M>) {
+        if (other instanceof Reference) {
             return this.reference == other.reference;
         } else {
             return false;


### PR DESCRIPTION
Hello, maintainers.

`instanceof` operates on runtime values (constructors). Generic instantiations like `Reference<T, M>` are erased at runtime, so `instanceof Reference<T, M>` is invalid TypeScript and should be `instanceof Reference`.

This appears to be a TypeScript version compatibility issue. Using a runtime-safe constructor check avoids relying on version-specific TypeScript behavior and should work consistently across more supported TypeScript versions.

Let me know if further adjustments are needed.

related issue: https://github.com/revng/orchestra/issues/192