### PR TITLE
EmitFieldAccesses: propagate `Type` through `IndirectionOp`

### DIFF
--- a/include/revng/Clift/CliftTypes.h
+++ b/include/revng/Clift/CliftTypes.h
@@ -135,6 +135,12 @@ template<typename TypeT>
 /// Determine if the two types are equivalent, ignoring Clift CV-qualifiers.
 [[nodiscard]] bool equivalent(mlir::Type Lhs, mlir::Type Rhs);
 
+/// Determine if the two types are equivalent after unwrapping typedefs and
+/// ignoring Clift CV-qualifiers.
+[[nodiscard]] inline bool equivalentUnwrapped(mlir::Type Lhs, mlir::Type Rhs) {
+  return equivalent(unwrapTypedefs(Lhs), unwrapTypedefs(Rhs));
+}
+
 //===-------------------------- Object type size --------------------------===//
 
 /// Returns the size of the given type, assuming it is an ObjectType (after

--- a/include/revng/CliftTransforms/Expressions.td
+++ b/include/revng/CliftTransforms/Expressions.td
@@ -140,4 +140,12 @@ def DirectAccessPattern
         (Clift_AccessOp $arg, (NativeCodeCall<"mlir::UnitAttr(nullptr)">), $member_index),
         [(Constraint<CPred<"not $0">> $indirect)]>;
 
+// x[0] -> *x
+// Constraint: the subscript index is a constant zero.
+def SubscriptZeroPattern
+  : Pat<(Clift_SubscriptOp $ptr, (Clift_ImmediateOp $value)),
+        (Clift_IndirectionOp $ptr),
+        [(Constraint<CPred<"$0.getValue().isZero()">> $value)]>;
+
+
 #endif

--- a/lib/CliftTransforms/BestTraversal.cpp
+++ b/lib/CliftTransforms/BestTraversal.cpp
@@ -198,17 +198,20 @@ static uint64_t commonPrefixStrides(const llvm::ArrayRef<ArrayShape> &LHS,
 }
 
 /// The `typeDistance` function computes the distance between two `Type`s.
-/// Returns 0 if the types are equal (after stripping `typedef`s), or infinity
-/// otherwise. The return type is kept as `uint64_t` to allow future refinement
-/// of the scoring criterion, enabling more fine grained control over this
-/// score.
+/// Returns 0 if the types are exactly equal (after stripping `typedef`s), 1 if
+/// they only differ in CV-qualifiers, or infinity otherwise. The return type is
+/// kept as `uint64_t` to allow future refinement of the scoring criterion,
+/// enabling more fine grained control over this score.
 static uint64_t typeDistance(mlir::Type Explicit, mlir::Type Ideal) {
+  if (unwrapTypedefs(Explicit) == unwrapTypedefs(Ideal)) {
+    return 0;
+  }
 
-  // Unwrap any typedefs to compare the underlying types
-  Explicit = unwrapTypedefs(Explicit);
-  Ideal = unwrapTypedefs(Ideal);
+  if (equivalentUnwrapped(Explicit, Ideal)) {
+    return 1;
+  }
 
-  return Explicit == Ideal ? 0 : std::numeric_limits<uint64_t>::max();
+  return std::numeric_limits<uint64_t>::max();
 }
 
 // =============================================================================

