### PR TITLE
Fix Clift comment emission

### DIFF
--- a/include/revng/ADT/LineRange.h
+++ b/include/revng/ADT/LineRange.h
@@ -1,0 +1,69 @@
+#pragma once
+
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+#include <algorithm>
+#include <string_view>
+
+/// Iterates over the lines of a string. If the string is empty, the range is
+/// empty. Each element line (except the last one) ends in a newline character.
+class LineRange {
+public:
+  class Sentinel {
+  public:
+    explicit Sentinel() = default;
+  };
+
+  class Iterator {
+    const char *LineBegin = nullptr;
+    const char *LineEnd = nullptr;
+    const char *End = nullptr;
+
+  public:
+    using value_type = std::string_view;
+    using difference_type = ptrdiff_t;
+
+    Iterator() = default;
+
+    explicit Iterator(std::string_view String) :
+      LineBegin(String.data()),
+      LineEnd(LineBegin),
+      End(LineBegin + String.size()) {
+      if (LineBegin != End)
+        ++(*this);
+    }
+
+    [[nodiscard]] std::string_view operator*() const {
+      return std::string_view(LineBegin, LineEnd);
+    }
+
+    Iterator &operator++() & {
+      const char *LF = std::find(LineEnd, End, '\n');
+      LineBegin = LineEnd;
+      LineEnd = LF == End ? End : LF + 1;
+      return *this;
+    }
+
+    [[nodiscard]] Iterator operator++(int) & {
+      auto Result = *this;
+      ++(*this);
+      return Result;
+    }
+
+    [[nodiscard]] friend bool operator==(const Iterator &Self,
+                                         const Sentinel &) {
+      return Self.LineBegin == Self.End;
+    }
+  };
+
+private:
+  Iterator Begin;
+
+public:
+  explicit LineRange(std::string_view String) : Begin(String) {}
+
+  [[nodiscard]] Iterator begin() const { return Begin; }
+  [[nodiscard]] Sentinel end() const { return Sentinel(); }
+};

--- a/include/revng/PTML/DoxygenEmitter.h
+++ b/include/revng/PTML/DoxygenEmitter.h
@@ -16,6 +16,9 @@ struct DoxygenCommentConfiguration {
   llvm::StringRef LinePrefix;
 };
 
