### PR TITLE
EmitFieldAccesses: add support for `pointer` as `array`

### DIFF
--- a/lib/CliftTransforms/BestTraversal.cpp
+++ b/lib/CliftTransforms/BestTraversal.cpp
@@ -3,6 +3,7 @@
 //
 #include <compare>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #include "revng/ADT/RecursiveCoroutine.h"
@@ -105,6 +106,34 @@ void Traversal::dump() const {
   Log.flush();
 }
 
+mlir::Type deriveBaseType(mlir::Value BasePointer) {
+
+  auto BasePtrType = getPointerType(BasePointer.getType());
+  revng_assert(BasePtrType);
+  auto PointeeType = BasePtrType.getPointeeType();
+  auto UnderlyingType = dealias(PointeeType, /*IgnoreQualifiers=*/true);
+
+  // If the pointee is a struct, union, or array, use it directly — the
+  // traversal analyzer can walk its fields and arrays.
+  // Wrapping also a `struct`, would mean rewriting a constant offset access
+  // into it as `p[0].field` instead of `p->field`.
+  if (mlir::isa<StructType, UnionType, ArrayType>(UnderlyingType)) {
+    return PointeeType;
+  }
+
+  // We don't want to wrap `void` or `function` `Type`s into `array`s.
+  if (not isObjectType(PointeeType)) {
+    return PointeeType;
+  }
+
+  // In all the other situations, wrap into an implicit array. We use
+  // `ImplicitArrayNumElements` a _very large_ array in order to cover any
+  // reasonable constant offset.
+  static constexpr uint64_t
+    ImplicitArrayNumElements = std::numeric_limits<uint64_t>::max();
+  return ArrayType::get(PointeeType, ImplicitArrayNumElements);
+}
+
 namespace {
 
 // =============================================================================
@@ -128,8 +157,8 @@ static bool isCompatible(const ArrayPath &Path, llvm::APInt BaseOffset) {
     // `BaseOffset`, consuming it
     if (BaseOffset.uge(Shape.Stride)) {
 
-      // If we're jumping over the whole array, past it, we just bail out
-      if (BaseOffset.uge(Shape.Stride * Shape.NumElements)) {
+      // If we're jumping over the whole array, past it, we just bail out.
+      if (BaseOffset.udiv(Shape.Stride).uge(Shape.NumElements)) {
         return false;
       }
 
@@ -658,9 +687,11 @@ private:
                         const ArrayPath &ArrayPath);
 
   /// Obtain all the explicit rewritings of the input `Arithmetic` following all
-  /// the `ArrayPath`s for the `BaseType`
+  /// the `ArrayPath`s for the `BaseType`. We explicitly specify the `BaseType`
+  /// to handle the _pointer as array_ situation.
   std::vector<PointerArithmetic>
-  toExplicitArrayAccesses(const PointerArithmetic &Arithmetic);
+  toExplicitArrayAccesses(const PointerArithmetic &Arithmetic,
+                          mlir::Type BaseType);
 
   /// Helper which trivially spill a `PointerArithmetic` into a `Traversal`
   Traversal toTraversal(const PointerArithmetic &PA,
@@ -685,12 +716,13 @@ BestTraversalChooser::computeBestTraversal(ExpressionOpInterface
     return std::nullopt;
   }
 
+  // Derive the `BaseType` for the traversal analysis, potentially wrapping the
+  // `BasePointerType` into an implicit array (`p[i]` rewrite).
+  auto BaseType = deriveBaseType(Arithmetic.BasePointer);
+
   // It may be that the `PointerToReplace` points to a `void 0` type, in that
   // case we cannot provide a `Traversal` for sure
-  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
-  revng_assert(BasePtrType);
-  auto BaseType = BasePtrType.getPointeeType();
-  if (BaseType.getByteSize() == 0) {
+  if (mlir::cast<ValueType>(BaseType).getByteSize() == 0) {
     return std::nullopt;
   }
 
@@ -700,7 +732,7 @@ BestTraversalChooser::computeBestTraversal(ExpressionOpInterface
   PointerBitWidth = getPointerType(PointerToReplaceType).getPointerSize() * 8;
 
   std::vector<PointerArithmetic>
-    ExplicitArithmetics = toExplicitArrayAccesses(Arithmetic);
+    ExplicitArithmetics = toExplicitArrayAccesses(Arithmetic, BaseType);
 
   mlir::Type PointeeType = getPointerType(PointerToReplaceType)
                              .getPointeeType();
@@ -822,12 +854,9 @@ BestTraversalChooser::getExplicitArithmetic(const PointerArithmetic &Arithmetic,
 
 std::vector<PointerArithmetic>
 BestTraversalChooser::toExplicitArrayAccesses(const PointerArithmetic
-                                                &Arithmetic) {
+                                                &Arithmetic,
+                                              mlir::Type BaseType) {
   std::vector<PointerArithmetic> Result;
-
-  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
-  revng_assert(BasePtrType);
-  auto BaseType = BasePtrType.getPointeeType();
 
   // We retrieve all the `ArrayPath`s that we can build from `BaseType`
   const std::vector<ArrayPath> &ArrayPaths = TraversalAnalyzer

--- a/lib/CliftTransforms/BestTraversal.h
+++ b/lib/CliftTransforms/BestTraversal.h
@@ -123,6 +123,12 @@ struct TraversalInfo {
 /// from a `mlir::Type`
 using TraversalInfoMap = llvm::DenseMap<mlir::Type, TraversalInfo>;
 
+/// Helper function used to obtain the `BaseType` for the `Traversal` analysis.
+/// Specifically, this is used to enable the `p[i]` rewrites. In situations
+/// where we have a `pointer` to a `PrimitiveType`, we virtually wrap it in a
+/// `array<N x T>`.
+mlir::Type deriveBaseType(mlir::Value BasePointer);
+
 /// Main entry point used to compute the `BestTraversal` from an `Expression`
 /// and PointerArithmetic`.
 std::optional<Traversal>

--- a/lib/CliftTransforms/FieldAccessReplacement.cpp
+++ b/lib/CliftTransforms/FieldAccessReplacement.cpp
@@ -329,6 +329,20 @@ void Replacement::replace(ExpressionOpInterface PointerToReplace,
         IndexValue = DynamicIndexValue;
       }
 
+      // The `SubscriptOp` requires its `Pointer` operand to be a `PointerType`.
+      // In case `CurrentValue` is a `PointerType`, wrapped into a
+      // `TypeDefType`, we need to cast it to the underlying `PointerType`
+      // first.
+      if (not mlir::isa<clift::PointerType>(CurrentValue.getType())) {
+        auto UnderlyingType = getPointerType(CurrentValue.getType());
+        revng_assert(UnderlyingType);
+        CurrentValue = Builder
+                         .create<CastOp>(PointerToReplaceLoc,
+                                         mlir::cast<mlir::Type>(UnderlyingType),
+                                         CurrentValue,
+                                         CastKind::Bitcast);
+      }
+
       // Finally, we emit the `SubscriptOp` using as `Index` the `mlir::Value`
       // constructed above
       CurrentValue = Builder.create<SubscriptOp>(PointerToReplaceLoc,

--- a/lib/CliftTransforms/FieldAccessReplacement.cpp
+++ b/lib/CliftTransforms/FieldAccessReplacement.cpp
@@ -86,8 +86,7 @@ Replacement Replacement::make(unsigned PointerBitWidth,
                               const PointerArithmetic &Arithmetic,
                               const Traversal &BestTraversal) {
 
-  auto BasePtrType = getPointerType(Arithmetic.BasePointer.getType());
-  auto BaseType = BasePtrType.getPointeeType();
+  auto BaseType = deriveBaseType(Arithmetic.BasePointer);
 
   // Start with an empty `Replacement` object, which will be populated in this
   // routine
@@ -264,23 +263,32 @@ void Replacement::replace(ExpressionOpInterface PointerToReplace,
     case FieldAccessInfo::Kind::Array: {
 
       // We may need to unwrap the `ArrayType` from a `PointerType`, and emit
-      // the needed `IndirectionOp` and `Decay` cast accordingly
-      auto [ArrayType,
-            IsIndirect] = getAccessedTypeInfo<clift::ArrayType>(CurrentValue);
-      if (IsIndirect) {
-        // Add the indirection operation
-        CurrentValue = Builder.create<IndirectionOp>(PointerToReplaceLoc,
-                                                     CurrentValue);
-      }
+      // the needed `IndirectionOp` and `Decay` cast accordingly.
+      clift::ValueType ArrayElementType;
 
-      // In this situation, we need to add a `decay` cast in order to be
-      // able to perform the subscript access to the array
-      auto ArrayElementType = ArrayType.getElementType();
-      auto DecayType = PointerType::get(ArrayElementType, PointerSize);
-      CurrentValue = Builder.create<CastOp>(PointerToReplaceLoc,
-                                            DecayType,
-                                            CurrentValue,
-                                            CastKind::Decay);
+      // We need to explicitly handle the `pointer as array` case, where
+      // `CurrentValue` is not a `ptr<T>` of `ArrayType` (we virtually wrap it
+      // ourselves), so the `indirection` and `cast<decay>` is not needed.
+      if (auto PtrType = getPointerType(CurrentValue.getType());
+          PtrType
+          and not mlir::isa<ArrayType>(dealias(PtrType.getPointeeType(),
+                                               /*IgnoreQualifiers=*/true))) {
+        ArrayElementType = PtrType.getPointeeType();
+      } else {
+        // Standard path emitting `indirection` and `cast<decay>` as needed
+        auto [ArrayType,
+              IsIndirect] = getAccessedTypeInfo<clift::ArrayType>(CurrentValue);
+        if (IsIndirect) {
+          CurrentValue = Builder.create<IndirectionOp>(PointerToReplaceLoc,
+                                                       CurrentValue);
+        }
+        ArrayElementType = ArrayType.getElementType();
+        auto DecayType = PointerType::get(ArrayElementType, PointerSize);
+        CurrentValue = Builder.create<CastOp>(PointerToReplaceLoc,
+                                              DecayType,
+                                              CurrentValue,
+                                              CastKind::Decay);
+      }
 
       // Emit the `mlir::Value` representing the `Index` access.
       // We declare all the possible components (constant and variable parts)

--- a/lib/CliftTransforms/PointerArithmetic.cpp
+++ b/lib/CliftTransforms/PointerArithmetic.cpp
@@ -228,6 +228,21 @@ PointerArithmeticBuilder::computePointerArithmetic(ExpressionOpInterface
     return std::nullopt;
   }
 
+  // We skip every replacement where the `PointerToReplace` is equal to the
+  // `BasePointer`. Replacing such expression would create a circular reference:
+  // the new `clift.subscript` uses the `BasePointer` as operand, and
+  // `replaceAllUsesWith` would replace the `BasePointer` uses with the new
+  // `clift.subscript` result, and this insert the circular reference between
+  // mlir `Value`s.
+  if (PointerToReplace->getResult(0) == Result->BasePointer) {
+
+    // We expect this situation only for empty `Result->Offset`
+    const auto &Offset = Result->Offset;
+    revng_assert(Offset.BaseOffset.isZero()
+                 and Offset.LinearCombination.empty());
+    return std::nullopt;
+  }
+
   // Verify invariants for the obtained `PointerArithmetic`
   revng_assert(not Result or Result->verify());
 

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-pointer-as-array-typedef.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-pointer-as-array-typedef.mlir
@@ -1,0 +1,62 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+!int32_t$ptr$typedef = !clift.typedef<"/type-definition/100-TypedefDefinition" : !int32_t$ptr>
+
+!f1 = !clift.func<
+  "1001" as "f1" : !void(!int32_t$ptr$typedef, !generic64_t)
+>
+
+!f2 = !clift.func<
+  "1002" as "f2" : !void(!int32_t$ptr$typedef)
+>
+
+module attributes {clift.module} {
+
+  // pointer as array access: *(p + i) should become p[i], with the index passed
+  // as an argument. The `ptr` is wrapped inside a `typedef`.
+
+  clift.func @test_typedef_pointer_as_array<!f1>(%arg0 : !int32_t$ptr$typedef, %arg1 : !generic64_t) {
+    clift.expr {
+      %0 = clift.cast<bitcast> %arg0 : !int32_t$ptr$typedef -> !generic64_t
+      %1 = clift.imm 4 : !generic64_t
+      %2 = clift.mul %arg1, %1 : !generic64_t
+      %3 = clift.add %0, %2 : !generic64_t
+      %4 = clift.cast<bitcast> %3 : !generic64_t -> !int32_t$ptr
+      clift.yield %4 : !int32_t$ptr
+    }
+  }
+
+  // CHECK: clift.func @test_typedef_pointer_as_array<!f1_>([[POINTER:%[a-z0-9]+]]: {{.*}}, [[INDEX:%[a-z0-9]+]]: {{.*}})
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<bitcast> [[POINTER]] : !_type_definition_100_TypedefDefinition -> !clift.ptr<8 to !int32_t>
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[INDEX]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF]] : !clift.ptr<8 to !int32_t>
+
+
+  // pointer as array access: *(p + 3) should become p[3], with a constant
+  // index. The `ptr` is wrapped inside a `typedef`.
+  clift.func @test_typedef_constant_index<!f2>(%arg0 : !int32_t$ptr$typedef) {
+    clift.expr {
+      %0 = clift.cast<bitcast> %arg0 : !int32_t$ptr$typedef -> !generic64_t
+      %1 = clift.imm 12 : !generic64_t
+      %2 = clift.add %0, %1 : !generic64_t
+      %3 = clift.cast<bitcast> %2 : !generic64_t -> !int32_t$ptr
+      clift.yield %3 : !int32_t$ptr
+    }
+  }
+
+  // CHECK: clift.func @test_typedef_constant_index<!f2_>([[POINTER:%[a-z0-9]+]]: {{.*}})
+  // CHECK: [[IMM:%[0-9]+]] = clift.imm 3
+  // CHECK: [[CAST:%[0-9]+]] = clift.cast<bitcast> [[POINTER]] : !_type_definition_100_TypedefDefinition -> !clift.ptr<8 to !int32_t>
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[CAST]], [[IMM]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/array-pointer-as-array.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/array-pointer-as-array.mlir
@@ -1,0 +1,75 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.primitive<void 0>
+!generic64_t = !clift.primitive<generic 8>
+!int32_t = !clift.primitive<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f1 = !clift.func<
+  "1001" as "f1" : !void(!int32_t$ptr)
+>
+
+!f2 = !clift.func<
+  "1002" as "f2" : !void(!int32_t$ptr, !generic64_t)
+>
+
+module attributes {clift.module} {
+
+  // pointer as array access: *(p + 3) should become p[3], with a constant index
+
+  clift.func @test_pointer_as_array__index<!f1>(%arg0 : !int32_t$ptr) {
+    clift.expr {
+      %0 = clift.cast<bitcast> %arg0 : !int32_t$ptr -> !generic64_t
+      %1 = clift.imm 12 : !generic64_t
+      %2 = clift.add %0, %1 : !generic64_t
+      %3 = clift.cast<bitcast> %2 : !generic64_t -> !int32_t$ptr
+      clift.yield %3 : !int32_t$ptr
+    }
+  }
+
+  // CHECK: clift.func @test_pointer_as_array__index<!f1_>([[POINTER:%[a-z0-9]+]]: {{.*}})
+  // CHECK: [[IMMEDIATE:%[0-9]+]] = clift.imm 3
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[POINTER]], [[IMMEDIATE]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF]] : !clift.ptr<8 to !int32_t>
+
+
+  // pointer as array access: *(p + i) should become p[i], with the index passed
+  // as an argument
+
+  clift.func @test_pointer_as_array_variable_index<!f2>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) {
+    clift.expr {
+      %0 = clift.cast<bitcast> %arg0 : !int32_t$ptr -> !generic64_t
+      %1 = clift.imm 4 : !generic64_t
+      %2 = clift.mul %arg1, %1 : !generic64_t
+      %3 = clift.add %0, %2 : !generic64_t
+      %4 = clift.cast<bitcast> %3 : !generic64_t -> !int32_t$ptr
+      clift.yield %4 : !int32_t$ptr
+    }
+  }
+
+  // CHECK: clift.func @test_pointer_as_array_variable_index<!f2_>([[POINTER:%[a-z0-9]+]]: {{.*}}, [[INDEX:%[a-z0-9]+]]: {{.*}})
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[POINTER]], [[INDEX]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF]] : !clift.ptr<8 to !int32_t>
+
+
+  // pointer as array access: *(p + i) should become p[i], with the index passed
+  // as an argument, using `ptr_add`
+
+  clift.func @test_pointer_as_array_ptr_add<!f2>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) {
+    clift.expr {
+      %0 = clift.ptr_add %arg0, %arg1 : (!int32_t$ptr, !generic64_t)
+      clift.yield %0 : !int32_t$ptr
+    }
+  }
+
+  // CHECK: clift.func @test_pointer_as_array_ptr_add<!f2_>([[POINTER:%[a-z0-9]+]]: {{[^,]*}}, [[INDEX:%[a-z0-9]+]]: {{.*}})
+  // CHECK: [[SUBSCRIPT:%[0-9]+]] = clift.subscript [[POINTER]], [[INDEX]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[SUBSCRIPT]]
+  // CHECK: clift.yield [[ADDRESSOF]] : !clift.ptr<8 to !int32_t>
+}


### PR DESCRIPTION
This enable us to wrap `BasePointerType` into an implicit array. This enables pointer arithmetic rewriting of `*(p + i)` as `p[i]`.