--- a/lib/CliftTransforms/EmitFieldAccesses.cpp
+++ b/lib/CliftTransforms/EmitFieldAccesses.cpp
@@ -49,37 +49,48 @@ struct PlannedReplacement {
 /// anonymous namespace in this translation unit
 mlir::LogicalResult emitFieldAccessesImpl(clift::FunctionOp Function) {
 
-  // `TraversalInfoMap` cache. Even if not elegant, we store the data computed
-  // at the pass level so that we can cache it instead of recomputing it every
-  // time
-  TraversalInfoMap TraversalMap;
+  bool PropagatedThroughIndirection = false;
 
-  // Phase 1-2: Collect all planned `Replacement`s without modifying the IR
-  llvm::SmallVector<PlannedReplacement> Replacements;
-  Function->walk([&TraversalMap,
-                  &Replacements](clift::ExpressionOpInterface Op) {
-    // 1. We inspect all the `ExpressionOp`s in the current `Function`
-    std::optional<PointerArithmetic> PA = computePointerArithmetic(Op);
+  do {
+    PropagatedThroughIndirection = false;
 
-    // The `PointerArithmetic` returned object could be empty at the moment of
-    // return, and this is a signal that we could not compute a
-    // `PointerArithmetic` for the current `ExpressionOpInterface`
+    // `TraversalInfoMap` cache. Even if not elegant, we store the data
+    // computed at the pass level so that we can cache it instead of
+    // recomputing it every time
+    TraversalInfoMap TraversalMap;
 
-    // 2. We proceed with the computation of the `BestTraversal` for the current
-    //    `PointerArithmetic`
-    if (PA) {
-      std::optional<Traversal> BT = computeBestTraversal(Op, *PA, TraversalMap);
+    // Phase 1-2: Collect all planned `Replacement`s without modifying the IR
+    llvm::SmallVector<PlannedReplacement> Replacements;
+    Function->walk([&TraversalMap,
+                    &Replacements](clift::ExpressionOpInterface Op) {
+      // 1. We inspect all the `ExpressionOp`s in the current `Function`
+      std::optional<PointerArithmetic> PA = computePointerArithmetic(Op);
 
-      if (BT) {
-        Replacements.push_back({ Op, std::move(*PA), std::move(*BT) });
+      // The `PointerArithmetic` returned object could be empty at the moment
+      // of return, and this is a signal that we could not compute a
+      // `PointerArithmetic` for the current `ExpressionOpInterface`
+
+      // 2. We proceed with the computation of the `BestTraversal` for the
+      //    current `PointerArithmetic`
+      if (PA) {
+        std::optional<Traversal> BT = computeBestTraversal(Op,
+                                                           *PA,
+                                                           TraversalMap);
+
+        if (BT) {
+          Replacements.push_back({ Op, std::move(*PA), std::move(*BT) });
+        }
       }
-    }
-  });
+    });
 
-  // Phase 3: Apply all replacements
-  for (const auto &R : Replacements) {
-    replaceFieldAccess(R.Op, R.PA, R.BestTraversal);
-  }
+    // Phase 3: Apply all replacements. If any replacement propagates a type
+    // through an indirection, we rerun the whole EFA to discover new
+    // rewriting opportunities enabled by the newly typed pointers.
+    for (const auto &R : Replacements) {
+      if (replaceFieldAccess(R.Op, R.PA, R.BestTraversal))
+        PropagatedThroughIndirection = true;
+    }
+  } while (PropagatedThroughIndirection);
 
   // The IR is always in a valid state, regardless of whether we performed an
   // operation rewrite or not.

--- a/lib/CliftTransforms/FieldAccessReplacement.cpp
+++ b/lib/CliftTransforms/FieldAccessReplacement.cpp
@@ -71,8 +71,9 @@ struct Replacement {
                           const PointerArithmetic &Arithmetic,
                           const Traversal &BestTraversal);
 
-  /// This method performs the actual `clift` IR rewriting,
-  void replace(ExpressionOpInterface PointerToReplace,
+  /// This method performs the actual `clift` IR rewriting. Returns `true` if
+  /// a type was propagated through an indirection.
+  bool replace(ExpressionOpInterface PointerToReplace,
                const PointerArithmetic &Arithmetic) const;
 };
 
@@ -205,8 +206,9 @@ Replacement Replacement::make(unsigned PointerBitWidth,
   return Result;
 }
 
-void Replacement::replace(ExpressionOpInterface PointerToReplace,
+bool Replacement::replace(ExpressionOpInterface PointerToReplace,
                           const PointerArithmetic &Arithmetic) const {
+  bool PropagatedThroughIndirection = false;
 
   // We need the `PointerSize` in order to generate the `ImmediateOp`s used to
   // access the `struct` fields and `array` members, and to generate the
@@ -357,6 +359,12 @@ void Replacement::replace(ExpressionOpInterface PointerToReplace,
                                              CurrentValuePointerType,
                                              CurrentValue);
 
+  // After we emit the `addressof`, we save the resulting `RichValue`, which may
+  // contain a _rich_ type information of the emitted access. We collect this
+  // here before the subsequent `cast` strips it of the type information`. We
+  // then propagate the type information into `indirection` uses.
+  mlir::Value RichValue = CurrentValue;
+
   // If there is a non-null `LeftoverOffset`, we add it as integer arithmetic
   if (not LeftoverOffset.BaseOffset.isZero()
       or not LeftoverOffset.LinearCombination.empty()) {
@@ -410,10 +418,8 @@ void Replacement::replace(ExpressionOpInterface PointerToReplace,
                                              CurrentValue);
   }
 
-  // If the result type differs from PointerToReplace's type, add a cast on
-  // `clift` IR in order to make the replacement fit the replaced
-  // `PointerToReplace` `Type`
-  auto PointerToReplaceOp = PointerToReplace.getOperation();
+  // If the result type differs from PointerToReplace's type, prepare a cast
+  // to make the replacement fit the replaced `PointerToReplace` type.
   if (CurrentValue.getType() != PointerToReplace->getResult(0).getType()) {
     CurrentValue = Builder.create<BitCastOp>(PointerToReplaceLoc,
                                              PointerToReplace->getResult(0)
@@ -421,21 +427,110 @@ void Replacement::replace(ExpressionOpInterface PointerToReplace,
                                              CurrentValue);
   }
 
-  // Replace all uses of `PointerToReplace` with `CurrentValue`
+  // Replace all the `Use`s of `PointerToReplace`, handling `IndirectionOp`s
+  // specially: instead of giving them the "type-erased" `CurrentValue` (through
+  // the `BitCast`) we give the `RichValue` directly so their result type
+  // reflects the actual pointed-to type.
   if (CurrentValue != Arithmetic.BasePointer) {
-    PointerToReplace->getResult(0).replaceAllUsesWith(CurrentValue);
+
+    // Collect the `Use`s before the iteration, to avoid invalidation
+    llvm::SmallVector<mlir::OpOperand *> Uses;
+    for (auto &Use : PointerToReplace->getResult(0).getUses()) {
+      Uses.push_back(&Use);
+    }
+
+    for (auto *Use : Uses) {
+
+      // Check if we can propagate the _rich_ type through `indirection` uses.
+      // We are interested in the `ptr<ptr<...>>` pattern, where the
+      // `indirection` loads a pointer through which further field accesses can
+      // be chained.
+      // If we are inspecting a non-`IndirectionOp`, or if the propagation is
+      // not applicable, we just redirect the `Use` to the type-matched
+      // `CurrentValue`
+      auto Indirection = mlir::dyn_cast<IndirectionOp>(Use->getOwner());
+      auto RichPointerType = unwrapped_dyn_cast<PointerType>(RichValue
+                                                               .getType());
+      bool CanPropagate = RichPointerType
+                          and unwrapped_isa<PointerType>(RichPointerType
+                                                           .getPointeeType());
+      if (not Indirection or not CanPropagate) {
+        Use->set(CurrentValue);
+        continue;
+      }
+
+      auto RichPointeeType = RichPointerType.getPointeeType();
+      auto IndirectionResultType = Indirection.getResult().getType();
+
+      // Size guard: the rich `pointee` must have the same byte size as the
+      // `IndirectionOp` result for the retyping to be safe
+      auto RichPointeeSize = getObjectSizeOrZero(RichPointeeType);
+      auto IndirectionResultSize = getObjectSizeOrZero(IndirectionResultType);
+      if (RichPointeeSize != IndirectionResultSize) {
+        Use->set(CurrentValue);
+        continue;
+      }
+
+      // Types already match — no propagation needed
+      if (RichPointeeType == IndirectionResultType) {
+        Use->set(CurrentValue);
+        continue;
+      }
+
+      // Create a new typed `IndirectionOp` with the `RichValue` as operand,
+      // so its result type is inferred from the `RichPointeeType`
+      Builder.setInsertionPoint(Indirection);
+      auto NewIndirection = Builder.create<IndirectionOp>(PointerToReplaceLoc,
+                                                          RichValue);
+
+      // Insert a `FixupCast` from the typed result to the old untyped result,
+      // so existing users that expect the original type still verify
+      auto FixupCast = Builder.create<BitCastOp>(PointerToReplaceLoc,
+                                                 IndirectionResultType,
+                                                 NewIndirection);
+
+      // Redirect the old `IndirectionOp`'s uses to the `FixupCast`.
+      // Lvalue uses (assign LHS) stay on the old `IndirectionOp`: a `BitCastOp`
+      // is not an lvalue, and changing the LHS type would break the assign's
+      // type constraints. The old `IndirectionOp` is left for DCE.
+      llvm::SmallVector<mlir::OpOperand *> IndirectionUses;
+      for (auto &IndirUse : Indirection.getResult().getUses()) {
+        if (mlir::isa<AssignOp>(IndirUse.getOwner())
+            and IndirUse.getOperandNumber() == 0) {
+          continue;
+        }
+        IndirectionUses.push_back(&IndirUse);
+      }
+
+      for (auto *IndirectionUse : IndirectionUses) {
+        IndirectionUse->set(FixupCast);
+      }
+
+      if (not IndirectionUses.empty()) {
+        PropagatedThroughIndirection = true;
+      }
+
+      // The old indirection's operand stays as-is (for assign LHS uses)
+      Use->set(CurrentValue);
+    }
   }
 
   // At this point, we are left in the `clift` IR with a set of dead `Value`s
   // representing the old `PointerArithmetic`. We rely on a subsequent DCE
   // pass to clean up all the dead `Value`s.
+
+  // We signal at the above level that we propagated the `Type` info through an
+  // `IndirectionOp`, which requires another iteration to find new rewriting
+  // opportunities
+  return PropagatedThroughIndirection;
 }
 } // namespace
 
 /// Entry point function to perform the replacement of the pointer arithmetic
 /// access (`PointerToReplace`), with operations equivalent to the
-/// `BestTraversal` elected in the previous steps
-void replaceFieldAccess(ExpressionOpInterface PointerToReplace,
+/// `BestTraversal` elected in the previous steps.
+/// Returns `true` if a type was propagated through an `indirection`.
+bool replaceFieldAccess(ExpressionOpInterface PointerToReplace,
                         const PointerArithmetic &Arithmetic,
                         const Traversal &BestTraversal) {
 
@@ -451,5 +546,5 @@ void replaceFieldAccess(ExpressionOpInterface PointerToReplace,
   auto R = Replacement::make(PointerBitWidth, Arithmetic, BestTraversal);
 
   // We actually perform the replacement
-  R.replace(PointerToReplace, Arithmetic);
+  return R.replace(PointerToReplace, Arithmetic);
 }

--- a/lib/CliftTransforms/FieldAccessReplacement.h
+++ b/lib/CliftTransforms/FieldAccessReplacement.h
@@ -7,6 +7,10 @@
 #include "BestTraversal.h"
 #include "PointerArithmetic.h"
 
-void replaceFieldAccess(mlir::clift::ExpressionOpInterface PointerToReplace,
+/// Perform the replacement of the pointer arithmetic access
+/// (`PointerToReplace`), with operations equivalent to the `BestTraversal`.
+/// Returns `true` if a type was propagated through an `indirection`, signaling
+/// that a subsequent EFA pass may find new rewriting opportunities.
+bool replaceFieldAccess(mlir::clift::ExpressionOpInterface PointerToReplace,
                         const PointerArithmetic &Arithmetic,
                         const Traversal &BestTraversal);

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-const-field-access.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-const-field-access.mlir
@@ -1,0 +1,94 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.void
+!generic64_t = !clift.int<generic 8>
+!generic32_t = !clift.int<generic 4>
+!int32_t = !clift.int<signed 4>
+!int32_t$const = !clift.const<!int32_t>
+
+!u_generic_const = !clift.union<
+  "2" : {
+    "" : !generic32_t,
+    "" : !int32_t$const
+  }
+>
+
+!s_generic_const = !clift.struct<
+  "1" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !u_generic_const
+  }
+>
+
+!u_const_exact = !clift.union<
+  "4" : {
+    "" : !int32_t$const,
+    "" : !int32_t
+  }
+>
+
+!s_const_exact = !clift.struct<
+  "3" : size(8) {
+    "" : offset(0) !int32_t,
+    "" : offset(4) !u_const_exact
+  }
+>
+
+!f = !clift.func<"1000" as "f" : !void()>
+!g = !clift.func<"1001" as "g" : !void()>
+
+module attributes {clift.module} {
+
+  // Access to the union field via an `int32_t` pointer.
+  // `const int32_t` (alt 1, distance 1) beats `generic32_t` (alt 0,
+  // distance max).
+  clift.func @test_off_by_const_beats_unrelated<!f>() {
+    %0 = clift.local : !s_generic_const
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s_generic_const>
+      %2 = clift.bitcast %1 : !clift.ptr<8 to !s_generic_const> -> !clift.ptr<8 to !void>
+      %3 = clift.bitcast %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.bitcast %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_off_by_const_beats_unrelated
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.bitcast [[ADDRESSOF2]]
+  // CHECK: clift.yield [[CAST]] : !clift.ptr<8 to !int32_t>
+
+
+  // Access to the union field via an `int32_t` pointer.
+  // `int32_t` (alt 1, distance 0) beats `const int32_t` (alt 0, distance 1).
+  clift.func @test_exact_match_beats_off_by_const<!g>() {
+    %0 = clift.local : !s_const_exact
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !s_const_exact>
+      %2 = clift.bitcast %1 : !clift.ptr<8 to !s_const_exact> -> !clift.ptr<8 to !void>
+      %3 = clift.bitcast %2 : !clift.ptr<8 to !void> -> !generic64_t
+      %4 = clift.imm 4 : !generic64_t
+      %5 = clift.add %3, %4 : !generic64_t
+      %6 = clift.bitcast %5 : !generic64_t -> !clift.ptr<8 to !int32_t>
+      clift.yield %6 : !clift.ptr<8 to !int32_t>
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_exact_match_beats_off_by_const
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_3_
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_3_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 1> [[ADDRESSOF1]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access< 1> [[ACCESS1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: clift.yield [[ADDRESSOF2]] : !clift.ptr<8 to !int32_t>
+}

--- a/tests/unit/mlir_lit_tests/emit-field-accesses/struct-indirection-propagation.mlir
+++ b/tests/unit/mlir_lit_tests/emit-field-accesses/struct-indirection-propagation.mlir
@@ -1,0 +1,58 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+!void = !clift.void
+!generic64_t = !clift.int<generic 8>
+!int32_t = !clift.int<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+!generic64_t$ptr = !clift.ptr<8 to !generic64_t>
+
+// Inner struct: has a field at offset 8 (an int32_t pointer)
+!inner = !clift.struct<
+  "2" : size(16) {
+    "" : offset(0) !generic64_t,
+    "" : offset(8) !int32_t$ptr
+  }
+>
+!inner$ptr = !clift.ptr<8 to !inner>
+
+// Outer struct: first field is a pointer to the inner struct
+!outer = !clift.struct<
+  "1" : size(16) {
+    "" : offset(0) !inner$ptr,
+    "" : offset(8) !generic64_t
+  }
+>
+
+!f = !clift.func<"1000" as "f" : !void()>
+
+module attributes {clift.module} {
+
+  // Test the type propagation through an `indirection` barrier
+  clift.func @test_indirection_propagation<!f>() {
+    %0 = clift.local : !outer
+    clift.expr {
+      %1 = clift.addressof %0 : !clift.ptr<8 to !outer>
+      %2 = clift.bitcast %1 : !clift.ptr<8 to !outer> -> !generic64_t$ptr
+      %3 = clift.indirection %2 : !generic64_t$ptr
+      %4 = clift.bitcast %3 : !generic64_t -> !generic64_t$ptr
+      %5 = clift.imm 1 : !generic64_t
+      %6 = clift.ptr_add %4, %5 : (!generic64_t$ptr, !generic64_t)
+      clift.yield %6 : !generic64_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @test_indirection_propagation
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local
+  // CHECK: [[ADDRESSOF1:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[ACCESS1:%[0-9]+]] = clift.access<indirect 0> [[ADDRESSOF1]]
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[ACCESS1]]
+  // CHECK: [[INDIRECTION:%[0-9]+]] = clift.indirection [[ADDRESSOF2]]
+  // CHECK: [[ACCESS2:%[0-9]+]] = clift.access<indirect 1> [[INDIRECTION]]
+  // CHECK: [[ADDRESSOF3:%[0-9]+]] = clift.addressof [[ACCESS2]]
+  // CHECK: [[CAST:%[0-9]+]] = clift.bitcast [[ADDRESSOF3]]
+  // CHECK: clift.yield [[CAST]] : !clift.ptr<8 to !generic64_t>
+}

--- a/tests/unit/mlir_lit_tests/expression-rewrites/subscript-zero.mlir
+++ b/tests/unit/mlir_lit_tests/expression-rewrites/subscript-zero.mlir
@@ -1,0 +1,66 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %revngcliftopt %s --optimize-expressions | FileCheck %s
+
+!void = !clift.void
+!generic64_t = !clift.int<generic 8>
+
+!int32_t = !clift.int<signed 4>
+!int32_t$ptr = !clift.ptr<8 to !int32_t>
+
+!f = !clift.func<"/model-type/1001" : !void(!int32_t$ptr, !generic64_t)>
+
+module attributes {clift.module} {
+  // x[0] -> *x
+  clift.func @f<!f>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) -> !void {
+    // CHECK: clift.expr {
+    clift.expr {
+      %0 = clift.imm 0 : !generic64_t
+      // CHECK-NOT: clift.subscript
+      %1 = clift.subscript %arg0, %0 : (!int32_t$ptr, !generic64_t)
+      // CHECK: clift.indirection %arg0
+      clift.yield %1 : !int32_t
+    }
+    // CHECK: }
+  }
+
+  // &(x[0]) -> x  (via composition with the `&*x -> x` rewriting)
+  clift.func @g<!f>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) -> !void {
+    // CHECK: clift.expr {
+    clift.expr {
+      %0 = clift.imm 0 : !generic64_t
+      // CHECK-NOT: clift.subscript
+      %1 = clift.subscript %arg0, %0 : (!int32_t$ptr, !generic64_t)
+      // CHECK-NOT: clift.addressof
+      %2 = clift.addressof %1 : !int32_t$ptr
+      // CHECK: clift.yield %arg0
+      clift.yield %2 : !int32_t$ptr
+    }
+    // CHECK: }
+  }
+
+  // x[i] is NOT rewritten (index is not a constant zero)
+  clift.func @h<!f>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) -> !void {
+    // CHECK: clift.expr {
+    clift.expr {
+      // CHECK: clift.subscript
+      %0 = clift.subscript %arg0, %arg1 : (!int32_t$ptr, !generic64_t)
+      clift.yield %0 : !int32_t
+    }
+    // CHECK: }
+  }
+
+  // x[1] is NOT rewritten (constant index is not zero)
+  clift.func @i<!f>(%arg0 : !int32_t$ptr, %arg1 : !generic64_t) -> !void {
+    // CHECK: clift.expr {
+    clift.expr {
+      %0 = clift.imm 1 : !generic64_t
+      // CHECK: clift.subscript
+      %1 = clift.subscript %arg0, %0 : (!int32_t$ptr, !generic64_t)
+      clift.yield %1 : !int32_t
+    }
+    // CHECK: }
+  }
+}


### PR DESCRIPTION
After `emit-fa` perform a replacement, propagate the `Type` of the `access` to the `IndirectionOp` uses.

If such propagation takes place, perform another run of `emit-fa` in order to unlock further replacements.