+/// An Emitter capable of emitting Doxygen comments. While at the time of
+/// creation only C comments are emitted (using CDoxygenEmitter via
+/// CTokenEmitter::CommentEmitter), future use for assembly comments is planned.
 template<PTMLEmitter EmitterT>
 class DoxygenEmitter : EmitterT {
   DoxygenCommentConfiguration Configuration;

--- a/include/revng/PTML/DoxygenEmitter.h
+++ b/include/revng/PTML/DoxygenEmitter.h
@@ -4,6 +4,7 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include "revng/ADT/LineRange.h"
 #include "revng/PTML/Constants.h"
 
 namespace ptml {
@@ -15,45 +16,20 @@ struct DoxygenCommentConfiguration {
   llvm::StringRef LinePrefix;
 };
 
-namespace detail {
-
-template<typename EmitterT>
-class DoxygenEmitterBase : public EmitterT {
-protected:
-  DoxygenCommentConfiguration Configuration;
-
-public:
-  template<typename... ArgsT>
-    requires std::constructible_from<EmitterT, ArgsT...>
-  explicit DoxygenEmitterBase(const DoxygenCommentConfiguration &Configuration,
-                              ArgsT &&...Args) :
-    EmitterT(std::forward<ArgsT>(Args)...), Configuration(Configuration) {}
-
-  void emitIndentation(unsigned Indentation) {
-    static constexpr llvm::StringRef IndentString = "  ";
-
-    EmitterT::emit(Configuration.LinePrefix);
-    for (unsigned I = 0; I < Indentation; ++I)
-      EmitterT::emit(IndentString);
-  }
-};
-
-} // namespace detail
-
 template<PTMLEmitter EmitterT>
-class DoxygenEmitter : IndentingEmitter<detail::DoxygenEmitterBase<EmitterT>> {
-  using Base = detail::DoxygenEmitterBase<EmitterT>;
-  using IndentingEmitter = IndentingEmitter<Base>;
+class DoxygenEmitter : EmitterT {
+  DoxygenCommentConfiguration Configuration;
+  bool IsAtBeginningOfLine = true;
 
 public:
   template<typename... ArgsT>
     requires std::constructible_from<EmitterT, ArgsT...>
   explicit DoxygenEmitter(const DoxygenCommentConfiguration &Configuration,
                           ArgsT &&...Args) :
-    IndentingEmitter(Configuration, std::forward<ArgsT>(Args)...) {
-    if (Base::Configuration.CommentHeader) {
-      EmitterT::emit(*Base::Configuration.CommentHeader);
-      IndentingEmitter::emit("\n");
+    EmitterT(std::forward<ArgsT>(Args)...), Configuration(Configuration) {
+    if (Configuration.CommentHeader) {
+      EmitterT::emit(*Configuration.CommentHeader);
+      EmitterT::emit(llvm::StringRef("\n"));
     }
   }
 
@@ -62,23 +38,41 @@ public:
     Tag.emitAttribute(ptml::attributes::Token, ptml::doxygen::tokens::Keyword);
     Tag.finalizeOpenTag();
 
-    char Signifier = Base::Configuration.KeywordSignifier;
-    IndentingEmitter::emit(llvm::StringRef(&Signifier, 1));
-    IndentingEmitter::emit(Keyword);
+    emit(llvm::StringRef(&Configuration.KeywordSignifier, 1));
+    emit(Keyword);
   }
 
   DoxygenEmitter(const DoxygenEmitter &) = delete;
   DoxygenEmitter &operator=(const DoxygenEmitter &) = delete;
 
   ~DoxygenEmitter() {
-    if (Base::Configuration.CommentFooter) {
-      if (not IndentingEmitter::isAtBeginningOfLine())
-        IndentingEmitter::emit("\n");
-      EmitterT::emit(*Base::Configuration.CommentFooter);
+    if (Configuration.CommentFooter) {
+      if (not IsAtBeginningOfLine)
+        EmitterT::emit(llvm::StringRef("\n"));
+      EmitterT::emit(*Configuration.CommentFooter);
     }
   }
 
-  using IndentingEmitter::emit;
+  void emit(llvm::StringRef Content) {
+    if (not Content.empty()) {
+      bool EmitLinePrefix = IsAtBeginningOfLine;
+
+      for (auto Line : LineRange(Content)) {
+        if (std::exchange(EmitLinePrefix, true))
+          emitLinePrefix(Line == "\n");
+
+        EmitterT::emit(Line);
+      }
+
+      IsAtBeginningOfLine = Content.back() == '\n';
+    }
+  }
+
+private:
+  void emitLinePrefix(bool IsEmptyLine) {
+    llvm::StringRef Prefix = Configuration.LinePrefix;
+    EmitterT::emit(IsEmptyLine ? Prefix.rtrim() : Prefix);
+  }
 };
 
 } // namespace ptml

--- a/include/revng/PTML/IndentingEmitter.h
+++ b/include/revng/PTML/IndentingEmitter.h
@@ -8,19 +8,19 @@
 
 #include "llvm/ADT/STLExtras.h"
 
+#include "revng/ADT/LineRange.h"
 #include "revng/PTML/Emitter.h"
 #include "revng/Support/Assert.h"
 
 namespace ptml {
 
-template<typename EmitterT>
-concept IndentableEmitter = //
-  Emitter<EmitterT> and requires(EmitterT &Emitter) {
-    Emitter.emitIndentation(static_cast<unsigned>(0));
-  };
+struct IndentString : llvm::StringRef {
+  explicit IndentString(llvm::StringRef String) : llvm::StringRef(String) {}
+};
 
-template<IndentableEmitter EmitterT>
+template<Emitter EmitterT>
 class IndentingEmitter : protected EmitterT {
+  llvm::StringRef IndentationString;
   unsigned Indentation = 0;
   bool IsAtBeginningOfLine = true;
 
@@ -28,6 +28,11 @@ public:
   template<typename... ArgsT>
     requires std::constructible_from<EmitterT, ArgsT...>
   explicit IndentingEmitter(ArgsT &&...Args) :
+    IndentingEmitter(IndentString("  "), std::forward<ArgsT>(Args)...) {}
+
+  template<typename... ArgsT>
+    requires std::constructible_from<EmitterT, ArgsT...>
+  explicit IndentingEmitter(IndentString Indent, ArgsT &&...Args) :
     EmitterT(std::forward<ArgsT>(Args)...) {}
 
   void indent(int Offset) {
@@ -39,20 +44,16 @@ public:
 
   [[nodiscard]] unsigned indentation() const { return Indentation; }
 
-  [[nodiscard]] bool isAtBeginningOfLine() const { return IsAtBeginningOfLine; }
-
   void emit(llvm::StringRef String) {
     if (not String.empty()) {
-      for (auto [I, R] : llvm::enumerate(std::views::split(String, '\n'))) {
-        llvm::StringRef Line = std::string_view(R.begin(), R.end());
+      bool EmitIndent = IsAtBeginningOfLine;
 
-        if (I != 0)
-          emitNewline();
+      for (auto Line : LineRange(String)) {
+        if (std::exchange(EmitIndent, true))
+          emitIndentation();
 
-        if (not Line.empty()) {
-          emitIndentationIfNeeded();
+        if (not Line.empty())
           EmitterT::emit(Line);
-        }
       }
 
       IsAtBeginningOfLine = String.back() == '\n';
@@ -68,8 +69,14 @@ protected:
   void emitIndentationIfNeeded() {
     if (IsAtBeginningOfLine) {
       IsAtBeginningOfLine = false;
-      EmitterT::emitIndentation(Indentation);
+      emitIndentation();
     }
+  }
+
+private:
+  void emitIndentation() {
+    for (unsigned I = 0; I < Indentation; ++I)
+      EmitterT::emit(IndentationString);
   }
 };
 

--- a/include/revng/PTML/PTMLEmitter.h
+++ b/include/revng/PTML/PTMLEmitter.h
@@ -30,8 +30,6 @@ protected:
 public:
   explicit PTMLEmitterBase(llvm::raw_ostream &OS, Tagging Tags) :
     StreamEmitter(OS), EmitTags(Tags == Tagging::Enabled) {}
-
-  void emitIndentation(unsigned Indentation);
 };
 
 } // namespace detail
@@ -128,7 +126,6 @@ public:
 
   using IndentingEmitter::indent;
   using IndentingEmitter::indentation;
-  using IndentingEmitter::isAtBeginningOfLine;
 
   /// Returns an initializer object which can be used for delayed initialization
   /// of a PTMLTagEmitter.

--- a/lib/PTML/CTokenEmitter.cpp
+++ b/lib/PTML/CTokenEmitter.cpp
@@ -8,6 +8,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "revng/ADT/LineRange.h"
 #include "revng/PTML/CTokenEmitter.h"
 #include "revng/PTML/Constants.h"
 #include "revng/Support/Assert.h"
@@ -773,13 +774,15 @@ CTokenEmitter::CommentEmitter::~CommentEmitter() {
 
 void CTokenEmitter::CommentEmitter::emit(llvm::StringRef Content) {
   if (not Content.empty()) {
-    for (auto [I, R] : llvm::enumerate(std::views::split(Content, '\n'))) {
-      llvm::StringRef Line = std::string_view(R.begin(), R.end());
+    bool EmitLinePrefix = IsAtBeginningOfLine;
 
-      if (I != 0)
+    for (auto Line : LineRange(Content)) {
+      if (std::exchange(EmitLinePrefix, true))
+        emitLinePrefix();
+
+      if (Line == "\n")
         PTML.emit("\n");
-
-      if (not Line.empty())
+      else
         emitEscaped(Line);
     }
 
@@ -800,11 +803,6 @@ void CTokenEmitter::CommentEmitter::emitLinePrefix() {
 
 void CTokenEmitter::CommentEmitter::emitEscaped(llvm::StringRef Content) {
   revng_assert(not Content.empty());
-
-  if (IsAtBeginningOfLine) {
-    emitLinePrefix();
-    IsAtBeginningOfLine = false;
-  }
 
   switch (Kind) {
   case CommentKind::Line:

--- a/lib/PTML/PTMLEmitter.cpp
+++ b/lib/PTML/PTMLEmitter.cpp
@@ -155,13 +155,6 @@ PTMLTagEmitter::emitListAttribute(llvm::StringRef Name,
 
 //===-------------------------- PTMLStreamEmitter -------------------------===//
 
-void detail::PTMLEmitterBase::emitIndentation(unsigned Indentation) {
-  static constexpr llvm::StringRef IndentString = "  ";
-
-  for (unsigned I = 0; I < Indentation; ++I)
-    emit(IndentString);
-}
-
 void PTMLStreamEmitter::emit(llvm::StringRef Content) {
   revng_assert(CurrentOpenTagEmitter == nullptr,
                "Cannot emit content while an unfinalized tag emitter is "

--- a/tests/unit/DoxygenEmitter.cpp
+++ b/tests/unit/DoxygenEmitter.cpp
@@ -21,9 +21,12 @@ BOOST_AUTO_TEST_CASE(LineComment) {
     Doxygen.emitKeyword("brief");
     Doxygen.emit(" This does something.");
     Doxygen.emit("\n");
+    Doxygen.emit("\n\n");
     Doxygen.emit("And also note this other thing.");
   }
   constexpr auto &Expected = "/// \\brief This does something.\n"
+                             "///\n"
+                             "///\n"
                              "/// And also note this other thing.\n";
   revng_assert(Content == Expected);
 }
@@ -38,10 +41,13 @@ BOOST_AUTO_TEST_CASE(BlockComment) {
     Doxygen.emitKeyword("brief");
     Doxygen.emit(" This does something.");
     Doxygen.emit("\n");
+    Doxygen.emit("\n\n");
     Doxygen.emit("And also note this other thing.");
   }
   constexpr auto Expected = "/**\n"
                             " * \\brief This does something.\n"
+                            " *\n"
+                            " *\n"
                             " * And also note this other thing.\n"
                             " */";
   revng_assert(Content == Expected);


### PR DESCRIPTION
1. Currently empty lines in comments are emitted without slashes:
A comment with content `A\n\nB` comes out as:
   ```
   //A

   //B
   ```
   With this change, the missing slashes are emitted.

2. Effectively the same problem applies to Doxygen comments, where (with the previous change), empty lines come out without the relevant prefixes:
   ```
   /// A
   //
   /// B
   ```
   With this change, the missing slash (but not the trailing space) is emitted.

3. Because `IndentingEmitter` is no longer used to emit anything non-trivial (e.g. the line comment slashes), the `IndentableEmitter` concept is removed and the indentation string of `IndentingEmitter` is instead made configurable. The default of `"  "` matches what was emitted by `PTMLStreamEmitter`.