### PR TITLE
EmitFieldAccesses: improve unit test suite

### DIFF
--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-index-from-struct-field.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-index-from-struct-field.mlir
@@ -1,0 +1,72 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// The following `struct` contains both an `array` and an `index` field. The
+// `index` field is used as the dynamic `index` into the `array`.
+// The access follows this structure:
+// `struct.array[(int64_t)(int32_t) struct.index]`
+!s = !clift.struct<
+  "1" : size(44) {
+    "" : offset(0) !a,
+    "" : offset(40) !int32_t
+  }
+>
+
+module attributes {clift.module} {
+  clift.func @test_index_from_field<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      // Load the `index` field
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 40 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.cast<bitcast> %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      %7 = clift.indirection %6 : !clift.ptr<8 to !int32_t>
+      // Sign-extend to 64 bits
+      %8 = clift.cast<extend> %7 : !int32_t -> !clift.primitive<signed 8>
+      %9 = clift.cast<bitcast> %8 : !clift.primitive<signed 8> -> !generic64_t
+      // Multiply by element size: `index * 4`
+      %10 = clift.imm 4 : !generic64_t
+      %11 = clift.mul %9, %10 : !generic64_t
+      // Add to array base: `&struct + index * 4`
+      %12 = clift.add %3, %11 : !generic64_t
+      %13 = clift.cast<bitcast> %12 : !generic64_t -> !int32_t$ptr
+      clift.yield %13 : !int32_t$ptr
+    }
+  }
+
+  // The pass resolves both the index load (struct field access) and the array
+  // access (struct field + decay + subscript) in a single rewrite:
+  // The rewrite emits:
+  // 1. `access<indirect 1>` loads the `index` from the `struct` second field
+  // 2. `access<indirect 0>` accesses the `array` field in the `struct`
+  // 4. `subscript ...` accesses the `array[index]` element
+  // CHECK-LABEL: clift.func @test_index_from_field<!f>
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[IDX_ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[IDX_ADDROF:%[0-9]+]] = clift.addressof [[IDX_ACCESS]]
+  // CHECK: [[IDX_LOAD:%[0-9]+]] = clift.indirection [[IDX_ADDROF]]
+  // CHECK: [[IDX_EXT:%[0-9]+]] = clift.cast<extend> [[IDX_LOAD]]
+  // CHECK: [[ARR_ACCESS:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ARR_DECAY:%[0-9]+]] = clift.cast<decay> [[ARR_ACCESS]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[ARR_DECAY]], [[IDX_EXT]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-struct-field-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-nested-struct-field-access.mlir
@@ -1,0 +1,99 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t, !generic64_t)
+>
+
+// A nested 2D array: `array<10 x array<5 x int32_t>>`. The outer array has
+// stride 20 (5 * `sizeof(int32_t)`), the inner array has stride 4.
+!a = !clift.array<10 x !clift.array<5 x !int32_t>>
+
+!a2 = !clift.array<5 x !int32_t>
+!s = !clift.struct<
+  "1" : size(20) {
+    "" : offset(0) !a2
+  }
+>
+!a3 = !clift.array<10 x !s>
+
+module attributes {clift.module} {
+
+  // Access pattern: `base + i * 20 + j * 4`.
+  // Two-term LinearCombination representing `array[i][j]`.
+  clift.func @test_nested_array<!f>(%arg0 : !generic64_t, %arg1 : !generic64_t) {
+    %0 = clift.local : !a
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      // Outer index: `i * 20`
+      %4 = clift.imm 20 : !generic64_t
+      %5 = clift.mul %arg0, %4 : !generic64_t
+      // Inner index: `j * 4`
+      %6 = clift.imm 4 : !generic64_t
+      %7 = clift.mul %arg1, %6 : !generic64_t
+      // Combined: `base + i * 20 + j * 4`
+      %8 = clift.add %5, %7 : !generic64_t
+      %9 = clift.add %3, %8 : !generic64_t
+      %10 = clift.cast<bitcast> %9 : !generic64_t -> !int32_t$ptr
+      clift.yield %10 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_nested_array<!f>
+  // CHECK-SAME: ([[ARG0:%[a-z0-9]+]]: !generic64_t, [[ARG1:%[a-z0-9]+]]: !generic64_t)
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local : !clift.array<10 x !clift.array<5 x !int32_t>>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]] : !clift.ptr<8 to !clift.array<10 x !clift.array<5 x !int32_t>>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[DECAY1:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[SUBSCRIPTION1:%[0-9]+]] = clift.subscript [[DECAY1]], [[ARG0]]
+  // CHECK: [[DECAY2:%[0-9]+]] = clift.cast<decay> [[SUBSCRIPTION1]]
+  // CHECK: [[SUBSCRIPTION2:%[0-9]+]] = clift.subscript [[DECAY2]], [[ARG1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPTION2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+
+  // Same access pattern but with a `struct` wrapping the `inner array`.
+  // This exercises the path through struct access + array subscript at each
+  // nesting level.
+  clift.func @test_nested_struct_with_array<!f>(%arg0 : !generic64_t, %arg1 : !generic64_t) {
+    %0 = clift.local : !a3
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a3>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a3> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      // Outer index: `i * 20`
+      %4 = clift.imm 20 : !generic64_t
+      %5 = clift.mul %arg0, %4 : !generic64_t
+      // Inner index: `j * 4`
+      %6 = clift.imm 4 : !generic64_t
+      %7 = clift.mul %arg1, %6 : !generic64_t
+      // Combined: `base + i * 20 + j * 4`
+      %8 = clift.add %5, %7 : !generic64_t
+      %9 = clift.add %3, %8 : !generic64_t
+      %10 = clift.cast<bitcast> %9 : !generic64_t -> !int32_t$ptr
+      clift.yield %10 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_nested_struct_with_array<!f>
+  // CHECK-SAME: ([[ARG0:%[a-z0-9]+]]: !generic64_t, [[ARG1:%[a-z0-9]+]]: !generic64_t)
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]]
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[DECAY1:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[SUBSCRIPTION1:%[0-9]+]] = clift.subscript [[DECAY1]], [[ARG0]]
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access< 0> [[SUBSCRIPTION1]]
+  // CHECK: [[DECAY2:%[0-9]+]] = clift.cast<decay> [[ACCESS]]
+  // CHECK: [[SUBSCRIPTION2:%[0-9]+]] = clift.subscript [[DECAY2]], [[ARG1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPTION2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-ptradd-linear-combination.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-ptradd-linear-combination.mlir
@@ -1,0 +1,42 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+// Generic void function prototype with single argument used for the access
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+!a = !clift.array<10 x !int32_t>
+
+// Dynamic array access via `ptr_add` with a variable `Offset` operand.
+// This is the `composePtrAdd` counterpart of the `composeAdd` test in
+// `array-linearcombination-access-argument.mlir`.
+
+module attributes {clift.module} {
+  clift.func @test_ptradd_linear_combination<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !a
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !a>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !a> -> !int32_t$ptr
+      %3 = clift.ptr_add %2, %arg0 : (!int32_t$ptr, !generic64_t)
+      clift.yield %3 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_ptradd_linear_combination<!f>
+  // CHECK: [[ARRAY:%[0-9]+]] = clift.local : !clift.array<10 x !int32_t>
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[ARRAY]] : !clift.ptr<8 to !clift.array<10 x !int32_t>>
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[INDIRECTION]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[ARG0:%[a-z0-9]+]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-struct-stride-mul.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-struct-stride-mul.mlir
@@ -1,0 +1,67 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+// A 20-byte inner `struct`, to be used as `array` element
+!inner = !clift.struct<
+  "2" : size(20) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !int32_t,
+    "" : offset(8) !int32_t,
+    "" : offset(12) !int32_t,
+    "" : offset(16) !int32_t
+  }
+>
+
+// Outer `struct` containing some fields before the `array`, an `array` of 10
+// inner `struct`s with stride 20, and another field.
+!outer = !clift.struct<
+  "1" : size(220) {
+    "" : offset(0) !generic64_t,
+    "" : offset(8) !generic64_t,
+    "" : offset(16) !clift.array<10 x !inner>,
+    "" : offset(216) !int32_t
+  }
+>
+
+module attributes {clift.module} {
+
+  // Access pattern: `base + 16 + arg0 * 20`
+  clift.func @test_stride20_mul<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !outer
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !outer>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !outer> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 20 : !generic64_t
+      %5 = clift.mul %4, %arg0 : !generic64_t
+      %6 = clift.imm 16 : !generic64_t
+      %7 = clift.add %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !int32_t$ptr
+      clift.yield %9 : !int32_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_stride20_mul<!f>
+  // CHECK-SAME: ([[ARG0:%[a-z0-9]+]]: !generic64_t)
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 2> [[ADDRESSOF1]]
+  // CHECK: [[DECAY:%[0-9]+]] = clift.cast<decay> [[ACCESS1]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[DECAY]], [[ARG0]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 0> [[SUBSCRIPT]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-struct-stride-shl.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-struct-stride-shl.mlir
@@ -1,0 +1,96 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int64_t = !clift.primitive<signed 8>
+!int16_t = !clift.primitive<signed 2>
+!int64_t$ptr = !clift.ptr<8 to !int64_t>
+!int16_t$ptr = !clift.ptr<8 to !int16_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void(!generic64_t)
+>
+
+// `struct` with array of `int64_t` at `offset_16`, accessed via `<< 3`
+// (stride=8).
+!s_stride8 = !clift.struct<
+  "1" : size(96) {
+    "" : offset(0) !generic64_t,
+    "" : offset(8) !generic64_t,
+    "" : offset(16) !clift.array<10 x !int64_t>
+  }
+>
+
+// `struct` with an `array` of `int16_t` at `offset_8`, accessed via `<< 1`
+// (stride=2).
+!s_stride2 = !clift.struct<
+  "2" : size(28) {
+    "" : offset(0) !generic64_t,
+    "" : offset(8) !clift.array<10 x !int16_t>
+  }
+>
+
+module attributes {clift.module} {
+
+  // Access pattern: `base + 16 + arg0 << 3` (stride=8 via shift-left by 3)
+  // This exercises `composeShl` producing `Stride=8`, then `composeAdd` merging
+  // it.
+  clift.func @test_stride8_shl<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !s_stride8
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s_stride8>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s_stride8> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 3 : !generic64_t
+      %5 = clift.shl %arg0, %4 : !generic64_t
+      %6 = clift.imm 16 : !generic64_t
+      %7 = clift.add %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !int64_t$ptr
+      clift.yield %9 : !int64_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_stride8_shl<!f>
+  // CHECK-SAME: ([[ARG0:%[a-z0-9]+]]: !generic64_t)
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 2> [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[ACCESS]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[ARG0]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int64_t>
+
+  // Access pattern: `base + 8 + arg0 << `1 (stride=2 via shift-left by 1)
+  // This exercises `composeShl` producing `Stride=2`, then `composeAdd` merging
+  // it.
+  clift.func @test_stride2_shl<!f>(%arg0 : !generic64_t) {
+    %0 = clift.local : !s_stride2
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s_stride2>
+      %2 = clift.cast<bitcast> %1 : !clift.ptr<8 to !s_stride2> -> !clift.ptr<8 to !void>
+      %3 = clift.cast<bitcast> %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 1 : !generic64_t
+      %5 = clift.shl %arg0, %4 : !generic64_t
+      %6 = clift.imm 8 : !generic64_t
+      %7 = clift.add %5, %6 : !generic64_t
+      %8 = clift.add %3, %7 : !generic64_t
+      %9 = clift.cast<bitcast> %8 : !generic64_t -> !int16_t$ptr
+      clift.yield %9 : !int16_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_stride2_shl<!f>
+  // CHECK-SAME: ([[ARG0:%[a-z0-9]+]]: !generic64_t)
+  // CHECK: [[LOCAL:%[0-9]+]] = clift.local : !_2_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[LOCAL]] : !clift.ptr<8 to !_2_>
+  // CHECK: [[ACCESS:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<decay> [[ACCESS]]
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[ARG0]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int16_t>
+}


### PR DESCRIPTION
Improve the unit test suite in order to include especially `array` access patterns observed in the wild.