### PR TITLE
Emit Field Accesses

### DIFF
--- a/include/revng/CliftTransforms/Passes.h
+++ b/include/revng/CliftTransforms/Passes.h
@@ -25,6 +25,8 @@ PassPtr<clift::FunctionOp> createLoopDetectionPass();
 PassPtr<clift::FunctionOp> createOptimizeStatementsPass();
 PassPtr<clift::FunctionOp> createOptimizeExpressionsPass();
 
+PassPtr<clift::FunctionOp> createEmitFieldAccessesPass();
+
 PassPtr<clift::FunctionOp> createTerminalBranchComplementHoistingPass();
 
 PassPtr<clift::FunctionOp>

--- a/include/revng/CliftTransforms/Passes.td
+++ b/include/revng/CliftTransforms/Passes.td
@@ -43,6 +43,11 @@ def CliftOptimizeExpressions : Clift_Pass<"optimize-expressions",
   let options = RewritePassUtils.options;
 }
 
+def CliftEmitFieldAccesses : Clift_Pass<"emit-field-accesses", "clift::FunctionOp"> {
+  let summary = "Emit field accesses.";
+  let constructor = "mlir::clift::createEmitFieldAccessesPass()";
+}
+
 def CliftTerminalBranchComplementHoisting
   : Clift_Pass<"terminal-branch-complement-hoisting", "clift::FunctionOp"> {
 

--- a/lib/Clift/Clift.cpp
+++ b/lib/Clift/Clift.cpp
@@ -1353,13 +1353,14 @@ mlir::LogicalResult CastOp::verify() {
       return emitOpError() << getOperationName()
                            << " result must have pointer type.";
 
-    if (auto ArrayT = mlir::dyn_cast<ArrayType>(ArgT)) {
+    auto DealiasedArgT = dealias(ArgT);
+    if (auto ArrayT = mlir::dyn_cast<ArrayType>(DealiasedArgT)) {
       if (PtrT.getPointeeType() != ArrayT.getElementType())
         return emitOpError() << getOperationName()
                              << " the pointee type of the result type must be"
                                 " equal to the element type of the argument"
                                 " type.";
-    } else if (auto FunctionT = mlir::dyn_cast<FunctionType>(ArgT)) {
+    } else if (auto FunctionT = mlir::dyn_cast<FunctionType>(DealiasedArgT)) {
       if (PtrT.getPointeeType() != FunctionT)
         return emitOpError() << getOperationName()
                              << " the pointee type of the result type must be"

--- a/lib/CliftPipes/OptimizationPipe.cpp
+++ b/lib/CliftPipes/OptimizationPipe.cpp
@@ -60,6 +60,11 @@ public:
     PM.addPass(clift::createOptimizeStatementsPass());
     PM.addPass(clift::createLabelMergingPass());
     PM.addPass(clift::createOptimizeExpressionsPass());
+
+    PM.addPass(clift::createEmitFieldAccessesPass());
+    PM.addPass(mlir::createCanonicalizerPass());
+    PM.addPass(clift::createOptimizeExpressionsPass());
+
     PM.addPass(clift::createTerminalBranchComplementHoistingPass());
 
     PM.addPass(clift::createCLegalizationPass(TargetCImplementation::Default));

--- a/lib/CliftTransforms/BestTraversal.cpp
+++ b/lib/CliftTransforms/BestTraversal.cpp
@@ -1,0 +1,960 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+#include <compare>
+#include <cstdint>
+#include <optional>
+
+#include "revng/ADT/RecursiveCoroutine.h"
+#include "revng/Clift/Clift.h"
+#include "revng/Support/Assert.h"
+
+#include "BestTraversal.h"
+#include "PointerArithmetic.h"
+
+namespace clift = mlir::clift;
+using namespace clift;
+
+static Logger Log("best-traversal");
+
+/// Helper function used to retrieve the byte size of any `mlir::Type`
+static uint64_t getTypeSize(mlir::Type Type) {
+  return mlir::cast<clift::ValueType>(Type).getByteSize();
+}
+
+/// Helper function which converts a generic `ArrayPath` to a compatible form
+/// used to store the `array` traversal into the `Traversal` class. The
+/// re-ordering in descending `Stride` order is provided by the comparison
+/// operator of `ArrayShape`
+static llvm::SmallVector<ArrayShape>
+arrayPathToSortedVector(const ArrayPath &Path) {
+  llvm::SmallVector<ArrayShape> Result;
+  Result.reserve(Path.size());
+  for (const NestedArrayShape &Nested : Path) {
+    ArrayShape Shape;
+    Shape.NumElements = Nested.NumElements;
+    Shape.Stride = Nested.Stride;
+    Result.push_back(Shape);
+  }
+  llvm::sort(Result);
+  return Result;
+}
+
+// =============================================================================
+// `ArrayShape` class methods
+// =============================================================================
+
+// =============================================================================
+// `Traversal` class methods
+// =============================================================================
+
+Traversal::Traversal(mlir::Type TargetType,
+                     int64_t StartOffset,
+                     int64_t LeftoverOffset,
+                     std::vector<uint64_t> TraversedFields,
+                     const ArrayPath &Path) :
+  TargetType(TargetType),
+  StartOffset(StartOffset),
+  LeftoverOffset(LeftoverOffset),
+  TraversedFields(std::move(TraversedFields)),
+  TraversedArrays(arrayPathToSortedVector(Path)) {
+}
+
+int64_t Traversal::depth() const {
+  return TraversedArrays.size() + TraversedFields.size();
+}
+
+int64_t Traversal::begin() const {
+  return StartOffset + LeftoverOffset;
+}
+
+int64_t Traversal::end() const {
+  return begin() + getTypeSize(TargetType);
+}
+
+void Traversal::dump() const {
+
+  Log << "\nDumping Traversal:\n";
+
+  // We dump the `TargetType` on which the `Traversal` lands on
+  Log << "  TargetType: ";
+  TargetType.print(*Log.getAsLLVMStream());
+  Log << "\n";
+
+  // Dump the `StartOffset` and `LeftoverOffset`
+  Log << "  StartOffset: " << StartOffset << "\n";
+  Log << "  LeftoverOffset: " << LeftoverOffset << "\n";
+
+  // Dump all the `Traversed Fields` which this `Traversal` describes
+  Log << "  Traversed Fields (" << TraversedFields.size() << "): [";
+  for (size_t I = 0; I < TraversedFields.size(); ++I) {
+    if (I > 0)
+      Log << ", ";
+    Log << TraversedFields[I];
+  }
+  Log << "]\n";
+
+  // Dump all the `TraversedArray` which this `Traversal` describes
+  Log << "  Traversed Arrays (" << TraversedArrays.size() << "):\n";
+  for (const auto &Array : TraversedArrays) {
+    Log << "    { NumElements: " << Array.NumElements
+        << ", Stride: " << Array.Stride << " }\n";
+  }
+
+  Log << "\n";
+  Log.flush();
+}
+
+namespace {
+
+// =============================================================================
+// Static helper functions
+// =============================================================================
+
+/// Helper function which checks if the `BaseOffset` falls inside of the
+/// innermost `array` described by the `ArrayPath`
+static bool isCompatible(const ArrayPath &Path, llvm::APInt BaseOffset) {
+  for (const NestedArrayShape &Shape : Path) {
+
+    // If the offset doesn't reach the offset of this `Shape` inside its parent
+    // we just bail out
+    if (BaseOffset.ult(Shape.OffsetFromParentArrayElement)) {
+      return false;
+    }
+
+    BaseOffset -= Shape.OffsetFromParentArrayElement;
+
+    // If we're entering in an array element past the first, we have to adjust
+    // `BaseOffset`, consuming it
+    if (BaseOffset.uge(Shape.Stride)) {
+
+      // If we're jumping over the whole array, past it, we just bail out
+      if (BaseOffset.uge(Shape.Stride * Shape.NumElements)) {
+        return false;
+      }
+
+      // Otherwise adjust the `BaseOffset`, to set it to the offset inside the
+      // array element we're traversing
+      BaseOffset = BaseOffset.urem(Shape.Stride);
+    }
+  }
+
+  // If we reach this point, it means that the `ArrayPath` was inedeed
+  // compatible
+  return true;
+}
+
+/// Helper function which finds all the `ArrayPath`s that are compatible with a
+/// given `BaseOffset`
+static llvm::SmallVector<const ArrayPath *>
+findCompatibleArrayPaths(const std::vector<ArrayPath> &AllArrayPaths,
+                         const llvm::APInt &BaseOffset) {
+  llvm::SmallVector<const ArrayPath *> CompatibleArrays;
+  for (const ArrayPath &Path : AllArrayPaths) {
+    if (isCompatible(Path, BaseOffset))
+      CompatibleArrays.push_back(&Path);
+  }
+  return CompatibleArrays;
+}
+
+/// Helper function which counts the length of the common prefix between two
+/// sorted `TraversedArrays` vectors. Since both are sorted in descending stride
+/// order, this counts how many leading array shapes match exactly.
+static uint64_t commonPrefixStrides(const llvm::ArrayRef<ArrayShape> &LHS,
+                                    const llvm::ArrayRef<ArrayShape> &RHS) {
+  uint64_t Count = 0;
+  auto LIt = LHS.begin();
+  auto RIt = RHS.begin();
+
+  while (LIt != LHS.end() && RIt != RHS.end() && *LIt == *RIt) {
+    ++Count;
+    ++LIt;
+    ++RIt;
+  }
+
+  return Count;
+}
+
+/// The `typeDistance` function computes the distance between two `Type`s.
+/// Returns 0 if the types are equal (after stripping `typedef`s), or infinity
+/// otherwise. The return type is kept as `uint64_t` to allow future refinement
+/// of the scoring criterion, enabling more fine grained control over this
+/// score.
+static uint64_t typeDistance(mlir::Type Explicit, mlir::Type Ideal) {
+
+  // Unwrap any typedefs to compare the underlying types
+  Explicit = dealias(mlir::cast<ValueType>(Explicit),
+                     /*IgnoreQualifiers=*/true);
+  Ideal = dealias(mlir::cast<ValueType>(Ideal), /*IgnoreQualifiers=*/true);
+
+  return Explicit == Ideal ? 0 : std::numeric_limits<uint64_t>::max();
+}
+
+// =============================================================================
+// `Score` class definition
+// =============================================================================
+
+/// We represent the `SizeRelation` between two `Traversal`s
+enum class SizeRelation {
+  Same,
+  Larger,
+  Smaller,
+  DontCare
+};
+
+/// `Score` is used to represent the score obtained comparing two `Traversal`s.
+/// It embeds the criteria we define in order to select the `BestTraversal` that
+/// we want to use to rewrite the pointer access.
+struct Score {
+  bool Valid;
+  int64_t StartDistance;
+  SizeRelation SizeRelation;
+  uint64_t TypeDistance;
+  uint64_t CommonStrides;
+  int64_t Depth;
+
+  static Score invalid();
+
+  std::strong_ordering operator<=>(const Score &Other);
+};
+
+Score Score::invalid() {
+  return Score{ .Valid = false,
+                .StartDistance = 0,
+                .SizeRelation = SizeRelation::DontCare,
+                .TypeDistance = 0,
+                .CommonStrides = 0,
+                .Depth = 0 };
+}
+
+/// We redefine the spaceship operator in order to define the ordering criteria
+/// for comparing `Score`s, which drives the selection of the `BestTraversal`
+std::strong_ordering Score::operator<=>(const Score &Other) {
+
+  // An `Invalid` field must be considered `greater` than a `Valid` one
+  if (not Valid and Other.Valid) {
+    return std::strong_ordering::greater;
+  }
+  if (Valid and not Other.Valid) {
+    return std::strong_ordering::less;
+  }
+  if (not Valid and not Other.Valid) {
+    return std::strong_ordering::equal;
+  }
+
+  // When both `Score`s are valid, we move on to comparing:
+  // 1) `StartDistance`
+  auto Cmp = StartDistance <=> Other.StartDistance;
+  if (Cmp != 0) {
+    return Cmp;
+  }
+
+  // 2) `SizeRelation`
+  Cmp = SizeRelation <=> Other.SizeRelation;
+  if (Cmp != 0) {
+    return Cmp;
+  }
+
+  // 3) `TypeDistance`
+  Cmp = TypeDistance <=> Other.TypeDistance;
+  if (Cmp != 0) {
+    return Cmp;
+  }
+
+  // 4) `CommonStrides`
+  Cmp = Other.CommonStrides <=> CommonStrides;
+  if (Cmp != 0) {
+    return Cmp;
+  }
+
+  // 5) `Depth`
+  return Depth <=> Other.Depth;
+}
+
+/// The `score` function is used in order to obtain a _similarity_ `Score`
+/// between the `Explicit` and `Ideal` `Traversal`s. We want to select the
+/// `Traversal` with the minimal score as the one that will constitute the
+/// pointer access rewrite
+static Score score(const Traversal &Explicit, const Traversal &Ideal) {
+  int64_t StartDistance = Explicit.begin() - Ideal.begin();
+  int64_t EndDistance = Explicit.end() - Ideal.end();
+
+  uint64_t CommonStrides = commonPrefixStrides(Explicit.TraversedArrays,
+                                               Ideal.TraversedArrays);
+  uint64_t TypeDistValue = typeDistance(Explicit.TargetType, Ideal.TargetType);
+
+  if (StartDistance < 0) {
+
+    // Explicit comes first - invalid
+    return Score::invalid();
+  } else if (StartDistance == 0) {
+
+    // They start at same point
+    if (EndDistance == 0) {
+
+      // We have a perfect match, in this situation we will rely on the other
+      // criteria to elect the `BestTraversal`
+      return Score{ .Valid = true,
+                    .StartDistance = 0,
+                    .SizeRelation = SizeRelation::Same,
+                    .TypeDistance = TypeDistValue,
+                    .CommonStrides = CommonStrides,
+                    .Depth = Ideal.depth() };
+    } else if (EndDistance < 0) {
+
+      // Explicit ends before Ideal
+      return Score{ .Valid = true,
+                    .StartDistance = 0,
+                    .SizeRelation = SizeRelation::Larger,
+                    .TypeDistance = 0,
+                    .CommonStrides = 0,
+                    .Depth = Ideal.depth() };
+    } else if (EndDistance > 0) {
+
+      // Explicit ends after Ideal
+      return Score{ .Valid = true,
+                    .StartDistance = 0,
+                    .SizeRelation = SizeRelation::Smaller,
+                    .TypeDistance = 0,
+                    .CommonStrides = 0,
+                    .Depth = Ideal.depth() };
+    }
+  } else if (StartDistance > 0) {
+
+    // Ideal comes first (StartDistance > 0)
+    if (EndDistance <= 0) {
+
+      // Explicit ends before or at Ideal
+      return Score{ .Valid = true,
+                    .StartDistance = StartDistance,
+                    .SizeRelation = SizeRelation::DontCare,
+                    .TypeDistance = 0,
+                    .CommonStrides = 0,
+                    .Depth = Ideal.depth() };
+    } else {
+
+      // Explicit ends after Ideal - partial overlap, invalid
+      return Score::invalid();
+    }
+  }
+
+  // We do not expect that we can reach this point, all the previous case should
+  // cover all the possibilities
+  revng_abort();
+}
+
+// =============================================================================
+// `TypeTraversalAnalyzer` class definition
+// =============================================================================
+
+/// `TypeTraversalAnalyzer` is used as an oracle to compute and retrieve
+/// `Traversal`s and `ArrayPath`s in a lazy manner
+class TypeTraversalAnalyzer {
+private:
+  /// Reference to the cache containing the pre-computed `Traversal`s and
+  /// `ArrayPath`s. This passed in the constructor, as we want to cache the
+  /// information across different runs
+  TraversalInfoMap &Data;
+
+public:
+  TypeTraversalAnalyzer(TraversalInfoMap &Data) : Data(Data) {}
+
+public:
+  /// Retrieve the precomputed `Traversal`s for `BaseType` (or compute them
+  /// on-the-fly`)
+  const std::vector<Traversal> &getTraversals(mlir::Type BaseType);
+
+  /// Retrieve the precomputed `ArrayPath`s for `BaseType` (or compute them
+  /// on-the-fly`)
+  const std::vector<ArrayPath> &getArrayPaths(mlir::Type BaseType);
+
+  /// Retrieve only the slice of `Traversal`s, starting from the `BaseType`,
+  /// that are useful for the comparison with the current access described by
+  /// `Arithmetic`.
+  /// There are two _modes of operation_:
+  /// 1) When `SmartLookup` is off, we simply retrieve all the `Traversal`s
+  ///    relative to `BaseType`. With this mode of operation, the additional
+  ///    parameters are actually useless.
+  //// 2) When `SmartLookup` is on, we employ some smarties in order to reduce
+  ///     the search space for `Traversal`s that we retrieve.
+  //      TODO: this mode of operation is not implemented ATM.
+  std::pair<std::vector<Traversal>::const_iterator,
+            std::vector<Traversal>::const_iterator>
+  getTraversalRange(mlir::Type BaseType,
+                    const PointerArithmetic &Arithmetic,
+                    mlir::Type PointeeType,
+                    bool SmartLookup);
+
+private:
+  /// Entry point for traversing the `BaseType`, and producing the corresponding
+  /// `Traversal`s and `ArrayPaths` (takes care of ordering them)
+  llvm::DenseMap<mlir::Type, TraversalInfo>::iterator
+  traverse(mlir::Type BaseType);
+
+  /// Underlying `impl` method for performing the recursive step of the traverse
+  /// of a `BaseType`. Uses `RecursiveCoroutine` for stack safety.
+  RecursiveCoroutine<void>
+  traverseImpl(mlir::Type Type,
+               std::vector<Traversal> &Traversals,
+               std::vector<ArrayPath> &ArrayPaths,
+               int64_t CurrentOffset = 0,
+               const std::vector<uint64_t> &FieldPath = {},
+               const ArrayPath &CurrentArrayPath = {});
+};
+
+const std::vector<Traversal> &
+TypeTraversalAnalyzer::getTraversals(mlir::Type BaseType) {
+  auto It = Data.find(BaseType);
+  if (It == Data.end()) {
+    It = traverse(BaseType);
+  }
+
+  return It->second.Traversals;
+}
+
+const std::vector<ArrayPath> &
+TypeTraversalAnalyzer::getArrayPaths(mlir::Type BaseType) {
+  auto It = Data.find(BaseType);
+  if (It == Data.end()) {
+    It = traverse(BaseType);
+  }
+
+  return It->second.ArrayPaths;
+}
+
+std::pair<std::vector<Traversal>::const_iterator,
+          std::vector<Traversal>::const_iterator>
+TypeTraversalAnalyzer::getTraversalRange(mlir::Type BaseType,
+                                         const PointerArithmetic &Arithmetic,
+                                         mlir::Type PointeeType,
+                                         bool SmartLookup) {
+
+  // TODO: for the time being, we do not implement the smart lookup logic, and
+  //       therefore we assert that this does not happen until we have added the
+  //       implementation
+  if (not SmartLookup) {
+    const std::vector<Traversal> &Traversals = getTraversals(BaseType);
+    return { Traversals.begin(), Traversals.end() };
+  }
+
+  revng_abort("Fast lookup not implemented");
+}
+
+llvm::DenseMap<mlir::Type, TraversalInfo>::iterator
+TypeTraversalAnalyzer::traverse(mlir::Type BaseType) {
+  revng_assert(Data.count(BaseType) == 0);
+
+  auto [It, Inserted] = Data.insert({ BaseType, TraversalInfo() });
+  auto &[Traversals, ArrayPaths] = It->second;
+
+  // Add the empty `ArrayPath` representing the case where no `array` is
+  // traversed. This ensures that `toExplicitArrayAccesses` can produce
+  // explicit `Arithmetic`s even when no array traversal is involved.
+  ArrayPaths.push_back(ArrayPath());
+
+  // Recursively traverse the `BaseType` to populate `Traversal`s and
+  // `ArrayPath`s
+  rc_eval(traverseImpl(BaseType, Traversals, ArrayPaths));
+
+  // Sort traversals by `StartOffset`, then by `Size` of the `TargetType`
+  std::sort(Traversals.begin(),
+            Traversals.end(),
+            [](const Traversal &A, const Traversal &B) {
+              if (A.StartOffset != B.StartOffset) {
+                return A.StartOffset < B.StartOffset;
+              } else {
+                return getTypeSize(A.TargetType) < getTypeSize(B.TargetType);
+              }
+            });
+
+  // Sort `ArrayPath`s by `Stride`, larger first
+  for (auto &Path : ArrayPaths) {
+    std::sort(Path.begin(),
+              Path.end(),
+              [](const NestedArrayShape &A, const NestedArrayShape &B) {
+                return A.Stride > B.Stride;
+              });
+  }
+
+  return It;
+}
+
+RecursiveCoroutine<void>
+TypeTraversalAnalyzer::traverseImpl(mlir::Type Type,
+                                    std::vector<Traversal> &Traversals,
+                                    std::vector<ArrayPath> &ArrayPaths,
+                                    int64_t CurrentOffset,
+                                    const std::vector<uint64_t> &FieldPath,
+                                    const ArrayPath &CurrentArrayPath) {
+
+  // We should never reach a type with zero size - if we do, it means there is
+  // something severely wrong in the types we're working with
+  revng_assert(getTypeSize(Type) > 0);
+
+  if (auto PrimitiveType = mlir::dyn_cast<clift::PrimitiveType>(Type)) {
+    // `PrimitiveType` is a leaf node in our traversal
+    Traversals.emplace_back(PrimitiveType,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+    rc_return;
+  }
+
+  // `PointerType` is a leaf node in our traversal: we do not traverse
+  // through pointers, but we still want to produce a `Traversal` that
+  // lands on a field whose type is a pointer
+  if (auto Pointer = mlir::dyn_cast<clift::PointerType>(Type)) {
+    Traversals.emplace_back(Pointer,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+    rc_return;
+  }
+
+  // Traverse each `typedef`
+  if (auto Typedef = mlir::dyn_cast<clift::TypedefType>(Type)) {
+    Traversals.emplace_back(Typedef,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+    rc_recur traverseImpl(Typedef.getUnderlyingType(),
+                          Traversals,
+                          ArrayPaths,
+                          CurrentOffset,
+                          FieldPath,
+                          CurrentArrayPath);
+    rc_return;
+  }
+
+  // Traverse the `array`
+  if (auto ArrayType = mlir::dyn_cast<clift::ArrayType>(Type)) {
+    Traversals.emplace_back(ArrayType,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+    clift::ValueType ElementType = ArrayType.getElementType();
+    uint64_t NumElements = ArrayType.getElementsCount();
+    uint64_t ElementSize = ElementType.getByteSize();
+
+    // Add this array to the current array path
+    NestedArrayShape ArrayInfo;
+    ArrayInfo.OffsetFromParentArrayElement = 0;
+    ArrayInfo.Stride = ElementSize;
+    ArrayInfo.NumElements = NumElements;
+
+    ArrayPath NewArrayPath = CurrentArrayPath;
+    if (!NewArrayPath.empty()) {
+
+      // Adjust `OffsetFromParentArray` for nested arrays
+      ArrayInfo
+        .OffsetFromParentArrayElement = CurrentOffset
+                                        - (NewArrayPath.back()
+                                             .OffsetFromParentArrayElement);
+    } else {
+      ArrayInfo.OffsetFromParentArrayElement = CurrentOffset;
+    }
+    NewArrayPath.push_back(ArrayInfo);
+
+    // Record this array path
+    ArrayPaths.push_back(NewArrayPath);
+
+    // Traverse into the first element of the array
+    rc_recur traverseImpl(ElementType,
+                          Traversals,
+                          ArrayPaths,
+                          CurrentOffset,
+                          FieldPath,
+                          NewArrayPath);
+    rc_return;
+  }
+
+  // Traverse `struct` or `union` (both implement `ClassType`).
+  // For `union`s, `Field.getOffset()` always returns 0 by verification.
+  if (auto ClassType = mlir::dyn_cast<clift::ClassType>(Type)) {
+    Traversals.emplace_back(ClassType,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+    llvm::ArrayRef<clift::FieldAttr> Fields = ClassType.getFields();
+    for (size_t I = 0; I < Fields.size(); ++I) {
+      clift::FieldAttr Field = Fields[I];
+      clift::ValueType FieldType = Field.getType();
+      int64_t FieldOffset = CurrentOffset + Field.getOffset();
+
+      std::vector<uint64_t> NewFieldPath = FieldPath;
+      NewFieldPath.push_back(static_cast<uint64_t>(I));
+
+      rc_recur traverseImpl(FieldType,
+                            Traversals,
+                            ArrayPaths,
+                            FieldOffset,
+                            NewFieldPath,
+                            CurrentArrayPath);
+    }
+    rc_return;
+  }
+
+  // Traverse the `enum`
+  if (auto EnumType = mlir::dyn_cast<clift::EnumType>(Type)) {
+
+    // We traverse the underlying `EnumType`
+    clift::ValueType UnderlyingType = EnumType.getUnderlyingType();
+
+    // Add traversal for the `enum` itself
+    Traversals.emplace_back(EnumType,
+                            CurrentOffset,
+                            0,
+                            FieldPath,
+                            CurrentArrayPath);
+
+    // Also traverse into the underlying type inside the `enum
+    rc_recur traverseImpl(UnderlyingType,
+                          Traversals,
+                          ArrayPaths,
+                          CurrentOffset,
+                          FieldPath,
+                          CurrentArrayPath);
+    rc_return;
+  }
+}
+
+// =============================================================================
+// `BestTraversalChooser` class definition
+// =============================================================================
+
+/// `BestTraversalChooser` is used as a compute class for the `BestTraversal`
+class BestTraversalChooser {
+private:
+  /// The `TypeTraversalAnalyzer` is our `Traversal` and `ArrayPath` oracle
+  TypeTraversalAnalyzer TraversalAnalyzer;
+
+  /// Bit width of the pointer type being rewritten
+  unsigned PointerBitWidth = 0;
+
+public:
+  /// We need an explicit constructor in order to propagate the
+  /// `TraversalInfoMap` which is used as a global cache for storing
+  /// `Traversal`s and `ArrayPath`s
+  BestTraversalChooser(TraversalInfoMap &Data) : TraversalAnalyzer(Data) {}
+
+public:
+  /// Public entry point for computing the `BestTraversal` for the
+  /// `PointerToReplace` and the pre-computed `Arithmetic`
+  std::optional<Traversal>
+  computeBestTraversal(ExpressionOpInterface PointerToReplace,
+                       const PointerArithmetic &Arithmetic);
+
+private:
+  /// Obtain the explicit rewrite of the constant folded portion of
+  /// `Arithmetic`, following an array traversal described by `ArrayPath`, so
+  /// that it is evident in the `LinearCombination` component of `Arithmetic`
+  std::optional<PointerArithmetic>
+  getExplicitArithmetic(const PointerArithmetic &Arithmetic,
+                        const ArrayPath &ArrayPath);
+
+  /// Obtain all the explicit rewritings of the input `Arithmetic` following all
+  /// the `ArrayPath`s for the `BaseType`
+  std::vector<PointerArithmetic>
+  toExplicitArrayAccesses(const PointerArithmetic &Arithmetic);
+
+  /// Helper which trivially spill a `PointerArithmetic` into a `Traversal`
+  Traversal toTraversal(const PointerArithmetic &PA,
+                        mlir::Type PointeeType,
+                        const Traversal &Ideal);
+
+  /// Obtain the best `Traversal`
+  std::optional<Traversal>
+  getBestTraversal(mlir::Type BaseType,
+                   mlir::Type PointeeType,
+                   const std::vector<PointerArithmetic> &ExplicitArithmetics);
+};
+
+std::optional<Traversal>
+BestTraversalChooser::computeBestTraversal(ExpressionOpInterface
+                                             PointerToReplace,
+                                           const PointerArithmetic
+                                             &Arithmetic) {
+  // We only perform the substitution for `PointerType`
+  auto PointerToReplaceType = PointerToReplace->getResult(0).getType();
+  if (not isPointerType(PointerToReplaceType)) {
+    return std::nullopt;
+  }
+
+  // It may be that the `PointerToReplace` points to a `void 0` type, in that
+  // case we cannot provide a `Traversal` for sure
+  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
+  revng_assert(BasePtrType);
+  auto BaseType = BasePtrType.getPointeeType();
+  if (BaseType.getByteSize() == 0) {
+    return std::nullopt;
+  }
+
+  // Expand to explicit array accesses the input `PointerArithmetic`, so that
+  // the constant folded component performed by the compiler is evident in the
+  // `LinearCombination` portion of `Arithmetic`
+  PointerBitWidth = getPointerType(PointerToReplaceType).getPointerSize() * 8;
+
+  std::vector<PointerArithmetic>
+    ExplicitArithmetics = toExplicitArrayAccesses(Arithmetic);
+
+  mlir::Type PointeeType = getPointerType(PointerToReplaceType)
+                             .getPointeeType();
+
+  // Obtain the `BestTraversal` for connecting `BaseType` to `PointeeType`,
+  // following one of the possible `ExplicitArithmetic`s
+  auto BestTraversal = getBestTraversal(BaseType,
+                                        PointeeType,
+                                        ExplicitArithmetics);
+
+  // In case we end up with a `BestTraversal` which does not actually traverse
+  // any `struct` field or `array` element, we avoid the rewriting altogether,
+  // and we leave the explicit pointer arithmetic access in `clift`
+  if (BestTraversal->depth() == 0) {
+    return std::nullopt;
+  }
+
+  return BestTraversal;
+}
+
+// Turn the input `Arithmetic` into another `PointerArithmetic` , following the
+// array traversal dictaded by the `ArrayPath` `AP`. On success, the output
+// `PointerArithmetic` has a `StartOffset` that is lower than or equal than the
+// input one, and all the array traversals of `AP` have an equivalent
+// `StridedTerm` in the `LinearCombination` of `OffsetExpression` of the
+// `Result`.
+// For example this can turn P + 12 (with no `LinearCombination`) into
+// P + 8 * 1 + 4 (with a single `StridedTerm`, with fixed `Index`) if `AP` is
+// e.g. `{.OffsetFromParentArrayElement = 0, .EndOffset = 48, .Stride = 8}`)
+std::optional<PointerArithmetic>
+BestTraversalChooser::getExplicitArithmetic(const PointerArithmetic &Arithmetic,
+                                            const ArrayPath &AP) {
+
+  PointerArithmetic Result{
+    .BasePointer = Arithmetic.BasePointer,
+    .Offset = PointerArithmetic::OffsetExpression(PointerBitWidth)
+  };
+
+  // We do not modify the input `Arithmetic`, but we work on a local copy
+  PointerArithmetic WorkingArithmetic = Arithmetic;
+
+  for (const NestedArrayShape &NAI : AP) {
+    const auto &[OffsetFromParentArrayElement, NumElements, Stride] = NAI;
+
+    // Consume the offset from the parent array element
+    Result.Offset.BaseOffset += OffsetFromParentArrayElement;
+
+    revng_assert(WorkingArithmetic.Offset.BaseOffset
+                   .uge(OffsetFromParentArrayElement));
+    llvm::APInt OffsetInsideArray = WorkingArithmetic.Offset.BaseOffset
+                                    - OffsetFromParentArrayElement;
+    WorkingArithmetic.Offset.BaseOffset = OffsetInsideArray;
+
+    // If, after adjusting `StartOffset`, the `StartOffset` of `Arithmetic` is
+    // still larger than the `Stride` coming from `NAI`, we have to take that
+    // into account and add to the `Result` a constant `StridedTerm`
+    auto &LC = Result.Offset.LinearCombination;
+
+    // `Stride`s must be in non-ascending order (equal strides are allowed for
+    // nested arrays with the same element size, e.g., int array[1][1])
+    revng_assert(LC.empty() or LC.back().Stride.uge(Stride));
+
+    llvm::APInt IndexConstantComponent = llvm::APInt(PointerBitWidth, 0);
+    if (WorkingArithmetic.Offset.BaseOffset.uge(Stride)) {
+      IndexConstantComponent = WorkingArithmetic.Offset.BaseOffset.udiv(Stride);
+      revng_assert(IndexConstantComponent.ult(NumElements));
+      WorkingArithmetic.Offset.BaseOffset = WorkingArithmetic.Offset.BaseOffset
+                                              .urem(Stride);
+    }
+
+    mlir::Value IndexVariableComponent = {};
+
+    // If the `PointerArithmetic` is doing a variable-index array traversal with
+    // a stride that differs from NAI, then we have to bail out. Either a
+    // subsequent `ArrayPath` will hit the sweet spot, or none will, but that's
+    // not something we have to handle here.
+    if (not WorkingArithmetic.Offset.LinearCombination.empty()) {
+      if (WorkingArithmetic.Offset.LinearCombination.front()
+            .Stride.ugt(Stride)) {
+        return std::nullopt;
+      }
+      if (Stride == WorkingArithmetic.Offset.LinearCombination.front().Stride) {
+        auto &FrontTerm = WorkingArithmetic.Offset.LinearCombination.front();
+        IndexVariableComponent = FrontTerm.Idx.Variable;
+
+        // If the index also has a constant component, sum it into the
+        // `IndexConstantComponent` we are building
+        if (FrontTerm.Idx.Constant.getBoolValue()) {
+          IndexConstantComponent += FrontTerm.Idx.Constant;
+        }
+
+        WorkingArithmetic.Offset.LinearCombination
+          .erase(WorkingArithmetic.Offset.LinearCombination.begin());
+      }
+    }
+
+    // We add a new term to the constructed `LinearCombination`, using the
+    // `Index` components identified
+    LC.push_back(PointerArithmetic::StridedTerm(llvm::APInt(PointerBitWidth,
+                                                            Stride),
+                                                { IndexVariableComponent,
+                                                  IndexConstantComponent }));
+  }
+
+  // If we were not able to consume all the `LinerCombination`s of the input
+  // `Arithmetic`, we bail out
+  if (not WorkingArithmetic.Offset.LinearCombination.empty()) {
+    return std::nullopt;
+  }
+
+  // If we still have some non-consumed portion of the input `BaseOffset`, we
+  // propagate it in the `Result`
+  if (WorkingArithmetic.Offset.BaseOffset.getBoolValue()) {
+    Result.Offset.BaseOffset += WorkingArithmetic.Offset.BaseOffset;
+  }
+
+  return Result;
+}
+
+std::vector<PointerArithmetic>
+BestTraversalChooser::toExplicitArrayAccesses(const PointerArithmetic
+                                                &Arithmetic) {
+  std::vector<PointerArithmetic> Result;
+
+  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
+  revng_assert(BasePtrType);
+  auto BaseType = BasePtrType.getPointeeType();
+
+  // We retrieve all the `ArrayPath`s that we can build from `BaseType`
+  const std::vector<ArrayPath> &ArrayPaths = TraversalAnalyzer
+                                               .getArrayPaths(BaseType);
+
+  // We now filter the `ArrayPath`s by taking into consideration only those that
+  // are compatible with the `BaseOffset` access present in the
+  // `PointerArithmetic` that we are considering
+  auto CompatibleArrayPaths = findCompatibleArrayPaths(ArrayPaths,
+                                                       Arithmetic.Offset
+                                                         .BaseOffset);
+
+  for (const ArrayPath *TheArrayPath : CompatibleArrayPaths) {
+
+    // Try and turn `Arithmetic` into a form where all array indexes, even the
+    // constant ones, are explicit. In case of success, we enqueue the
+    // `Explicit` in the final `Result`s
+    std::optional<PointerArithmetic>
+      Explicit = getExplicitArithmetic(Arithmetic, *TheArrayPath);
+    if (Explicit) {
+      Result.push_back(std::move(*Explicit));
+    }
+  }
+
+  return Result;
+}
+
+Traversal BestTraversalChooser::toTraversal(const PointerArithmetic &PA,
+                                            mlir::Type PointeeType,
+                                            const Traversal &Ideal) {
+
+  // Ensure that we never end up with a negative `LeftoverOffset`, which would
+  // not make any sense
+  revng_assert(Ideal.StartOffset >= 0);
+  revng_assert(PA.Offset.BaseOffset.uge(Ideal.StartOffset));
+
+  // We want to turn an explicit `PointerArithmetic` `PA` in a `Traversal`,
+  // assuming that it does the traversal described in `Ideal`.
+  // Because `PA` is explicit (i.e. all array traversals at fixed index have
+  // been expanded in the `LinearCombination`), the `Result` `Traversal` will
+  // always be the same, except that we have to adjust the leftover offset
+  // and fix the `TargetType` to the actual type required by the traversal
+  auto BaseOffset = PA.Offset.BaseOffset.getZExtValue();
+  Traversal Result = Ideal;
+  Result.TargetType = PointeeType;
+  Result.LeftoverOffset = BaseOffset - Ideal.StartOffset;
+  return Result;
+}
+
+// To find the `BestTraversal`, we have to compare all the valid `Traversal`s
+// from `BaseType` with all the ones that we can build from the
+// `ExplicitArithmetic`s we get from `clift`.
+std::optional<Traversal>
+BestTraversalChooser::getBestTraversal(mlir::Type BaseType,
+                                       mlir::Type PointeeType,
+                                       const std::vector<PointerArithmetic>
+                                         &ExplicitArithmetics) {
+
+  std::optional<Traversal> BestTraversal = std::nullopt;
+  Score BestScore = Score::invalid();
+
+  // The `Traversal`s are lazily computed upon first inspection of a `BaseType`
+  const std::vector<Traversal> &Traversals = TraversalAnalyzer
+                                               .getTraversals(BaseType);
+
+  for (const PointerArithmetic &Explicit : ExplicitArithmetics) {
+
+    // Get the range of `Traversal`s to compare from the `TraversalAnalyzer`.
+    // There are two modes of operation for this: with `SmartLookup`, or
+    // without.
+    // ATM only `SmartLookup` is not implemented. Once it is however,
+    // in the tests we want to double check that the results obtained are the
+    // SAME both if `SmartLookup` enabled and disabled.
+    auto [Begin, End] = TraversalAnalyzer.getTraversalRange(BaseType,
+                                                            Explicit,
+                                                            PointeeType,
+                                                            false);
+    for (auto It = Begin; It != End; ++It) {
+      const Traversal &Ideal = *It;
+
+      // Skip `Ideals` whose `StartOffset` exceeds the `Explicit` `BaseOffset`,
+      // the `Explicit` cannot reach that far, and `toTraversal` would
+      // underflow.
+      auto BaseOffset = Explicit.Offset.BaseOffset.getZExtValue();
+      if (Explicit.Offset.BaseOffset.ult(Ideal.StartOffset))
+        continue;
+
+      // Convert each `ExplicitArithemtic` into a `Traversal`, so we can compare
+      // it with `Ideal`. `ExplicitTraversal` is the `Traversal` that we
+      // would obtain traversing the `BaseType` with `Explicit` if we did
+      // traverse it as the `Ideal` suggests. Basically what can be
+      // different is just the `LeftOverOffset`.
+      Traversal ExplicitTraversal = toTraversal(Explicit, PointeeType, Ideal);
+
+      Score CurrentScore = score(ExplicitTraversal, Ideal);
+
+      if (!CurrentScore.Valid)
+        continue;
+
+      // We select the `Score` which best suits the criteria defining in the
+      // _scoring_ mechanism
+      if (CurrentScore < BestScore) {
+        BestScore = CurrentScore;
+        BestTraversal = ExplicitTraversal;
+      }
+    }
+  }
+
+  // We serialize on the `Log` the selected `BestTraversal`
+  if (Log.isEnabled() and BestTraversal) {
+    Log << "Elected  BestTraversal:\n";
+    BestTraversal->dump();
+  }
+
+  // If no `Traversal` was valid, we'll return a `nullopt` here, meaning that we
+  // will not replace the `PointerToReplace` with a field access. This basically
+  // means that all the possible `Traversal`s that the clift expression could
+  // represent are so ugly that we bail out.
+  return BestTraversal;
+}
+
+} // namespace
+
+std::optional<Traversal>
+computeBestTraversal(ExpressionOpInterface PointerToReplace,
+                     const PointerArithmetic &Arithmetic,
+                     TraversalInfoMap &Data) {
+  auto BestTraversalC = BestTraversalChooser(Data);
+  return BestTraversalC.computeBestTraversal(PointerToReplace, Arithmetic);
+}

--- a/lib/CliftTransforms/BestTraversal.h
+++ b/lib/CliftTransforms/BestTraversal.h
@@ -1,0 +1,131 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <compare>
+#include <optional>
+#include <vector>
+
+#include "llvm/ADT/SmallVector.h"
+
+#include "revng/Support/Debug.h"
+
+#include "PointerArithmetic.h"
+
+/// `NestedArrayShape` represents the shape of a nested array element within a
+/// type traversal, including its offset from the parent array element, the
+/// number of elements, and the stride between consecutive elements
+struct NestedArrayShape {
+
+  // Represents the offset from the last _parent array_ element traversed to
+  // reach this array
+  int64_t OffsetFromParentArrayElement;
+  uint64_t NumElements;
+  uint64_t Stride;
+};
+
+/// A path of traversed `array`s is represented as a vector. These are kept
+/// sorted with larger strides first, and we assume that there are no duplicated
+/// strides
+using ArrayPath = std::vector<NestedArrayShape>;
+
+/// The `ArrayShape` struct is used to represent a generic array shape, where
+/// the concrete accessed element is not taken into consideration
+struct ArrayShape {
+  uint64_t NumElements; ///< Size of the described array
+  uint64_t Stride; ///< Stride of the described array
+
+  /// Orders `ArrayShape`s by descending `Stride`, then ascending `NumElements`
+  friend std::strong_ordering operator<=>(const ArrayShape &LHS,
+                                          const ArrayShape &RHS) {
+    // Descending Stride, then ascending NumElements
+    if (auto Cmp = RHS.Stride <=> LHS.Stride; Cmp != 0)
+      return Cmp;
+    return LHS.NumElements <=> RHS.NumElements;
+  }
+
+  friend bool operator==(const ArrayShape &LHS,
+                         const ArrayShape &RHS) = default;
+};
+
+/// This represents a type traversal starting from a fixed `BaseType`.
+/// A Traversal represents a way to traverse `BaseType` accessing struct fields,
+/// union fields and array elements, to reach a given fixed total offset from
+/// the beginning of `BaseType`. The total offset is composed of two components:
+///
+/// * The `StartOffset`, which is the start offset of the innermost nested
+/// target field that the traversal reaches
+/// * The `LeftoverOffset`, which is the additional offset inside that target
+/// field, not explicitly captured by the `Traversal`.
+///
+/// Note: The index of the traversal for an array is not specified.
+///       In this sense, the traversal is "abstract".
+/// Note: `StartOffset` behaves like if the first element of each
+///       array is always traversed.
+struct Traversal {
+
+  /// The nested type, inside `BaseType`, where the `Traversal` lands
+  mlir::Type TargetType;
+
+  /// The start offset, from a fixed `BaseType`, which is "consumed" by this
+  /// `Traversal`
+  int64_t StartOffset;
+
+  /// Additional offset inside the `TargetType`, not explicitly covered by the
+  /// `Traversal`
+  int64_t LeftoverOffset;
+
+  /// The index (position in the fields array) of each traversed
+  /// `union`/`struct` field. For `struct`s, this is the positional index of the
+  /// field, not the byte offset. For unions, all fields start at offset 0 so
+  /// this is also the positional index.
+  std::vector<uint64_t> TraversedFields;
+
+  /// Sorted vector of `ArrayShape` describing the array traversals, ordered in
+  /// descending order by `Stride` (via `operator<` on `ArrayShape`). There can
+  /// be consecutive `ArrayShape`s with the same `Stride`, to allow expressing
+  /// e.g., `int array[1][1]`.
+  llvm::SmallVector<ArrayShape> TraversedArrays;
+
+  /// Construct a `Traversal` from its components, converting the `ArrayPath`
+  /// to a sorted `SmallVector<ArrayShape>` internally
+  Traversal(mlir::Type TargetType,
+            int64_t StartOffset,
+            int64_t LeftoverOffset,
+            std::vector<uint64_t> TraversedFields,
+            const ArrayPath &ArrayPath);
+
+  /// Total depth described by this `Traversal` (fields + array elements)
+  int64_t depth() const;
+
+  /// Initial offset accessed by the `Traversal`
+  int64_t begin() const;
+
+  /// First out of bound offset accessed by the `Traversal`, considering the
+  /// size of the `PointeeType`
+  int64_t end() const;
+
+  /// Debug `dump` method used to provide a textual representation on the logger
+  /// of the `Traversal`
+  void dump() const debug_function;
+};
+
+/// `TraversalInfo` describes a set of `Traversal`s and `ArrayPaths`, which we
+/// associated to a `mlir::Type` (so we can cache them)
+struct TraversalInfo {
+  std::vector<Traversal> Traversals;
+  std::vector<ArrayPath> ArrayPaths;
+};
+
+/// The map used to cache the `Traversal`s and `ArrayPath`s computed starting
+/// from a `mlir::Type`
+using TraversalInfoMap = llvm::DenseMap<mlir::Type, TraversalInfo>;
+
+/// Main entry point used to compute the `BestTraversal` from an `Expression`
+/// and PointerArithmetic`.
+std::optional<Traversal>
+computeBestTraversal(mlir::clift::ExpressionOpInterface PointerToReplace,
+                     const PointerArithmetic &Arithmetic,
+                     TraversalInfoMap &Data);

--- a/lib/CliftTransforms/CMakeLists.txt
+++ b/lib/CliftTransforms/CMakeLists.txt
@@ -5,13 +5,17 @@
 revng_add_library_internal(
   revngCliftTransforms
   SHARED
+  BestTraversal.cpp
   BooleanNegations.cpp
+  EmitFieldAccesses.cpp
   Expressions.cpp
+  FieldAccessReplacement.cpp
   ImmediateRadixDeduction.cpp
   LabelMerging.cpp
   Legalization.cpp
   LoopDetection.cpp
   PatternRewriter.cpp
+  PointerArithmetic.cpp
   RewriteHelpers.cpp
   Statements.cpp
   TerminalBranchComplementHoisting.cpp

--- a/lib/CliftTransforms/EmitFieldAccesses.cpp
+++ b/lib/CliftTransforms/EmitFieldAccesses.cpp
@@ -1,0 +1,98 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+#include <compare>
+#include <cstdint>
+#include <memory>
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#include "revng/Clift/CliftEnums.h"
+#include "revng/CliftTransforms/Passes.h"
+#include "revng/Support/CTarget.h"
+
+#include "BestTraversal.h"
+#include "EmitFieldAccesses.h"
+#include "FieldAccessReplacement.h"
+#include "PointerArithmetic.h"
+
+namespace mlir {
+namespace clift {
+#define GEN_PASS_DEF_CLIFTEMITFIELDACCESSES
+#include "revng/CliftTransforms/Passes.h.inc"
+} // namespace clift
+} // namespace mlir
+
+namespace clift = mlir::clift;
+using namespace clift;
+
+namespace {
+
+struct EmitFieldAccessesPass
+  : clift::impl::CliftEmitFieldAccessesBase<EmitFieldAccessesPass> {
+  void runOnOperation() override {
+    if (emitFieldAccesses(getOperation()).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+/// Holds the planned `Replacement` for a single expression
+struct PlannedReplacement {
+  clift::ExpressionOpInterface Op;
+  PointerArithmetic PA;
+  Traversal BestTraversal;
+};
+
+/// Implementation of the high level `emitFieldAccesses` phases inside the
+/// anonymous namespace in this translation unit
+mlir::LogicalResult emitFieldAccessesImpl(clift::FunctionOp Function) {
+
+  // `TraversalInfoMap` cache. Even if not elegant, we store the data computed
+  // at the pass level so that we can cache it instead of recomputing it every
+  // time
+  TraversalInfoMap TraversalMap;
+
+  // Phase 1-2: Collect all planned `Replacement`s without modifying the IR
+  llvm::SmallVector<PlannedReplacement> Replacements;
+  Function->walk([&TraversalMap,
+                  &Replacements](clift::ExpressionOpInterface Op) {
+    // 1. We inspect all the `ExpressionOp`s in the current `Function`
+    std::optional<PointerArithmetic> PA = computePointerArithmetic(Op);
+
+    // The `PointerArithmetic` returned object could be empty at the moment of
+    // return, and this is a signal that we could not compute a
+    // `PointerArithmetic` for the current `ExpressionOpInterface`
+
+    // 2. We proceed with the computation of the `BestTraversal` for the current
+    //    `PointerArithmetic`
+    if (PA) {
+      std::optional<Traversal> BT = computeBestTraversal(Op, *PA, TraversalMap);
+
+      if (BT) {
+        Replacements.push_back({ Op, std::move(*PA), std::move(*BT) });
+      }
+    }
+  });
+
+  // Phase 3: Apply all replacements
+  for (const auto &R : Replacements) {
+    replaceFieldAccess(R.Op, R.PA, R.BestTraversal);
+  }
+
+  // The IR is always in a valid state, regardless of whether we performed an
+  // operation rewrite or not.
+  return mlir::success();
+}
+
+} // namespace
+
+/// `emitFieldAccesses` driver that can be called by importing the header
+mlir::LogicalResult emitFieldAccesses(clift::FunctionOp Function) {
+  return emitFieldAccessesImpl(Function);
+}
+
+clift::PassPtr<clift::FunctionOp> clift::createEmitFieldAccessesPass() {
+  return std::make_unique<EmitFieldAccessesPass>();
+}

--- a/lib/CliftTransforms/EmitFieldAccesses.h
+++ b/lib/CliftTransforms/EmitFieldAccesses.h
@@ -1,0 +1,9 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "revng/Clift/Clift.h"
+
+mlir::LogicalResult emitFieldAccesses(mlir::clift::FunctionOp Function);

--- a/lib/CliftTransforms/Expressions.cpp
+++ b/lib/CliftTransforms/Expressions.cpp
@@ -49,6 +49,10 @@ static bool assignTypePunnedConstraint(mlir::Value Ptr, mlir::Value Value) {
   auto SrcType = mlir::cast<clift::ValueType>(Value.getType());
   auto DstType = PtrType.getPointeeType();
 
+  if (not isObjectType(DstType) or isArrayType(DstType)) {
+    return false;
+  }
+
   return SrcType != DstType and SrcType.getByteSize() == DstType.getByteSize();
 }
 

--- a/lib/CliftTransforms/FieldAccessReplacement.cpp
+++ b/lib/CliftTransforms/FieldAccessReplacement.cpp
@@ -1,0 +1,440 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "llvm/ADT/APInt.h"
+
+#include "revng/Clift/Clift.h"
+#include "revng/Clift/CliftTypes.h"
+
+#include "BestTraversal.h"
+#include "FieldAccessReplacement.h"
+#include "PointerArithmetic.h"
+
+namespace clift = mlir::clift;
+using namespace mlir::clift;
+
+namespace {
+
+/// Helper to unwrap a `clift` `Type` from a potential `PointerType` wrapper,
+/// returning the unwrapped `Type` and whether indirection was needed
+template<typename CliftType>
+static std::pair<CliftType, bool>
+getAccessedTypeInfo(mlir::Value CurrentValue) {
+  if (isPointerType(CurrentValue.getType())) {
+    auto PtrType = getPointerType(CurrentValue.getType());
+    return { mlir::cast<CliftType>(dealias(PtrType.getPointeeType())), true };
+  }
+  return { mlir::cast<CliftType>(dealias(CurrentValue.getType())), false };
+}
+
+// =============================================================================
+// `Replacement` struct definition
+// =============================================================================
+
+/// `Replacement` is used as a builder class to perform the rewrite of the
+/// pointer arithmetic with (multiple) `clift` `operation`s equivalent to the
+/// elected `BestTraversal`
+struct Replacement {
+
+  /// `FieldAccessInfo` represent the atomic element of the `Replacement`. It
+  /// can represent an access to `union`, `struct`, `array`, accompanied by the
+  /// relative `Index`
+  struct FieldAccessInfo {
+    enum Kind {
+      Union,
+      Struct,
+      Array
+    } TheKind;
+
+    // We need to have the possibility to represent an `Index` with both a
+    // constant and a variable component (in order to represent access like
+    // `[i + 4]`)
+    struct IndexInfo {
+      mlir::Value Variable;
+      uint64_t Constant;
+    } Index;
+  };
+
+  /// We store the sequence of needed `FieldAccess`es here
+  llvm::SmallVector<FieldAccessInfo> FieldAccesses;
+
+  /// `LeftoverOffset` holds the eventual portion of the access that is not
+  /// captured by the `BestTraversal`
+  PointerArithmetic::OffsetExpression LeftoverOffset;
+
+  /// Bit width of the pointer type being rewritten
+  unsigned PointerBitWidth;
+
+  /// This `static` method prepares the description of the `Replacement`, that
+  /// will be later applied
+  static Replacement make(unsigned PointerBitWidth,
+                          const PointerArithmetic &Arithmetic,
+                          const Traversal &BestTraversal);
+
+  /// This method performs the actual `clift` IR rewriting,
+  void replace(ExpressionOpInterface PointerToReplace,
+               const PointerArithmetic &Arithmetic) const;
+};
+
+// =============================================================================
+// `Replacement` methods implementation
+// =============================================================================
+
+/// Factory `make` constructor method
+Replacement Replacement::make(unsigned PointerBitWidth,
+                              const PointerArithmetic &Arithmetic,
+                              const Traversal &BestTraversal) {
+
+  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
+  auto BaseType = BasePtrType.getPointeeType();
+
+  // Start with an empty `Replacement` object, which will be populated in this
+  // routine
+  Replacement Result = {
+    .LeftoverOffset = PointerArithmetic::OffsetExpression(PointerBitWidth),
+    .PointerBitWidth = PointerBitWidth
+  };
+
+  // Copy the starting `BestTraversal` and `Offset`, we will consume them in the
+  // current phase
+
+  // We initialize the `LeftoverTraversal` with the `BestTraversal` we
+  // identified during phase 2, and we consume it until the whole `Replacement`
+  // is produced
+  Traversal LeftoverTraversal = BestTraversal;
+
+  // We initialize the `LeftoverOffset` with the offset expression that was
+  // produced in the `PointerArithmetic` during phase 1
+  PointerArithmetic::OffsetExpression LeftoverOffset = Arithmetic.Offset;
+
+  // We perform an iterator-based traversal of the fields, going over each
+  // component in the selected `Traversal` and building the `Replacement`
+  auto FieldIt = LeftoverTraversal.TraversedFields.begin();
+  auto FieldEnd = LeftoverTraversal.TraversedFields.end();
+  auto ArrayIt = LeftoverTraversal.TraversedArrays.begin();
+  auto ArrayEnd = LeftoverTraversal.TraversedArrays.end();
+  while (FieldIt != FieldEnd or ArrayIt != ArrayEnd) {
+
+    // Inspect the `TypedefType` and cast to a known `clift` `Type`
+    if (auto TypedefType = mlir::dyn_cast<clift::TypedefType>(BaseType)) {
+      BaseType = mlir::cast<mlir::Type>(TypedefType.getUnderlyingType());
+      continue;
+    }
+
+    // We should never reach these `Type`s by construction
+    if (isa<FunctionType, PointerType, PrimitiveType, EnumType>(BaseType)) {
+      revng_abort("Invalid type in traversal");
+    }
+
+    // Inspect `struct` or `union` (both implement ClassType)
+    if (auto ClassType = mlir::dyn_cast<clift::ClassType>(BaseType)) {
+
+      auto Kind = mlir::isa<clift::StructType>(BaseType) ?
+                    FieldAccessInfo::Struct :
+                    FieldAccessInfo::Union;
+      unsigned FieldIndex = *FieldIt++;
+
+      Result.FieldAccesses.push_back({ .TheKind = Kind,
+                                       .Index = { mlir::Value(),
+                                                  FieldIndex } });
+
+      // Look up the field by positional index. Subtract the field's byte
+      // offset from LeftoverOffset (for unions, getOffset() returns 0)
+      const FieldAttr &Field = ClassType.getFields()[FieldIndex];
+      BaseType = mlir::cast<mlir::Type>(Field.getType());
+      LeftoverOffset.BaseOffset -= Field.getOffset();
+
+      continue;
+    }
+
+    // Inspect the `array`
+    if (auto ArrayType = mlir::dyn_cast<clift::ArrayType>(BaseType)) {
+
+      ArrayShape CurrentArray = *ArrayIt++;
+
+      // When reaching this iteration, if there was an array traversal in the
+      // original traversal with a larger stride than the current, it must have
+      // been already processed in a previous iteration
+      if (not LeftoverOffset.LinearCombination.empty()) {
+        revng_assert(LeftoverOffset.LinearCombination.front()
+                       .Stride.ule(CurrentArray.Stride));
+      }
+
+      // We decide if we consume the offset from the `BaseOffset` or the
+      // `LinearCombination`
+      llvm::APInt NumFixedConsumedElements = llvm::APInt(PointerBitWidth, 0);
+      if (LeftoverOffset.BaseOffset.uge(CurrentArray.Stride)) {
+        NumFixedConsumedElements = LeftoverOffset.BaseOffset
+                                     .udiv(CurrentArray.Stride);
+        LeftoverOffset.BaseOffset -= CurrentArray.Stride
+                                     * NumFixedConsumedElements;
+      }
+
+      mlir::Value DynamicElementId = {};
+      const auto &LinearCombination = LeftoverOffset.LinearCombination;
+      if (not LinearCombination.empty()
+          and LinearCombination.front().Stride == CurrentArray.Stride) {
+        auto &FrontTerm = LeftoverOffset.LinearCombination.front();
+        DynamicElementId = FrontTerm.Idx.Variable;
+
+        // If the Idx also has a constant component, add it to the fixed
+        // consumed elements count
+        if (FrontTerm.Idx.Constant.getBoolValue()) {
+          NumFixedConsumedElements += FrontTerm.Idx.Constant;
+        }
+
+        LeftoverOffset.LinearCombination
+          .erase(LeftoverOffset.LinearCombination.begin());
+      }
+
+      Result.FieldAccesses
+        .push_back({ .TheKind = FieldAccessInfo::Array,
+                     .Index = { DynamicElementId,
+                                static_cast<uint64_t>(NumFixedConsumedElements
+                                                        .getZExtValue()) } });
+
+      // Move to the `array` element `Type`
+      BaseType = ArrayType.getElementType();
+
+      continue;
+    }
+  }
+
+  // We pass over the remaining `LeftoverOffset`
+  Result.LeftoverOffset = LeftoverOffset;
+
+  return Result;
+}
+
+void Replacement::replace(ExpressionOpInterface PointerToReplace,
+                          const PointerArithmetic &Arithmetic) const {
+
+  // We need the `PointerSize` in order to generate the `ImmediateOp`s used to
+  // access the `struct` fields and `array` members, and to generate the
+  // `AddressOp` at the end of the field access substitution. We extract it
+  // from the `PointerToReplace` we are processing.
+  auto PointerSize = getPointerType(PointerToReplace->getResult(0).getType())
+                       .getPointerSize();
+
+  // Set insertion point right before the `PointerToReplace`
+  mlir::OpBuilder Builder(PointerToReplace);
+  mlir::Value CurrentValue = Arithmetic.BasePointer;
+
+  // Every new `Operation` created in this phase will retain the `Location` of
+  // the original `PointerToReplace`.
+  // TODO: possible improvement for building the `PointerToReplaceLocation`.
+  //       We could consider merging all the locations of all the
+  //       `ExpressionOp`s that contributed to the computation of the
+  //       `PointerArithmetic`. That would be much more accurate and probably
+  //       give better results.
+  mlir::Location PointerToReplaceLoc = PointerToReplace.getLoc();
+
+  // Apply each field access in sequence
+  // Iterate over every `FieldAccess` in `Replacement`, and materialize the
+  // `clift` `Operation`s needed to perform such access
+  for (const FieldAccessInfo &Access : FieldAccesses) {
+    switch (Access.TheKind) {
+    case FieldAccessInfo::Kind::Struct: {
+      auto Index = Access.Index.Constant;
+      auto [Type,
+            IsIndirect] = getAccessedTypeInfo<clift::StructType>(CurrentValue);
+      mlir::Type FieldType = Type.getFields()[Index].getType();
+      CurrentValue = Builder.create<AccessOp>(PointerToReplaceLoc,
+                                              FieldType,
+                                              CurrentValue,
+                                              IsIndirect,
+                                              Index);
+      break;
+    }
+
+    case FieldAccessInfo::Kind::Union: {
+      auto Index = Access.Index.Constant;
+      auto [Type,
+            IsIndirect] = getAccessedTypeInfo<clift::UnionType>(CurrentValue);
+      mlir::Type FieldType = Type.getFields()[Index].getType();
+      CurrentValue = Builder.create<AccessOp>(PointerToReplaceLoc,
+                                              FieldType,
+                                              CurrentValue,
+                                              IsIndirect,
+                                              Index);
+      break;
+    }
+
+    case FieldAccessInfo::Kind::Array: {
+
+      // We may need to unwrap the `ArrayType` from a `PointerType`, and emit
+      // the needed `IndirectionOp` and `Decay` cast accordingly
+      auto [ArrayType,
+            IsIndirect] = getAccessedTypeInfo<clift::ArrayType>(CurrentValue);
+      if (IsIndirect) {
+        // Add the indirection operation
+        CurrentValue = Builder.create<IndirectionOp>(PointerToReplaceLoc,
+                                                     CurrentValue);
+      }
+
+      // In this situation, we need to add a `decay` cast in order to be
+      // able to perform the subscript access to the array
+      auto ArrayElementType = ArrayType.getElementType();
+      auto DecayType = PointerType::get(ArrayElementType, PointerSize);
+      CurrentValue = Builder.create<CastOp>(PointerToReplaceLoc,
+                                            DecayType,
+                                            CurrentValue,
+                                            CastKind::Decay);
+
+      // Emit the `mlir::Value` representing the `Index` access.
+      // We declare all the possible components (constant and variable parts)
+      // as uninitialized here, and later fill only the components that we
+      // need to emit.
+      mlir::Value FixedIndexValue = {};
+      mlir::Value DynamicIndexValue = {};
+      mlir::Value IndexValue = {};
+
+      // If present, we emit a new `mlir::Value` representing the constant
+      // component of the `Index` access. If we do not have a `DynamicIndex`
+      // component, we still emit a `imm 0` to represent the access to `[0]`.
+      if (Access.Index.Constant != 0 or not Access.Index.Variable) {
+        auto Index = Access.Index.Constant;
+        auto IntegerType = PrimitiveType::get(Builder.getContext(),
+                                              PrimitiveKind::GenericKind,
+                                              PointerSize);
+        FixedIndexValue = Builder.create<ImmediateOp>(PointerToReplaceLoc,
+                                                      IntegerType,
+                                                      Index);
+      }
+
+      // If present, we emit a new `mlir::Value` representing the variable
+      // component of the `Index` access
+      if (Access.Index.Variable) {
+        DynamicIndexValue = Access.Index.Variable;
+      }
+
+      // We compose the constant and variable components of the `Index` access
+      // depending on whether they are present
+      if (FixedIndexValue and DynamicIndexValue) {
+        IndexValue = Builder.create<AddOp>(PointerToReplaceLoc,
+                                           FixedIndexValue,
+                                           DynamicIndexValue);
+      } else if (FixedIndexValue) {
+        IndexValue = FixedIndexValue;
+      } else {
+        IndexValue = DynamicIndexValue;
+      }
+
+      // Finally, we emit the `SubscriptOp` using as `Index` the `mlir::Value`
+      // constructed above
+      CurrentValue = Builder.create<SubscriptOp>(PointerToReplaceLoc,
+                                                 CurrentValue,
+                                                 IndexValue);
+
+      break;
+    }
+    }
+  }
+
+  // Take address of the result, since we always start the replacement from a
+  // `PointerType`, we want to get back to it
+  auto CurrentValuePointerType = PointerType::get(CurrentValue.getType(),
+                                                  PointerSize);
+  CurrentValue = Builder.create<AddressofOp>(PointerToReplaceLoc,
+                                             CurrentValuePointerType,
+                                             CurrentValue);
+
+  // If there is a non-null `LeftoverOffset`, we add it as integer arithmetic
+  if (not LeftoverOffset.BaseOffset.isZero()
+      or not LeftoverOffset.LinearCombination.empty()) {
+
+    // Cast pointer to integer
+    auto IntegerType = PrimitiveType::get(Builder.getContext(),
+                                          PrimitiveKind::GenericKind,
+                                          PointerSize);
+    CurrentValue = Builder.create<CastOp>(PointerToReplaceLoc,
+                                          IntegerType,
+                                          CurrentValue,
+                                          CastKind::Bitcast);
+
+    // Add base offset
+    if (!LeftoverOffset.BaseOffset.isZero()) {
+      auto IntegerType = PrimitiveType::get(Builder.getContext(),
+                                            PrimitiveKind::GenericKind,
+                                            PointerSize);
+
+      auto LeftoverOffsetValue = LeftoverOffset.BaseOffset.getSExtValue();
+      auto AddOperandValue = Builder.create<ImmediateOp>(PointerToReplaceLoc,
+                                                         IntegerType,
+                                                         LeftoverOffsetValue);
+      CurrentValue = Builder.create<AddOp>(PointerToReplaceLoc,
+                                           CurrentValue,
+                                           AddOperandValue);
+    }
+
+    // Add strided terms
+    for (const auto &Term : LeftoverOffset.LinearCombination) {
+      // Multiply stride by index
+      auto IndexValue = Builder.create<ImmediateOp>(PointerToReplaceLoc,
+                                                    IntegerType,
+                                                    Term.Idx.Constant
+                                                      .getSExtValue());
+      auto StrideValue = Builder
+                           .create<ImmediateOp>(PointerToReplaceLoc,
+                                                IntegerType,
+                                                Term.Stride.getSExtValue());
+      auto StridedValue = Builder.create<clift::MulOp>(PointerToReplaceLoc,
+                                                       IndexValue,
+                                                       StrideValue);
+      CurrentValue = Builder.create<clift::AddOp>(PointerToReplaceLoc,
+                                                  CurrentValue,
+                                                  StridedValue);
+    }
+
+    // Cast back to pointer
+    auto PointerType = PointerType::get(CurrentValue.getType(), PointerSize);
+    CurrentValue = Builder.create<CastOp>(PointerToReplaceLoc,
+                                          PointerType,
+                                          CurrentValue,
+                                          CastKind::Bitcast);
+  }
+
+  // If the result type differs from PointerToReplace's type, add a cast on
+  // `clift` IR in order to make the replacement fit the replaced
+  // `PointerToReplace` `Type`
+  auto PointerToReplaceOp = PointerToReplace.getOperation();
+  if (CurrentValue.getType() != PointerToReplace->getResult(0).getType()) {
+    CurrentValue = Builder
+                     .create<CastOp>(PointerToReplaceLoc,
+                                     PointerToReplace->getResult(0).getType(),
+                                     CurrentValue,
+                                     CastKind::Bitcast);
+  }
+
+  // Replace all uses of `PointerToReplace` with `CurrentValue`
+  if (CurrentValue != Arithmetic.BasePointer) {
+    PointerToReplace->getResult(0).replaceAllUsesWith(CurrentValue);
+  }
+
+  // At this point, we are left in the `clift` IR with a set of dead `Value`s
+  // representing the old `PointerArithmetic`. We rely on a subsequent DCE
+  // pass to clean up all the dead `Value`s.
+}
+} // namespace
+
+/// Entry point function to perform the replacement of the pointer arithmetic
+/// access (`PointerToReplace`), with operations equivalent to the
+/// `BestTraversal` elected in the previous steps
+void replaceFieldAccess(ExpressionOpInterface PointerToReplace,
+                        const PointerArithmetic &Arithmetic,
+                        const Traversal &BestTraversal) {
+
+  // Derive the `PointerBitWidth` from the `PointerToReplace` type
+  unsigned PointerBitWidth = getPointerType(PointerToReplace->getResult(0)
+                                              .getType())
+                               .getPointerSize()
+                             * 8;
+
+  // We prepare the `Replacement`, which describes the `Traversal` in a way that
+  // can easily be converted into a series of `clift` `operation`s
+  auto R = Replacement::make(PointerBitWidth, Arithmetic, BestTraversal);
+
+  // We actually perform the replacement
+  R.replace(PointerToReplace, Arithmetic);
+}

--- a/lib/CliftTransforms/FieldAccessReplacement.h
+++ b/lib/CliftTransforms/FieldAccessReplacement.h
@@ -1,0 +1,12 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include "BestTraversal.h"
+#include "PointerArithmetic.h"
+
+void replaceFieldAccess(mlir::clift::ExpressionOpInterface PointerToReplace,
+                        const PointerArithmetic &Arithmetic,
+                        const Traversal &BestTraversal);

--- a/lib/CliftTransforms/PointerArithmetic.cpp
+++ b/lib/CliftTransforms/PointerArithmetic.cpp
@@ -1,0 +1,502 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+#include <compare>
+#include <optional>
+
+#include "revng/ADT/RecursiveCoroutine.h"
+#include "revng/Clift/Clift.h"
+
+#include "EmitFieldAccesses.h"
+#include "PointerArithmetic.h"
+
+namespace clift = mlir::clift;
+using namespace clift;
+
+static Logger Log("pointer-arithmetic");
+
+// =============================================================================
+// `PointerArithmetic` class methods
+// =============================================================================
+
+PointerArithmetic::OffsetExpression::OffsetExpression(unsigned BitWidth) :
+  BaseOffset(BitWidth, 0) {
+}
+
+PointerArithmetic::OffsetExpression::OffsetExpression(llvm::APInt Offset) :
+  BaseOffset(Offset) {
+}
+
+bool PointerArithmetic::isNumeric() const {
+  return !BasePointer;
+}
+
+bool PointerArithmetic::isAddress() const {
+  return static_cast<bool>(BasePointer);
+}
+
+bool PointerArithmetic::verify() const {
+
+  const auto &LinearCombination = Offset.LinearCombination;
+
+  // Check that strides are strictly positive. Negative or null strides do not
+  // make sense
+  for (const auto &Term : LinearCombination) {
+    if (Term.Stride.isNegative() or Term.Stride.isZero()) {
+      return false;
+    }
+  }
+
+  // Check that we do not have duplicated strides, and that they are in
+  // descending order
+  for (size_t I = 0; I < LinearCombination.size(); I++) {
+    for (size_t J = I + 1; J < LinearCombination.size(); J++) {
+      if (LinearCombination[I].Stride == LinearCombination[J].Stride) {
+        return false;
+      }
+      if (LinearCombination[I].Stride.ult(LinearCombination[J].Stride)) {
+        return false;
+      }
+    }
+  }
+
+  // If we pass all the previous checks, we have a valid `PointerArithmetic`
+  return true;
+}
+
+void PointerArithmetic::StridedTerm::dump() const {
+  Log << "      Stride: ";
+  Log << Stride.getZExtValue() << "\n";
+
+  Log << "      Dynamic Index: ";
+  if (Idx.Variable) {
+    mlir::Value ValueToPrint = Idx.Variable;
+    ValueToPrint.print(*Log.getAsLLVMStream());
+  } else {
+    Log << "(null)";
+  }
+  Log << "\n";
+
+  Log << "      Fixed Offset: ";
+  Log << Idx.Constant.getSExtValue() << "\n";
+}
+
+void PointerArithmetic::OffsetExpression::dump() const {
+  Log << "  Base Offset: ";
+  Log << BaseOffset.getSExtValue() << "\n";
+
+  Log << "  Linear Combinations (" << LinearCombination.size() << " terms):\n";
+
+  for (size_t I = 0; I < LinearCombination.size(); ++I) {
+    Log << "    Term #" << I << ":\n";
+    LinearCombination[I].dump();
+  }
+}
+
+void PointerArithmetic::dump() const {
+
+  Log << "Dumping PointerArithmetic object:\n";
+
+  Log << "  BasePointer: ";
+  if (BasePointer) {
+    mlir::Value ValueToPrint = BasePointer;
+    ValueToPrint.print(*Log.getAsLLVMStream());
+    Log << "\n";
+  } else {
+    Log << "(null)\n";
+  }
+
+  Offset.dump();
+
+  Log << "\n";
+  Log.flush();
+}
+
+// =============================================================================
+// `PointerArithmeticBuilder` class implementation, which contains the logic
+// used to compute the resulting `PointerArithmetic`
+// =============================================================================
+
+/// The `PointerArithmeticBuilder` class is the main helper class used for
+/// computing the `PointerArithmetic` object starting from the
+/// `PointerToReplace`
+class PointerArithmeticBuilder {
+  unsigned PointerBitWidth = 0;
+
+public:
+  PointerArithmeticBuilder() = default;
+
+  // Compute pointer arithmetic for a given `PointerToReplace`
+  std::optional<PointerArithmetic>
+  computePointerArithmetic(mlir::clift::ExpressionOpInterface PointerToReplace);
+
+private:
+  // Traversal function to inspect the operands. Uses RecursiveCoroutine
+  // for stack safety, since traverse and compose* are mutually recursive
+  // over user input expressions.
+  RecursiveCoroutine<std::optional<PointerArithmetic>> traverse(mlir::Value V);
+
+  // Return the `PointerArithmetic` for the leaf nodes
+  PointerArithmetic createLeaf(mlir::Value V);
+
+  // Methods which are used to compose the currently computed
+  // `PointerArithmetic` with different `clift` `Operation`s that want to
+  // traverse during our exploration
+  RecursiveCoroutine<std::optional<PointerArithmetic>>
+  composeBitcast(CastOp Bitcast);
+
+  RecursiveCoroutine<std::optional<PointerArithmetic>> composeAdd(AddOp Add);
+
+  RecursiveCoroutine<std::optional<PointerArithmetic>>
+  composePtrAdd(PtrAddOp PtrAdd);
+
+  RecursiveCoroutine<std::optional<PointerArithmetic>> composeMul(MulOp Mul);
+
+  RecursiveCoroutine<std::optional<PointerArithmetic>>
+  composeShl(ShiftLeftOp ShiftLeft);
+
+  // Helper function used to multiply all the `PointerArithmetic` strides and
+  // offset by a constant. Clears the BasePointer since the result of a
+  // multiplication is no longer a pointer.
+  PointerArithmetic multiplyByConstant(PointerArithmetic PA,
+                                       const llvm::APInt &Multiplier);
+
+  // Helper function used to sort linear combination by stride, in descending
+  // order
+  void sortLinearCombination(PointerArithmetic &PA);
+};
+
+// =============================================================================
+// Static helper standalone functions
+// =============================================================================
+
+/// Helper function used to verify if an `ExpressionOpInterface` is
+/// `PointerType`d
+static bool isPointerTyped(ExpressionOpInterface Expr) {
+  return Expr->getNumResults() > 0
+         and isPointerType(Expr->getResult(0).getType());
+}
+
+/// Helper function used to extract the underlying constant value from an
+/// `Value`
+static std::optional<llvm::APInt> getConstantValue(mlir::Value V,
+                                                   unsigned BitWidth) {
+  if (auto Immediate = V.getDefiningOp<ImmediateOp>()) {
+    return llvm::APInt(BitWidth, Immediate.getValue());
+  }
+
+  return std::nullopt;
+}
+
+// =============================================================================
+// `PointerArithmeticBuilder` class methods
+// =============================================================================
+
+std::optional<PointerArithmetic>
+PointerArithmeticBuilder::computePointerArithmetic(ExpressionOpInterface
+                                                     PointerToReplace) {
+
+  // We skip every non pointer-typed `PointerToReplace`
+  if (not isPointerTyped(PointerToReplace)) {
+    return std::nullopt;
+  }
+
+  // Derive the pointer bit size from the PointerToReplace type
+  auto PtrType = getPointerType(PointerToReplace->getResult(0).getType());
+  PointerBitWidth = PtrType.getPointerSize() * 8;
+
+  // We traverse upwards the dataflow starting from the
+  auto Result = rc_eval(traverse(PointerToReplace->getResult(0)));
+
+  // If we got a numeric result, discard it, since we cannot use it
+  if (Result and Result->isNumeric()) {
+    return std::nullopt;
+  }
+
+  // Verify invariants for the obtained `PointerArithmetic`
+  revng_assert(not Result or Result->verify());
+
+  // Log the resulting `PointerArithmetic`, together with the initial
+  // `PointerToReplace` it was produced from
+  if (Log.isEnabled() and PointerToReplace and Result) {
+    Log << "PointerArithmetic Relative to operation:\n";
+    PointerToReplace.print(*Log.getAsLLVMStream());
+    Log << "\n";
+    Result->dump();
+  }
+
+  // If we reach this point, it means that we successfully computed the
+  // `PointerArithmetic` object, so we can return it, so that the rewrite can
+  // happen in later phases
+  return Result;
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::traverse(mlir::Value V) {
+
+  // Every time we find a compatible `Expression`, we traverse it in order to
+  // compose its operands
+  if (auto Expr = V.getDefiningOp<ExpressionOpInterface>()) {
+    if (auto Cast = mlir::dyn_cast<CastOp>(Expr.getOperation())) {
+      if (Cast.getKind() == CastKind::Bitcast) {
+        rc_return rc_recur composeBitcast(Cast);
+      }
+    } else if (auto Add = mlir::dyn_cast<AddOp>(Expr.getOperation())) {
+      rc_return rc_recur composeAdd(Add);
+    } else if (auto PtrAdd = mlir::dyn_cast<PtrAddOp>(Expr.getOperation())) {
+      rc_return rc_recur composePtrAdd(PtrAdd);
+    } else if (auto Mul = mlir::dyn_cast<MulOp>(Expr.getOperation())) {
+      rc_return rc_recur composeMul(Mul);
+    } else if (auto Shl = mlir::dyn_cast<ShiftLeftOp>(Expr.getOperation())) {
+      rc_return rc_recur composeShl(Shl);
+    }
+  }
+
+  // If we do not traverse V, we create the leaf
+  rc_return createLeaf(V);
+}
+
+PointerArithmetic PointerArithmeticBuilder::createLeaf(mlir::Value V) {
+  using OffsetExpression = PointerArithmetic::OffsetExpression;
+  PointerArithmetic PA{ .Offset = OffsetExpression(PointerBitWidth) };
+  if (isPointerType(V.getType())) {
+
+    // Pointer typed expression
+    PA.BasePointer = V;
+    PA.Offset = OffsetExpression(llvm::APInt(PointerBitWidth, 0));
+  } else if (auto ConstantValue = getConstantValue(V, PointerBitWidth)) {
+
+    // Integer Constant
+    PA.Offset = OffsetExpression(*ConstantValue);
+  } else {
+
+    // We want to handle `ExpressionOpInterface`s and `mlir::BlockArgument`s for
+    // building leaf `PA` containing a `LinearCombination`. These can be the
+    // `Index` component of an array access.
+    // Generic offset expression - strided 1 term.
+    PA.Offset = OffsetExpression(llvm::APInt(PointerBitWidth, 0));
+    PA.Offset.LinearCombination.emplace_back(llvm::APInt(PointerBitWidth, 1),
+                                             PointerArithmetic::Index{
+                                               V,
+                                               llvm::APInt(PointerBitWidth,
+                                                           0) });
+  }
+
+  return PA;
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::composeBitcast(CastOp Cast) {
+
+  // Retrieve the `bitcast` single `Operand`, and recursively forward the
+  // `PointerArithmetic` produced from it
+  auto Operand = Cast->getOperand(0);
+
+  auto OperandPA = rc_recur traverse(Operand);
+
+  // Potentially, every `bitcast` could be treated as a `PointerOperand` leaf in
+  // the exploration, if it was a `PointerType`. This can be useful in cases
+  // where the exploration through the `Operand` produces a `Numeric`
+  // `PointerArithmetic` (not reaching a `PointerType`). In such cases, we use
+  // the current `bitcast` as a `BasePointer`. Better than nothing.
+  if (OperandPA->isNumeric() and isPointerTyped(Cast)) {
+    auto CastPA = createLeaf(Cast);
+    rc_return CastPA;
+  }
+
+  rc_return OperandPA;
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::composeAdd(AddOp Add) {
+  auto LHS = Add.getLhs();
+  auto RHS = Add.getRhs();
+
+  auto LHSPA = rc_recur traverse(LHS);
+  auto RHSPA = rc_recur traverse(RHS);
+
+  // It may happen that either the LHS or the RHS traversal produced an invalid
+  // `PointerArithmetic` result. In such case, we need to propagate upward the
+  // failure.
+  if (not LHSPA or not RHSPA) {
+    rc_return std::nullopt;
+  }
+
+  // It may happen that both `LHSPA` or `RHSPA` have an address
+  // `PointerArithmetic`. In such situation, we cannot know which one is the
+  // `BasePointer`, so we bail out from the construction of the
+  // `PointerArithmetic` result.
+  if (LHSPA->isAddress() and RHSPA->isAddress()) {
+    rc_return std::nullopt;
+  }
+
+  // Add the two `PointerArithmetic`s together
+  using OffsetExpression = PointerArithmetic::OffsetExpression;
+  PointerArithmetic Result{ .Offset = OffsetExpression(PointerBitWidth) };
+
+  // Add the `BaseOffsets`
+  Result.Offset.BaseOffset = LHSPA->Offset.BaseOffset
+                             + RHSPA->Offset.BaseOffset;
+
+  // Append the linear combinations of `LHS` and `RHS`
+  Result.Offset.LinearCombination = LHSPA->Offset.LinearCombination;
+  Result.Offset.LinearCombination
+    .append(RHSPA->Offset.LinearCombination.begin(),
+            RHSPA->Offset.LinearCombination.end());
+
+  // After we combined the `LinearCombination`s coming from the operands, we
+  // sort them in descending order so that larger `Stride`s come before shorter
+  // ones. This is the expected form derived from a nested array access, where
+  // the stride of the _outer_ level is greater than the _inner_ one by
+  // construction. Duplicate strides are checked in the verify phase as an
+  // invariant.
+  sortLinearCombination(Result);
+
+  // After merging and sorting, if both sides contributed terms with the same
+  // `Stride`, the `Result` would have duplicate `Stride`s and not pass verify.
+  // In this situation, we return `nullopt` in order to soft fail the
+  // `PointerArithmetic` construction, instead of not verifying.
+  for (size_t I = 1; I < Result.Offset.LinearCombination.size(); ++I) {
+    const auto &LinearCombination = Result.Offset.LinearCombination;
+    if (LinearCombination[I].Stride == LinearCombination[I - 1].Stride) {
+      rc_return std::nullopt;
+    }
+  }
+
+  // We propagate as the `BasePointer` of the result the one corresponding to
+  // the _address_ part of the traversal
+  if (LHSPA->isAddress()) {
+    Result.BasePointer = LHSPA->BasePointer;
+  } else if (RHSPA->isAddress()) {
+    Result.BasePointer = RHSPA->BasePointer;
+  }
+
+  rc_return Result;
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::composePtrAdd(PtrAddOp Add) {
+
+  mlir::Value PointerOperand = Add.getPointer();
+  mlir::Value OffsetOperand = Add.getOffset();
+
+  // Compute the `PointerArithmetic` for both the pointer and offset operands.
+  auto PointerOperandPA = rc_recur traverse(PointerOperand);
+  auto OffsetOperandPA = rc_recur traverse(OffsetOperand);
+
+  // We should check that the pointer and offset operands are not both `numeric`
+  // or `address`
+  if (not PointerOperandPA or not OffsetOperandPA) {
+    rc_return std::nullopt;
+  }
+  revng_assert(not(PointerOperandPA->isAddress()
+                   and OffsetOperandPA->isAddress()));
+  revng_assert(not(PointerOperandPA->isNumeric()
+                   and OffsetOperandPA->isNumeric()));
+
+  // We expect that the offset operand is indeed a numeric `PointerArithmetic`.
+  // We need this so that we can multiply the size of the clift pointee type by
+  // the value that the numeric `PointerArithmetic` brings with it.
+  revng_assert(OffsetOperandPA->isNumeric());
+
+  // We multiply the size of the `PointeeType` of the `PointerOperand` operand
+  // by the `OffsetOperand` `BaseOffset`. The multiplication factor is contained
+  // into the `BaseOffset` of the numeric operand.
+  auto PointerOperandType = getPointerType(PointerOperand.getType());
+  auto PointeeSize = PointerOperandType.getPointeeType().getByteSize();
+  PointerOperandPA->Offset.BaseOffset += OffsetOperandPA->Offset.BaseOffset
+                                         * PointeeSize;
+
+  rc_return PointerOperandPA;
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::composeMul(MulOp Mul) {
+  auto LHS = Mul.getLhs();
+  auto RHS = Mul.getRhs();
+
+  // Categorize the `Mul` operands constant and non constant, so that we can
+  // choose which one to traverse
+  std::optional<llvm::APInt> Constant;
+  mlir::Value Variable;
+
+  if (auto C = getConstantValue(LHS, PointerBitWidth)) {
+    Constant = C;
+    Variable = RHS;
+  } else if (auto C = getConstantValue(RHS, PointerBitWidth)) {
+    Constant = C;
+    Variable = LHS;
+  } else {
+
+    // Neither operand is constant, bail out
+    rc_return std::nullopt;
+  }
+
+  // Traverse the variable operand
+  auto VarPA = rc_recur traverse(Variable);
+  if (not VarPA) {
+    rc_return std::nullopt;
+  }
+
+  // Multiply the result (`multiplyByConstant` also clears `BasePointer`)
+  rc_return multiplyByConstant(*VarPA, *Constant);
+}
+
+RecursiveCoroutine<std::optional<PointerArithmetic>>
+PointerArithmeticBuilder::composeShl(ShiftLeftOp Shl) {
+
+  // Handling is similar to `MulOp`, shift by N is multiplication by 2^N
+  auto LHS = Shl.getLhs();
+  auto RHS = Shl.getRhs();
+
+  auto ShiftAmount = getConstantValue(RHS, PointerBitWidth);
+
+  // We do not have a constant amount to perform the shift, so we bail out
+  if (not ShiftAmount) {
+    rc_return std::nullopt;
+  }
+
+  // We craft multiplication factor equivalent to the shift amount
+  llvm::APInt Multiplier = llvm::APInt(PointerBitWidth, 1).shl(*ShiftAmount);
+
+  // We traverse the variable operand
+  auto LHSPA = rc_recur traverse(LHS);
+  if (not LHSPA) {
+    rc_return std::nullopt;
+  }
+
+  // Multiply the result (`multiplyByConstant` also clears `BasePointer`)
+  rc_return multiplyByConstant(*LHSPA, Multiplier);
+}
+
+PointerArithmetic
+PointerArithmeticBuilder::multiplyByConstant(PointerArithmetic PA,
+                                             const llvm::APInt &Multiplier) {
+
+  // Multiply the base offset
+  PA.Offset.BaseOffset = PA.Offset.BaseOffset * Multiplier;
+
+  // Multiply all the strides contained in the `LinearCombination`s
+  for (auto &Term : PA.Offset.LinearCombination) {
+    Term.Stride = Term.Stride * Multiplier;
+  }
+
+  // Multiplying implicitly returns something that is not a pointer
+  PA.BasePointer = mlir::Value();
+
+  return PA;
+}
+
+void PointerArithmeticBuilder::sortLinearCombination(PointerArithmetic &PA) {
+  std::sort(PA.Offset.LinearCombination.begin(),
+            PA.Offset.LinearCombination.end(),
+            [](const auto &First, const auto &Second) {
+              return First.Stride.ugt(Second.Stride);
+            });
+}
+
+std::optional<PointerArithmetic>
+computePointerArithmetic(mlir::clift::ExpressionOpInterface PointerToReplace) {
+  auto Impl = PointerArithmeticBuilder();
+  return Impl.computePointerArithmetic(PointerToReplace);
+}

--- a/lib/CliftTransforms/PointerArithmetic.h
+++ b/lib/CliftTransforms/PointerArithmetic.h
@@ -1,0 +1,78 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <optional>
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "mlir/IR/Value.h"
+
+#include "revng/Clift/Clift.h"
+#include "revng/Support/Debug.h"
+
+/// Represents a pointer-typed expression decomposed into a `BasePointer` and an
+/// `Offset` expression. The offset is a constant `BaseOffset`, plus a linear
+/// combination of strided terms, which capture array index patterns
+struct PointerArithmetic {
+
+  /// Represents an `Index` with both a variable and a constant component,
+  /// e.g., `array[i+4]`
+  struct Index {
+    mlir::Value Variable;
+    llvm::APInt Constant;
+  };
+
+  /// Represents a strided term in the `PointerArithmetic`
+  struct StridedTerm {
+    llvm::APInt Stride;
+    Index Idx;
+
+    StridedTerm(llvm::APInt Stride, Index Idx) :
+      Stride(std::move(Stride)), Idx(std::move(Idx)) {}
+
+    void dump() const debug_function;
+  };
+
+  /// Represents the offset with possible strided terms in the
+  /// `PointerArithmetic`
+  struct OffsetExpression {
+
+    /// Represents the constant part of the `Offset`
+    llvm::APInt BaseOffset;
+
+    /// Holds the terms of the linear combination components of the `Offset`
+    llvm::SmallVector<StridedTerm> LinearCombination;
+
+    OffsetExpression(unsigned BitWidth);
+    OffsetExpression(llvm::APInt Offset);
+
+    void dump() const debug_function;
+  };
+
+  /// The base pointer the `PointerArithmetic` is expressed relative to
+  /// `BasePointer` object, which is where the root of the computation lies
+  mlir::Value BasePointer;
+
+  /// The offset w.r.t. the `BasePointer`
+  OffsetExpression Offset;
+
+  /// We define a `PointerArithmetic` with an empty `BasePointer` a _numeric_
+  bool isNumeric() const;
+
+  /// Check if this is an address (has base pointer) arithmetic
+  bool isAddress() const;
+
+  /// Verify the invariants for the strides contained in the PointerArithmetic
+  bool verify() const;
+
+  /// Dump method
+  void dump() const debug_function;
+};
+
+/// `PointerArithmetic` computation function entrypoint
+std::optional<PointerArithmetic>
+computePointerArithmetic(mlir::clift::ExpressionOpInterface PointerToReplace);

--- a/python/revng/internal/pipeline.yml
+++ b/python/revng/internal/pipeline.yml
@@ -353,6 +353,9 @@ branches:
             - optimize-statements
             - label-merging
             - optimize-expressions
+            - emit-field-accesses
+            - canonicalize
+            - optimize-expressions
             - terminal-branch-complement-hoisting
             - c-legalization
             - deduce-immediate-radices

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-index-with-constant-component.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-index-with-constant-component.mlir
@@ -1,0 +1,54 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with single argument used as array index
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Dynamic `array` access with both a variable and a constant index component.
+// The access pattern is: base + 4*arg0 + 8, which represents array[arg0 + 2].
+// This exercises the `IndexConstantComponent` path in `getExplicitArithmetic`,
+// where the `BaseOffse`t (8) is divided by the Stride (4) to produce a constant
+// index component (2) alongside the variable component (arg0).
+
+module attributes {clift.module} {
+  clift.func @test_index_constant<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !a
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.mul %4, %arg0 : !generic64_t
+      %6 = clift.imm 8 : !generic64_t
+      %7 = clift.add %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !int32_t$ptr
+      clift.yield %9 : !int32_t$ptr
+    }
+  }
+
+  // The constant component (2) and variable component (arg0) should both appear
+  // in the subscript index as an add expression
+  // CHECK: clift.func @test_index_constant<!f>([[ARG0:%[0-9a-z]*]]: !generic64_t)
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[CONST:%[0-9]+]] = clift.imm 2
+  // CHECK: [[INDEX:%[0-9]+]] = clift.add [[CONST]], [[ARG0]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[INDEX]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-argument-plus-offset.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-argument-plus-offset.mlir
@@ -1,0 +1,56 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Dynamic array access with the index provided as an argument plus a fixed
+// offset
+
+module attributes {clift.module} {
+  clift.func @f<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !a
+
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 1 : !generic64_t
+      %5 = clift.add %4, %arg0 : !generic64_t
+      %6 = clift.imm 4 : !generic64_t
+      %7 = clift.mul %6, %5 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %9 : !int32_t$ptr
+    }
+  }
+
+  // TODO: add a unit test going over the bounds of the array with just the constant part of the access index
+  // We check that the argument of the function is used as the dynamic index into
+  // the array, and a constant argument
+  // CHECK: clift.func @f<!f>([[ARG0:%[0-9a-z]*]]: !generic64_t)
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 1
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[IMM]], [[ARG0]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[ADD]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-argument.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-argument.mlir
@@ -1,0 +1,51 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with single argument used for the access
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Dynamic array access with the index provided as function argument
+
+module attributes {clift.module} {
+  clift.func @f<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !a
+
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.mul %4, %arg0 : !generic64_t
+      %6 = clift.add %3, %5 : !generic64_t
+      %7 = clift.cast<bitcast> %6 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %7 : !int32_t$ptr
+    }
+  }
+
+  // We check that the argument of the function is used as the dynamic index into
+  // the array
+  // CHECK: clift.func @f<!f>([[ARG0:%[0-9a-z]*]]: !generic64_t)
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[ARG0]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-global.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-linearcombination-access-global.mlir
@@ -1,0 +1,57 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with single argument used for the access
+
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Dynamic `array` access with the index provided as a global
+
+module attributes {clift.module} {
+  clift.global @global : !generic64_t
+
+  clift.func @f<!f>() {
+    %0 = clift.local : !a
+
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %global = clift.use @global : !generic64_t
+      %5 = clift.mul %4, %global : !generic64_t
+      %6 = clift.add %3, %5 : !generic64_t
+      %7 = clift.cast<bitcast> %6 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %7 : !int32_t$ptr
+    }
+  }
+
+  // We check that the argument of the function is used as the dynamic index into
+  // the array
+  // CHECK: clift.global [[GLOBAL:@[0-9a-z]*]]
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[USE:%[0-9a-z]+]] = clift.use [[GLOBAL]]
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[USE]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-mul-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-mul-access.mlir
@@ -1,0 +1,125 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!a = !clift.array<10 x !int32_t>
+
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t
+  }
+>
+
+!a2 = !clift.array<2 x !int32_t>
+
+!s2 = !clift.struct<
+  "2" : size(12) {
+    "" : offset(0) !a2,
+    "" : offset(8) !int32_t
+  }
+>
+
+!a3 = !clift.array<10 x !s>
+
+// `array` access a `mul` operation to compute the offset
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !a
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.imm 2 : !generic64_t
+      %6 = clift.mul %4, %5 : !generic64_t
+      %7 = clift.add %3, %6 : !generic64_t
+      %8 = clift.cast<bitcast> %7 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %8 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 2
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+
+  // `array` access to the first nested `struct` field
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s2
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s2>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s2> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.imm 1 : !generic64_t
+      %6 = clift.mul %4, %5 : !generic64_t
+      %7 = clift.add %3, %6 : !generic64_t
+      %8 = clift.cast<bitcast> %7 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %8 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[ACCESS]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 1
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+
+  // Access to the second `struct` field nested inside an `array`
+
+  clift.func @h<!f>() {
+    %0 = clift.local : !a3
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a3>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a3> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 8 : !generic64_t
+      %5 = clift.imm 2 : !generic64_t
+      %6 = clift.mul %4, %5 : !generic64_t
+      %7 = clift.add %3, %6 : !generic64_t
+      %8 = clift.imm 4 : !generic64_t
+      %9 = clift.add %7, %8 : !generic64_t
+      %10 = clift.cast<bitcast> %9 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %10 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @h<!f>
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !_1_>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !_1_>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 2
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM]]
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access< 1> [[SUBSCRIPT]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-same-stride-scoring.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-same-stride-scoring.mlir
@@ -1,0 +1,55 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Nested array where both levels have the same stride (4 bytes):
+// int array[3][1]
+// The outer array has stride 4 (1 * sizeof(int)), the inner array also has
+// stride 4 (sizeof(int)). Both ArrayShapes have Stride=4.
+// This exercises `commonPrefixStrides` counting duplicate strides correctly:
+// both levels must be matched for the score to reflect the full traversal
+// depth.
+!inner = !clift.array<1 x !int32_t>
+!outer = !clift.array<3 x !inner>
+
+module attributes {clift.module} {
+  // Constant access: base + 4 represents array[1][0]
+  clift.func @test_common_strides_duplicates<!f>() {
+    %0 = clift.local : !outer
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !outer>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !outer> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !int32_t$ptr
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // Both nested array levels should be traversed: outer[1][0]
+  // CHECK-LABEL: clift.func @test_common_strides_duplicates<!f>
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<3 x !clift.array<1 x !int32_t>>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<3 x !clift.array<1 x !int32_t>>>
+  // CHECK: [[INDIR:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[INDIR]]
+  // CHECK: [[IMM1:%[0-9]+]] = clift.imm 1
+  // CHECK: [[SUBSCRIPT1:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM1]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<decay> [[SUBSCRIPT1]]
+  // CHECK: [[IMM2:%[0-9]+]] = clift.imm 0
+  // CHECK: [[SUBSCRIPT2:%[0-9]+]] = clift.subscript [[CAST2]], [[IMM2]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-same-stride.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-same-stride.mlir
@@ -1,0 +1,63 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Nested array where both levels have the same stride (4 bytes):
+// int array[1][1]
+// The inner array has stride 4 (1 element * 4 bytes), the outer array also has
+// stride 4 (1 * 4 bytes). Both ArrayShapes have identical Stride=4.
+
+// This tests that the `std::multiset` preserves duplicate `ArrayShapes` (a
+// `std::set` would collapse them into one).
+!inner = !clift.array<1 x !int32_t>
+!outer = !clift.array<1 x !inner>
+
+// Wrap in a struct so we have a clear base pointer context
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !outer
+  }
+>
+
+module attributes {clift.module} {
+  // Access to struct.array[1][1] at offset 4.
+  // Should produce a struct access followed by two nested subscript operations.
+  clift.func @test_nested_same_stride<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_nested_same_stride<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[ACCESS]]
+  // CHECK: [[IMM1:%[0-9]+]] = clift.imm 0
+  // CHECK: [[SUBSCRIPT1:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM1]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<decay> [[SUBSCRIPT1]]
+  // CHECK: [[IMM2:%[0-9]+]] = clift.imm 0
+  // CHECK: [[SUBSCRIPT2:%[0-9]+]] = clift.subscript [[CAST2]], [[IMM2]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-array-field-no-traverse.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-array-field-no-traverse.mlir
@@ -1,0 +1,50 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Struct with an `array` field at offset 0 and a `int32_t` field at offset 40.
+// Accessing the `int32_t` field at offset 40 exercises the empty `ArrayPath`,
+// the type has `array`s, but this access doesn't traverse any.
+!s = !clift.struct<
+  "1" : size(44) {
+    "" : offset(0) !a,
+    "" : offset(40) !int32_t
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the non-`array` field at offset 40
+  clift.func @test_no_array_traverse<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 40 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_no_array_traverse<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-array-field-target.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-array-field-target.mlir
@@ -1,0 +1,50 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!a = !clift.array<10 x !int32_t>
+!a_ptr = !clift.ptr<8 to !a>
+
+// Struct with an `array` field at offset 4. The access targets the array
+// itself, not an element within it. This exercises a `Traversal` ending on an
+// `ArrayType`.
+!s = !clift.struct<
+  "1" : size(44) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !a
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the `array` field itself (not an element of it)
+  clift.func @test_array_target<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !a_ptr
+      clift.yield %6 : !a_ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_array_target<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-base-access-leftover.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-base-access-leftover.mlir
@@ -1,0 +1,82 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int8_t$ptr = !clift.ptr<8 to !int8_t>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t
+  }
+>
+
+// Struct access with a leftover offset
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 6 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int8_t>
+      clift.yield %6 : !int8_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF2]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 2
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[CAST1]], [[IMM]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<bitcast> [[ADD]]
+  // CHECK: [[CAST3:%[0-9]+]] = clift.cast<bitcast> [[CAST2]]
+  // CHECK: clift.yield [[CAST3]] : !clift.ptr<8 to !int8_t>
+
+  // Struct access going over the boundaries of the struct, not converted into an access
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 8 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int8_t>
+      clift.yield %6 : !int8_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<bitcast> [[CAST1]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 8
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[CAST2]], [[IMM]]
+  // CHECK: [[CAST3:%[0-9]+]] = clift.cast<bitcast> [[ADD]]
+  // CHECK: clift.yield [[CAST3]] : !clift.ptr<8 to !int8_t>
+  // CHECK-NOT: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF]]
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-base-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-base-access.mlir
@@ -1,0 +1,73 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t
+  }
+>
+
+// Basic `struct` access test to the second field
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+
+  // Access to the beginning of the struct which we do not convert into a
+  // explicit access
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 0 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-enum-field-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-enum-field-access.mlir
@@ -1,0 +1,56 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Enum type with underlying `int32_t`
+!my_enum = !clift.enum<
+  "1001" as "my_enum" : !int32_t {
+    "" as "A" : 0,
+    "" as "B" : 1
+  }
+>
+
+// Struct with an `enum` field: the enum should be traversed correctly and
+// the underlying type should be reachable through the enum
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !my_enum
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the enum field at offset 4
+  clift.func @test_enum_field<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_enum_field<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF2]]
+  // CHECK: clift.yield [[CAST]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-mul-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-mul-access.mlir
@@ -1,0 +1,51 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(12) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t,
+    "" : offset(8) !int32_t
+  }
+>
+
+// Struct access using an access deriving from a `mul`
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.imm 2 : !generic64_t
+      %7 = clift.mul %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %9 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 2> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-nested-access-union.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-nested-access-union.mlir
@@ -1,0 +1,155 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+!int64_t$ptr = !clift.ptr<8 to !int64_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t
+  }
+>
+
+!u = !clift.union<
+  "2" : {
+    "" : !s,
+    "" : !int64_t
+  }
+>
+
+!s2 = !clift.struct<
+  "3" : size(12) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !u
+  }
+>
+
+!u2 = !clift.union<
+   "4" : {
+    "" : !s,
+    "" : !int32_t
+  }
+>
+
+!s3 = !clift.struct<
+  "5" : size(12) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !u2
+  }
+>
+
+// Access to the `int64_t` field of the nested union, selected due to the type
+// of the access
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s2
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s2>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s2> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int64_t>
+      clift.yield %6 : !int64_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_3_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_3_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int64_t>
+
+  // Access to the `struct` field of the nested union, selected due to the type of
+  // the access towards the nested struct field
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s2
+      clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s2>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s2> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_3_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_3_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ACCESS3:%[0-9]+]] = clift.access< 0> [[ACCESS2]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS3]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+  // Access to the `struct` field of the nested union, second field, selected due
+  // to the offset into the nested `struct`
+
+  clift.func @h<!f>() {
+    %0 = clift.local : !s2
+      clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s2>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s2> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 8 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @h<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_3_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_3_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ACCESS3:%[0-9]+]] = clift.access< 1> [[ACCESS2]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS3]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+
+  // Access to the `int32_t` field of the nested union, selected due to the type
+  // of the access and the depth of the access
+
+  clift.func @i<!f>() {
+    %0 = clift.local : !s3
+      clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s3>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s3> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @i<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_5_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_5_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-nested-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-nested-access.mlir
@@ -1,0 +1,83 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!nested_s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t
+  }
+>
+
+!s = !clift.struct<
+  "2" : size(12) {
+    "" : offset(0) !nested_s,
+    "" : offset(8) !int32_t
+  }
+>
+
+// Struct access to the second field of a struct nested in the first field of
+// the outer struct
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+
+  // Access to the beginning of the struct which we do not convert into a
+  // explicit access
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 0 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-pointer-field-target.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-pointer-field-target.mlir
@@ -1,0 +1,49 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!int32_ptr = !clift.ptr<8 to !int32_t>
+!int32_ptr_ptr = !clift.ptr<8 to !int32_ptr>
+
+// Struct with a pointer field at offset 8. The access targets the pointer
+// field itself, exercising a `Traversal` ending on a `PointerType`.
+!s = !clift.struct<
+  "1" : size(16) {
+    "" : offset(0) !int32_t,
+    "" : offset(8) !int32_ptr
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the pointer field itself
+  clift.func @test_pointer_target<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 8 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !int32_ptr_ptr
+      clift.yield %6 : !int32_ptr_ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_pointer_target<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !clift.ptr<8 to !int32_t>>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-ptradd-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-ptradd-access.mlir
@@ -1,0 +1,49 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!generic64_t$ptr = !clift.ptr<8 to !generic64_t>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(12) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t,
+    "" : offset(8) !int32_t
+  }
+>
+!s$ptr = !clift.ptr<8 to !s>
+
+// Access, with offset computed with a `ptr_add` operation, to the third field
+// of the `struct`
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !s$ptr -> !int32_t$ptr
+      %3 = clift.imm 2 : !generic64_t
+      %4 = clift.ptr_add %2, %3 : (!int32_t$ptr, !generic64_t)
+      clift.yield %4 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 2> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-commonstrides.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-commonstrides.mlir
@@ -1,0 +1,76 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint8_t = !clift.primitive<unsigned 1>
+!uint16_t = !clift.primitive<unsigned 2>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!float32_t = !clift.primitive<float 4>
+!float64_t = !clift.primitive<float 8>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Create nested arrays with different stride patterns
+// One path: array[10] of array[5] of int32_t (strides: 20, 4)
+// Another path: array[50] of int32_t (stride: 4)
+// Access with strides [20, 4] should prefer the first path (2 common strides
+// vs 1 stride)
+
+!array_5_int32 = !clift.array<5 x !int32_t>
+!array_10_of_array_5 = !clift.array<10 x !array_5_int32>
+!array_50_int32 = !clift.array<50 x !int32_t>
+
+!union_commonstrides = !clift.union<
+  "1" : {
+    "" : !array_50_int32,
+    "" : !array_10_of_array_5
+  }
+>
+
+!struct_commonstrides = !clift.struct<
+  "2" : size(200) {
+    "" : offset(0) !union_commonstrides
+  }
+>
+
+module attributes {clift.module} {
+  // Access at offset 28 (which is 20 + 8 = array[1][2])
+  // Should select the nested array path due to more strides matching
+  clift.func @test_commonstrides<!f>() {
+    %0 = clift.local : !struct_commonstrides
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_commonstrides>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_commonstrides> -> !generic64_t
+      %3 = clift.imm 28 : !generic64_t
+      %4 = clift.add %2, %3 : !generic64_t
+      %5 = clift.cast<bitcast> %4 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %5 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_commonstrides<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<decay> [[ACCESS2]]
+  // CHECK: [[IMM1:%[0-9]+]] = clift.imm 1
+  // CHECK: [[SUBSCRIPT1:%[0-9]+]] = clift.subscript [[CAST1]], [[IMM1]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<decay> [[SUBSCRIPT1]]
+  // CHECK: [[IMM2:%[0-9]+]] = clift.imm 2
+  // CHECK: [[SUBSCRIPT2:%[0-9]+]] = clift.subscript [[CAST2]], [[IMM2]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-depth.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-depth.mlir
@@ -1,0 +1,64 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint8_t = !clift.primitive<unsigned 1>
+!uint16_t = !clift.primitive<unsigned 2>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!float32_t = !clift.primitive<float 4>
+!float64_t = !clift.primitive<float 8>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!inner_struct = !clift.struct<
+  "1" : size(4) {
+    "" : offset(0) !int32_t
+  }
+>
+
+!union_depth = !clift.union<
+  "2" : {
+    "" : !inner_struct,
+    "" : !int32_t
+  }
+>
+
+!struct_depth = !clift.struct<
+  "3" : size(4) {
+    "" : offset(0) !union_depth
+  }
+>
+
+module attributes {clift.module} {
+  // Access at offset 0 with int32_t, which should select the shallow union field
+  // (depth 2: struct -> union -> int32_t) over the deep path
+  // (depth 3: struct -> union -> inner_struct -> int32_t)
+  clift.func @test_depth<!f>() {
+    %0 = clift.local : !struct_depth
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_depth>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_depth> -> !clift.ptr<8 to !int32_t>
+      clift.yield %2 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_depth<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_3_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_3_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-sizerelation.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-sizerelation.mlir
@@ -1,0 +1,96 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint8_t = !clift.primitive<unsigned 1>
+!uint16_t = !clift.primitive<unsigned 2>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!float32_t = !clift.primitive<float 4>
+!float64_t = !clift.primitive<float 8>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Test the SizeRelation criterion: Same > Larger > Smaller
+
+!u = !clift.union<
+  "1" : {
+    "" : !int64_t,
+    "" : !int32_t,
+    "" : !int16_t
+  }
+>
+
+!struct_sizerelation = !clift.struct<
+  "2" : size(16) {
+    "" : offset(0) !u,
+    "" : offset(8) !int64_t
+  }
+>
+
+module attributes {clift.module} {
+  // Access at offset 0 with size 8 - should select the int64_t field (same size)
+  clift.func @test_sizerelation_same64<!f>() {
+    %0 = clift.local : !struct_sizerelation
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_sizerelation>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_sizerelation> -> !clift.ptr<8 to !int64_t>
+      clift.yield %2 : !clift.ptr<8 to !int64_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_sizerelation_same64<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDR1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDR1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ADDR2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDR2]] : !clift.ptr<8 to !int64_t>
+
+  // Access at offset 0 with size 4 - should select the int32_t field (same size)
+  clift.func @test_sizerelation_same32<!f>() {
+    %0 = clift.local : !struct_sizerelation
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_sizerelation>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_sizerelation> -> !clift.ptr<8 to !int32_t>
+      clift.yield %2 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_sizerelation_same32<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDR1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDR1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDR2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDR2]] : !clift.ptr<8 to !int32_t>
+
+  // Access at offset 0 with size 2 should select the int16_t field (same size)
+  clift.func @test_sizerelation_same16<!f>() {
+    %0 = clift.local : !struct_sizerelation
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_sizerelation>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_sizerelation> -> !clift.ptr<8 to !int16_t>
+      clift.yield %2 : !clift.ptr<8 to !int16_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_sizerelation_same16<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDR1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDR1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 2> [[ACCESS1]]
+  // CHECK: [[ADDR2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDR2]] : !clift.ptr<8 to !int16_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-startdistance.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-startdistance.mlir
@@ -1,0 +1,89 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint8_t = !clift.primitive<unsigned 1>
+!uint16_t = !clift.primitive<unsigned 2>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!float32_t = !clift.primitive<float 4>
+!float64_t = !clift.primitive<float 8>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!struct_startdistance = !clift.struct<
+  "1" : size(16) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int64_t,
+    "" : offset(12) !int32_t
+  }
+>
+
+// Access at offset 6 in the `struct`, between fields at offset 4 and 12, so we
+// need to choose field at offset 4, plus a  leftover. Choosing field at offset
+// 12 would lead to a negative `StartDistance`, which should result in an
+// invalid score and not be selected
+
+module attributes {clift.module} {
+  // Access, of size 4, at offset 6 - should select field at offset 4 (int64_t),
+  // because the end distance is within the boundaries of field
+  clift.func @test_startdistance<!f>() {
+    %0 = clift.local : !struct_startdistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_startdistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_startdistance> -> !generic64_t
+      %3 = clift.imm 6 : !generic64_t
+      %4 = clift.add %2, %3 : !generic64_t
+      %5 = clift.cast<bitcast> %4 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %5 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_startdistance<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS1]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF2]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 2
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[CAST1]], [[IMM]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<bitcast> [[ADD]]
+  // CHECK: [[CAST3:%[0-9]+]] = clift.cast<bitcast> [[CAST2]]
+  // CHECK: clift.yield [[CAST3]] : !clift.ptr<8 to !int32_t>
+
+  // Access, of size 8, at offset 6 - should not select field at offset 4
+  // (int64_t), because the end distance would overshoot the field, since they
+  // only partially overlap
+  clift.func @test_enddistance<!f>() {
+    %0 = clift.local : !struct_startdistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_startdistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_startdistance> -> !generic64_t
+      %3 = clift.imm 6 : !generic64_t
+      %4 = clift.add %2, %3 : !generic64_t
+      %5 = clift.cast<bitcast> %4 : !generic64_t -> !clift.ptr<8 to !int64_t>
+      clift.yield %5 : !clift.ptr<8 to !int64_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_enddistance<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF1]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 6
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[CAST1]], [[IMM]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<bitcast> [[ADD]]
+  // CHECK: clift.yield [[CAST2]] : !clift.ptr<8 to !int64_t>
+  // CHECK-NOT: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-typedistance.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-score-typedistance.mlir
@@ -1,0 +1,127 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int8_t = !clift.primitive<signed 1>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!int64_t = !clift.primitive<signed 8>
+!uint8_t = !clift.primitive<unsigned 1>
+!uint16_t = !clift.primitive<unsigned 2>
+!uint32_t = !clift.primitive<unsigned 4>
+!uint64_t = !clift.primitive<unsigned 8>
+!float32_t = !clift.primitive<float 4>
+!float64_t = !clift.primitive<float 8>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!union_typedistance = !clift.union<
+  "1" : {
+    "" : !int32_t,
+    "" : !uint32_t,
+    "" : !float32_t
+  }
+>
+
+!struct_typedistance = !clift.struct<
+  "2" : size(4) {
+    "" : offset(0) !union_typedistance
+  }
+>
+
+// The union now misses the `int32_t`, therefore we should revert to `uint32_t`
+// as an alternative
+
+!union_typedistance_2 = !clift.union<
+  "3" : {
+    "" : !uint32_t,
+    "" : !float32_t
+  }
+>
+
+!struct_typedistance_2 = !clift.struct<
+  "4" : size(4) {
+    "" : offset(0) !union_typedistance_2
+  }
+>
+
+module attributes {clift.module} {
+  // Access with signed type - should select int32_t field
+  clift.func @test_typedistance1<!f>() {
+    %0 = clift.local : !struct_typedistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_typedistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_typedistance> -> !clift.ptr<8 to !int32_t>
+      clift.yield %2 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedistance1<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+  // Access with unsigned type - should select uint32_t field
+  clift.func @test_typedistance2<!f>() {
+    %0 = clift.local : !struct_typedistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_typedistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_typedistance> -> !clift.ptr<8 to !uint32_t>
+      clift.yield %2 : !clift.ptr<8 to !uint32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedistance2<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !uint32_t>
+
+  // Access with float type - should select float32_t field
+  clift.func @test_typedistance3<!f>() {
+    %0 = clift.local : !struct_typedistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_typedistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_typedistance> -> !clift.ptr<8 to !float32_t>
+      clift.yield %2 : !clift.ptr<8 to !float32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedistance3<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 2> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !float32_t>
+
+  // Access with signed type - should select uint32_t field
+  clift.func @test_typedistance4<!f>() {
+    %0 = clift.local : !struct_typedistance
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !struct_typedistance>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !struct_typedistance> -> !clift.ptr<8 to !int32_t>
+      clift.yield %2 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedistance4<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-shl-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-shl-access.mlir
@@ -1,0 +1,52 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(12) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t,
+    "" : offset(8) !int32_t
+  }
+>
+
+// Access, with offset computed with a `shl` operation, to the third field of
+// the `struct`
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.imm 1 : !generic64_t
+      %7 = clift.shl %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %9 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 2> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-typedef-field-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-typedef-field-access.mlir
@@ -1,0 +1,48 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+// Typedef wrapping `int32_t`
+!my_int = !clift.typedef<"" as "my_int" : !int32_t>
+
+// Struct with a `typedef` field: the traversal should unwrap the `typedef` and
+// still match the underlying type correctly
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !my_int,
+    "" : offset(4) !int32_t
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the first field (typedef) at offset 0 with `int32_t` pointer type,
+  // through the `typedef`.
+  clift.func @test_typedef_field<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !int32_t>
+      clift.yield %2 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedef_field<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF2]]
+  // CHECK: clift.yield [[CAST]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-typedef-field-target.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-typedef-field-target.mlir
@@ -1,0 +1,49 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!my_int = !clift.typedef<"" as "my_int" : !int32_t>
+!my_int_ptr = !clift.ptr<8 to !my_int>
+
+// Struct with a typedef field at offset 4. The access targets the `typedef`
+// itself, exercising a `Traversal` ending on a `TypedefType`.
+!s = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !my_int
+  }
+>
+
+module attributes {clift.module} {
+  // Access to the typedef field itself
+  clift.func @test_typedef_target<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !my_int_ptr
+      clift.yield %6 : !my_int_ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_typedef_target<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !my_int>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-union-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-union-access.mlir
@@ -1,0 +1,110 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int16_t = !clift.primitive<signed 2>
+!int32_t = !clift.primitive<signed 4>
+!uint32_t = !clift.primitive<unsigned 4>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with no argument
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!nested_u = !clift.union<
+  "1" : {
+    "" : !int32_t,
+    "" : !int16_t
+  }
+>
+
+!s = !clift.struct<
+  "2" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !nested_u
+  }
+>
+
+// Access the first field of the union based on the type (size) of the returned
+// pointer
+
+module attributes {clift.module} {
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+  // Access the second field of the union based on the type (size) of the returned
+  // pointer
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int16_t>
+      clift.yield %6 : !int16_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int16_t>
+
+  // Access to the second field of the `struct`, plus a `Leftover` remaining part
+  // of the access
+
+  clift.func @h<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 5 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int16_t>
+      clift.yield %6 : !int16_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @h<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS]]
+  // CHECK: [[CAST1:%[0-9]+]] = clift.cast<bitcast> [[ADDRESSOF2]]
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 1
+  // CHECK: [[ADD:%[0-9]+]] = clift.add [[CAST1]], [[IMM]]
+  // CHECK: [[CAST2:%[0-9]+]] = clift.cast<bitcast> [[ADD]]
+  // CHECK: [[CAST3:%[0-9]+]] = clift.cast<bitcast> [[CAST2]]
+  // CHECK: clift.yield [[CAST3]] : !clift.ptr<8 to !int16_t>
+}

--- a/tests/unit/mlir_lit_tests/expressions/cast-decay-array.mlir
+++ b/tests/unit/mlir_lit_tests/expressions/cast-decay-array.mlir
@@ -7,6 +7,10 @@
 !int32_t = !clift.primitive<signed 4>
 !int32_t$array = !clift.array<1 x !int32_t>
 !int32_t$ptr = !clift.ptr<8 to !int32_t>
+!typedef$array = !clift.typedef<"" : !int32_t$array>
 
 %array = clift.undef : !int32_t$array
 clift.cast<decay> %array : !int32_t$array -> !int32_t$ptr
+
+%typedef_array = clift.undef : !typedef$array
+clift.cast<decay> %typedef_array : !typedef$array -> !int32_t$ptr


### PR DESCRIPTION
The `EmitFieldAccesses` pass transforms `clift` by taking pointer-typed
expressions computed via integerr arithmetic with type-safe field
accesses and array accesses.

The transformation is split in three main phases:
1) `PointerArithmetic` computation.
2) `BestTraversal` computation.
3) `FieldAccess` `clift` rewrite.

The high level driver is implemented in the `EmitFieldAccesses` header
and cpp, while the nested 3 phases are implemented respectively in
`PointerArithmetic`, `BestTraversal` and `FieldAccessReplacement`.

The `computerPointerArithmetic` phase is concerned with taking a
pointer-typed `ExpressionOp`, called `PointerToReplace`, and expressing
it in a `BasePointer+Offset` form.

The `computeBestTraversal` phase is concerned with computing the best
traversal of the type pointed to by `BasePointer`, that can be used to
rewrite the pointer arithmetic in `clift` with just field accesses and
array subscripts.

The `replaceFieldAccess` phase takes the `Traversal` computed at the
previous step, and actually rewrites in `clift` the `PointerToReplace`
in terms of field accesses and array accesses w.r.t. the `BasePointer`.