### PR TITLE
Add SQLite-based model import/export and REVNG_NO_FETCH_DEBUG_INFO

### DIFF
--- a/include/revng/Support/Sqlite3.h
+++ b/include/revng/Support/Sqlite3.h
@@ -131,6 +131,12 @@ private:
     return llvm::StringRef{ static_cast<const char *>(Ptr),
                             static_cast<size_t>(Size) };
   }
+
+  template<std::same_as<int64_t> T, int I>
+  int64_t unpackRow() {
+    assertType(I, SQLITE_INTEGER);
+    return sqlite3_column_int64(Statement.get(), I);
+  }
 };
 
 class Sqlite3Db {

--- a/lib/Model/Importer/DebugInfo/ImportDebugInfoHelper.h
+++ b/lib/Model/Importer/DebugInfo/ImportDebugInfoHelper.h
@@ -13,6 +13,9 @@
 namespace {
 
 inline int runFetchDebugInfo(llvm::StringRef InputFileName, bool Verbose) {
+  if (llvm::sys::Process::GetEnv("REVNG_NO_FETCH_DEBUG_INFO"))
+    return 1;
+
   revng_assert(::Runner.isProgramAvailable("revng"));
   std::vector<std::string> Args{ "model",
                                  "fetch-debuginfo",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -284,6 +284,7 @@ set(REVNG_CLI_COMMANDS_MODULE_FILES
     revng/internal/cli/_commands/trace_run.py
     revng/internal/cli/_commands/model_compare.py
     revng/internal/cli/_commands/model_migrate.py
+    revng/internal/cli/_commands/model_export_sqlite.py
     revng/internal/cli/_commands/ptml.py)
 python_module(TARGET_NAME revng-python-cli-commands WHEEL revng_internal
               MODULE_FILES ${REVNG_CLI_COMMANDS_MODULE_FILES})

--- a/python/revng/internal/cli/_commands/model_export_sqlite.py
+++ b/python/revng/internal/cli/_commands/model_export_sqlite.py
@@ -1,0 +1,238 @@
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+
+import argparse
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from revng.internal.cli.commands_registry import Command, CommandsRegistry, Options
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+TYPE_DEFINITION_REFERENCE_PATTERN = re.compile(r"/TypeDefinitions/(\d+)-(\w+)")
+
+
+def create_schema(connection: sqlite3.Connection) -> None:
+    connection.executescript("""
+        CREATE TABLE IF NOT EXISTS Platform (
+            PlatformID INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT NOT NULL UNIQUE
+        );
+
+        CREATE TABLE IF NOT EXISTS Library (
+            LibraryID INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT NOT NULL,
+            PlatformID INTEGER NOT NULL,
+            Header TEXT NOT NULL DEFAULT '',
+            FOREIGN KEY (PlatformID) REFERENCES Platform(PlatformID),
+            UNIQUE(Name, PlatformID)
+        );
+
+        CREATE TABLE IF NOT EXISTS TypeDefinition (
+            TypeDefinitionID INTEGER PRIMARY KEY AUTOINCREMENT,
+            LibraryID INTEGER NOT NULL,
+            Body TEXT NOT NULL,
+            OriginalID INTEGER NOT NULL,
+            FOREIGN KEY (LibraryID) REFERENCES Library(LibraryID)
+        );
+
+        CREATE TABLE IF NOT EXISTS Symbol (
+            SymbolID INTEGER PRIMARY KEY AUTOINCREMENT,
+            LibraryID INTEGER NOT NULL,
+            Name TEXT NOT NULL,
+            Kind TEXT NOT NULL,
+            TypeDefinitionID INTEGER,
+            FOREIGN KEY (LibraryID) REFERENCES Library(LibraryID),
+            FOREIGN KEY (TypeDefinitionID) REFERENCES TypeDefinition(TypeDefinitionID)
+        );
+
+        CREATE TABLE IF NOT EXISTS TypeDefinitionDependencies (
+            SourceTypeDefinitionID INTEGER NOT NULL,
+            DestinationTypeDefinitionID INTEGER NOT NULL,
+            PRIMARY KEY (SourceTypeDefinitionID, DestinationTypeDefinitionID),
+            FOREIGN KEY (SourceTypeDefinitionID)
+                REFERENCES TypeDefinition(TypeDefinitionID),
+            FOREIGN KEY (DestinationTypeDefinitionID)
+                REFERENCES TypeDefinition(TypeDefinitionID)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_symbol_name ON Symbol(Name);
+        CREATE INDEX IF NOT EXISTS idx_symbol_library ON Symbol(LibraryID);
+        CREATE INDEX IF NOT EXISTS idx_typedef_library ON TypeDefinition(LibraryID);
+        CREATE INDEX IF NOT EXISTS idx_typedef_original
+            ON TypeDefinition(OriginalID, LibraryID);
+        CREATE INDEX IF NOT EXISTS idx_deps_source
+            ON TypeDefinitionDependencies(SourceTypeDefinitionID);
+        CREATE INDEX IF NOT EXISTS idx_deps_dest
+            ON TypeDefinitionDependencies(DestinationTypeDefinitionID);
+    """)
+
+
+def find_type_references(node: Any) -> set:
+    references = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "Definition" and isinstance(value, str):
+                match = TYPE_DEFINITION_REFERENCE_PATTERN.search(value)
+                if match:
+                    references.add(int(match.group(1)))
+            else:
+                references.update(find_type_references(value))
+    elif isinstance(node, list):
+        for item in node:
+            references.update(find_type_references(item))
+    return references
+
+
+def import_model(
+    connection: sqlite3.Connection,
+    yaml_path: Path,
+    platform_name: str,
+    library_name: str = None,
+) -> None:
+    with open(yaml_path) as yaml_file:
+        model = yaml.safe_load(yaml_file)
+
+    if not model:
+        return
+
+    if library_name is None:
+        library_name = yaml_path.stem
+
+    header_fields = {
+        key: value
+        for key, value in model.items()
+        if key not in ("ImportedDynamicFunctions", "TypeDefinitions")
+    }
+    header = yaml.safe_dump(
+        header_fields, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
+
+    connection.execute(
+        "INSERT OR IGNORE INTO Platform (Name) VALUES (?)", (platform_name,)
+    )
+    platform_id = connection.execute(
+        "SELECT PlatformID FROM Platform WHERE Name = ?", (platform_name,)
+    ).fetchone()[0]
+
+    connection.execute(
+        "INSERT OR IGNORE INTO Library (Name, PlatformID, Header) VALUES (?, ?, ?)",
+        (library_name, platform_id, header),
+    )
+    library_id = connection.execute(
+        "SELECT LibraryID FROM Library WHERE Name = ? AND PlatformID = ?",
+        (library_name, platform_id),
+    ).fetchone()[0]
+
+    original_id_to_database_id = {}
+    type_definitions = model.get("TypeDefinitions", [])
+
+    for type_definition in type_definitions:
+        original_id = type_definition["ID"]
+        body = yaml.safe_dump(
+            type_definition,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+        cursor = connection.execute(
+            "INSERT INTO TypeDefinition (LibraryID, Body, OriginalID) VALUES (?, ?, ?)",
+            (library_id, body, original_id),
+        )
+        original_id_to_database_id[original_id] = cursor.lastrowid
+
+    for type_definition in type_definitions:
+        database_id = original_id_to_database_id[type_definition["ID"]]
+        for reference_id in find_type_references(type_definition) - {
+            type_definition["ID"]
+        }:
+            if reference_id in original_id_to_database_id:
+                connection.execute(
+                    "INSERT OR IGNORE INTO TypeDefinitionDependencies "
+                    "(SourceTypeDefinitionID, DestinationTypeDefinitionID) "
+                    "VALUES (?, ?)",
+                    (original_id_to_database_id[reference_id], database_id),
+                )
+
+    for function in model.get("ImportedDynamicFunctions", []):
+        type_definition_database_id = None
+        prototype = function.get("Prototype")
+        if prototype and prototype.get("Kind") == "DefinedType":
+            match = TYPE_DEFINITION_REFERENCE_PATTERN.search(
+                prototype.get("Definition", "")
+            )
+            if match:
+                type_definition_database_id = original_id_to_database_id.get(
+                    int(match.group(1))
+                )
+        connection.execute(
+            "INSERT INTO Symbol (LibraryID, Name, Kind, TypeDefinitionID) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                library_id,
+                function["Name"],
+                "ImportedDynamicFunction",
+                type_definition_database_id,
+            ),
+        )
+
+
+class ModelExportSqliteCommand(Command):
+    def __init__(self):
+        super().__init__(
+            ("model", "export", "sqlite"),
+            "Import rev.ng YAML models into a SQLite database",
+        )
+
+    def register_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--db",
+            required=True,
+            help="Path to the output SQLite database",
+        )
+        parser.add_argument(
+            "--platform",
+            required=True,
+            help="Platform name (e.g. ubuntu-24-04-x86-64)",
+        )
+        parser.add_argument(
+            "--library",
+            default=None,
+            help="Override library name (default: filename stem)",
+        )
+        parser.add_argument(
+            "models",
+            nargs="+",
+            help="YAML model file(s) to import",
+        )
+
+    def run(self, options: Options) -> int:
+        args = options.parsed_args
+
+        connection = sqlite3.connect(args.db)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=NORMAL")
+        create_schema(connection)
+
+        for model_path in args.models:
+            path = Path(model_path)
+            log(f"Importing {path.name}...")
+            import_model(connection, path, args.platform, args.library)
+
+        connection.commit()
+        connection.close()
+        log("Import complete.")
+        return 0
+
+
+def setup(commands_registry: CommandsRegistry):
+    commands_registry.register_command(ModelExportSqliteCommand())

--- a/python/revng/internal/cli/revng.py
+++ b/python/revng/internal/cli/revng.py
@@ -23,6 +23,9 @@ _commands_registry.define_namespace(
     ("model", "import"), f"Model import helpers, see {executable_name()} model import --help"
 )
 _commands_registry.define_namespace(
+    ("model", "export"), f"Model export helpers, see {executable_name()} model export --help"
+)
+_commands_registry.define_namespace(
     ("trace",), f"Trace-related tools, see {executable_name()} trace --help"
 )
 _commands_registry.define_namespace(

--- a/tools/model/import/CMakeLists.txt
+++ b/tools/model/import/CMakeLists.txt
@@ -3,3 +3,4 @@
 #
 
 add_subdirectory(debug-info)
+add_subdirectory(sqlite)

--- a/tools/model/import/sqlite/CMakeLists.txt
+++ b/tools/model/import/sqlite/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+
+revng_add_executable(model-import-sqlite Main.cpp)
+
+llvm_map_components_to_libnames(LLVM_LIBRARIES Support)
+target_link_libraries(model-import-sqlite revngModel revngSupport
+                      ${LLVM_LIBRARIES} sqlite3)

--- a/tools/model/import/sqlite/Main.cpp
+++ b/tools/model/import/sqlite/Main.cpp
@@ -1,0 +1,293 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#include "revng/Model/Binary.h"
+#include "revng/Support/Debug.h"
+#include "revng/Support/InitRevng.h"
+#include "revng/Support/Sqlite3.h"
+
+namespace cl = llvm::cl;
+
+static cl::OptionCategory ThisToolCategory("Tool options", "");
+
+static cl::opt<std::string> DatabasePath("db",
+                                         cl::Required,
+                                         cl::desc("Path to the SQLite "
+                                                  "database"),
+                                         cl::cat(ThisToolCategory));
+
+static cl::opt<std::string> PlatformName("platform",
+                                         cl::Required,
+                                         cl::desc("Platform name"),
+                                         cl::cat(ThisToolCategory));
+
+static cl::opt<std::string> LibraryName("library",
+                                        cl::Required,
+                                        cl::desc("Library name"),
+                                        cl::cat(ThisToolCategory));
+
+static cl::list<std::string> SymbolNames("symbol",
+                                         cl::desc("Symbol to export "
+                                                  "(repeatable)"),
+                                         cl::OneOrMore,
+                                         cl::cat(ThisToolCategory));
+
+static cl::opt<std::string> OutputFilename("o",
+                                           cl::init("-"),
+                                           cl::desc("Output filename"),
+                                           cl::value_desc("filename"),
+                                           cl::cat(ThisToolCategory));
+
+/// Turn a TypeDefinition body (flat YAML mapping) into a YAML list item
+/// indented for inclusion under a top-level key.
+///
+/// Input (each line at column 0):
+///   ID: 123
+///   Kind: CABIFunctionDefinition
+///   ...
+///
+/// Output:
+///   - ID: 123
+///     Kind: CABIFunctionDefinition
+///     ...
+static std::string indentAsListItem(llvm::StringRef Body) {
+  std::string Result;
+  llvm::raw_string_ostream Stream(Result);
+
+  bool FirstLine = true;
+  while (!Body.empty()) {
+    auto [Line, Rest] = Body.split('\n');
+    if (FirstLine) {
+      Stream << "  - " << Line << "\n";
+      FirstLine = false;
+    } else if (!Line.empty()) {
+      Stream << "    " << Line << "\n";
+    }
+    Body = Rest;
+    if (Body.empty() && Line.empty())
+      break;
+  }
+
+  return Result;
+}
+
+int main(int Argc, char *Argv[]) {
+  revng::InitRevng X(Argc, Argv, "", { &ThisToolCategory });
+
+  llvm::ExitOnError ExitOnError;
+
+  Sqlite3Db Database(DatabasePath);
+
+  // 1. Fetch the library header
+  auto HeaderStatement = Database.makeStatement(R"(
+    SELECT l.Header
+    FROM Library l
+    JOIN Platform p ON l.PlatformID = p.PlatformID
+    WHERE l.Name = ?1 AND p.Name = ?2
+  )");
+  HeaderStatement.bind(1, llvm::StringRef(LibraryName));
+  HeaderStatement.bind(2, llvm::StringRef(PlatformName));
+
+  std::string Header;
+  bool Found = false;
+  for (auto [HeaderText] :
+       HeaderStatement.execute<llvm::StringRef>()) {
+    Header = HeaderText.str();
+    Found = true;
+  }
+
+  if (!Found) {
+    dbg << "No matching library/platform found.\n";
+    return EXIT_FAILURE;
+  }
+
+  // 2. Build the recursive CTE query for type definitions.
+  //    We need to build the IN clause dynamically.
+  std::string SymbolPlaceholders;
+  for (size_t I = 0; I < SymbolNames.size(); ++I) {
+    if (I > 0)
+      SymbolPlaceholders += ",";
+    SymbolPlaceholders += "?" + std::to_string(I + 1);
+  }
+
+  int LibraryParamIndex = SymbolNames.size() + 1;
+  int PlatformParamIndex = SymbolNames.size() + 2;
+
+  std::string TypeDefsSQL;
+  {
+    llvm::raw_string_ostream SQL(TypeDefsSQL);
+    SQL << R"(
+      WITH RECURSIVE DependentTypeDefinitions AS (
+        SELECT td.TypeDefinitionID, td.Body, td.OriginalID
+        FROM TypeDefinition td
+        JOIN Symbol s ON s.TypeDefinitionID = td.TypeDefinitionID
+        JOIN Library l ON s.LibraryID = l.LibraryID
+        JOIN Platform p ON l.PlatformID = p.PlatformID
+        WHERE s.Name IN ()" << SymbolPlaceholders << R"()
+          AND l.Name = ?)" << LibraryParamIndex << R"(
+          AND p.Name = ?)" << PlatformParamIndex << R"(
+        UNION
+        SELECT t.TypeDefinitionID, t.Body, t.OriginalID
+        FROM TypeDefinition t
+        JOIN TypeDefinitionDependencies dependency
+          ON dependency.SourceTypeDefinitionID = t.TypeDefinitionID
+        JOIN DependentTypeDefinitions dt
+          ON dependency.DestinationTypeDefinitionID = dt.TypeDefinitionID
+      )
+      SELECT DISTINCT Body, OriginalID
+      FROM DependentTypeDefinitions
+      ORDER BY OriginalID
+    )";
+  }
+
+  auto TypeDefsStatement = Database.makeStatement(TypeDefsSQL);
+  for (size_t I = 0; I < SymbolNames.size(); ++I)
+    TypeDefsStatement.bind(I + 1, llvm::StringRef(SymbolNames[I]));
+  TypeDefsStatement.bind(LibraryParamIndex, llvm::StringRef(LibraryName));
+  TypeDefsStatement.bind(PlatformParamIndex, llvm::StringRef(PlatformName));
+
+  // We need to extract the Kind from each body to build function references.
+  // The Kind is on a line like "Kind: CABIFunctionDefinition".
+  struct TypeInfo {
+    std::string Body;
+    int64_t OriginalID;
+    std::string Kind;
+  };
+
+  std::vector<TypeInfo> TypeDefinitions;
+  std::map<int64_t, std::string> OriginalIDToKind;
+
+  for (auto [Body, OriginalID] :
+       TypeDefsStatement.execute<llvm::StringRef, int64_t>()) {
+    std::string BodyStr = Body.str();
+
+    // Extract Kind from the YAML body
+    std::string Kind;
+    llvm::StringRef BodyRef(BodyStr);
+    while (!BodyRef.empty()) {
+      auto [Line, Rest] = BodyRef.split('\n');
+      if (Line.starts_with("Kind: ")) {
+        Kind = Line.substr(6).str();
+        break;
+      }
+      BodyRef = Rest;
+    }
+
+    OriginalIDToKind[OriginalID] = Kind;
+    TypeDefinitions.push_back({ std::move(BodyStr), OriginalID, Kind });
+  }
+
+  // 3. Fetch symbol rows
+  std::string SymbolsSQL;
+  {
+    llvm::raw_string_ostream SQL(SymbolsSQL);
+    SQL << R"(
+      SELECT s.Name, COALESCE(td.OriginalID, -1)
+      FROM Symbol s
+      JOIN Library l ON s.LibraryID = l.LibraryID
+      JOIN Platform p ON l.PlatformID = p.PlatformID
+      LEFT JOIN TypeDefinition td
+        ON s.TypeDefinitionID = td.TypeDefinitionID
+      WHERE s.Name IN ()" << SymbolPlaceholders << R"()
+        AND l.Name = ?)" << LibraryParamIndex << R"(
+        AND p.Name = ?)" << PlatformParamIndex;
+  }
+
+  auto SymbolsStatement = Database.makeStatement(SymbolsSQL);
+  for (size_t I = 0; I < SymbolNames.size(); ++I)
+    SymbolsStatement.bind(I + 1, llvm::StringRef(SymbolNames[I]));
+  SymbolsStatement.bind(LibraryParamIndex, llvm::StringRef(LibraryName));
+  SymbolsStatement.bind(PlatformParamIndex, llvm::StringRef(PlatformName));
+
+  struct SymbolInfo {
+    std::string Name;
+    int64_t OriginalID; // -1 if no type
+    bool HasType;
+  };
+
+  std::vector<SymbolInfo> Symbols;
+  for (auto [Name, OriginalID] :
+       SymbolsStatement.execute<llvm::StringRef, int64_t>()) {
+    bool HasType = OriginalID >= 0 && OriginalIDToKind.count(OriginalID) > 0;
+    Symbols.push_back({ Name.str(), OriginalID, HasType });
+  }
+
+  // 4. Compose the model YAML via string concatenation
+  std::string ModelYAML;
+  llvm::raw_string_ostream YAMLStream(ModelYAML);
+
+  YAMLStream << "---\n";
+
+  // Strip trailing whitespace from header
+  llvm::StringRef HeaderRef(Header);
+  HeaderRef = HeaderRef.rtrim();
+  YAMLStream << HeaderRef << "\n";
+
+  // ImportedDynamicFunctions
+  if (!Symbols.empty()) {
+    YAMLStream << "ImportedDynamicFunctions:\n";
+    for (const auto &Symbol : Symbols) {
+      YAMLStream << "  - Name:            " << Symbol.Name << "\n";
+      if (Symbol.HasType) {
+        auto KindIt = OriginalIDToKind.find(Symbol.OriginalID);
+        if (KindIt != OriginalIDToKind.end()) {
+          YAMLStream << "    Prototype:\n";
+          YAMLStream << "      Kind:            DefinedType\n";
+          YAMLStream << "      Definition:      \"/TypeDefinitions/"
+                     << Symbol.OriginalID << "-" << KindIt->second << "\"\n";
+        }
+      }
+    }
+  }
+
+  // TypeDefinitions
+  if (!TypeDefinitions.empty()) {
+    YAMLStream << "TypeDefinitions:\n";
+    for (const auto &TypeDef : TypeDefinitions) {
+      YAMLStream << indentAsListItem(TypeDef.Body);
+    }
+  }
+
+  YAMLStream << "...\n";
+  YAMLStream.flush();
+
+  // 5. Parse via TupleTree
+  auto MaybeModel = TupleTree<model::Binary>::fromString(ModelYAML);
+  if (!MaybeModel) {
+    dbg << "Failed to parse composed model YAML.\n";
+
+    // Dump the YAML for debugging
+    dbg << "--- Composed YAML ---\n" << ModelYAML << "\n";
+
+    llvm::consumeError(MaybeModel.takeError());
+    return EXIT_FAILURE;
+  }
+
+  // 6. Verify
+  if (!MaybeModel->verify()) {
+    dbg << "Warning: model verification failed.\n";
+  }
+
+  // 7. Dump
+  std::error_code EC;
+  llvm::ToolOutputFile OutputFile(OutputFilename,
+                                  EC,
+                                  llvm::sys::fs::OpenFlags::OF_Text);
+  if (EC) {
+    ExitOnError(llvm::createStringError(EC, EC.message()));
+  }
+
+  MaybeModel->serialize(OutputFile.os());
+  OutputFile.keep();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- Restore `Sqlite3.h` C++ wrapper (dropped in a previous refactor) and add `int64_t` column support
- Add `REVNG_NO_FETCH_DEBUG_INFO` environment variable to skip debug info fetching during `import-binary`, useful for batch processing where debug symbols are pre-cached
- Add `revng model export sqlite` Python command to export model YAML files into a SQLite database (types, symbols, dependencies)
- Add `revng model import sqlite` C++ tool to query the SQLite database and reconstruct model YAML for selected symbols with transitive type dependencies

## Test plan

- [ ] Build with `orc install -b revng`
- [ ] Verify `revng model export sqlite --help` works
- [ ] Verify `revng model import sqlite --help` works
- [ ] Export a model to SQLite: `revng model export sqlite --db test.db --platform test model.yml`
- [ ] Import symbols back: `revng model import sqlite --db test.db --platform test --library <lib> --symbol <sym>`
- [ ] Verify round-trip produces valid YAML
- [ ] Verify `REVNG_NO_FETCH_DEBUG_INFO=1 revng analyze import-binary` skips fetching