### PR TITLE
Fix handling of `import-from-c` tests various failure modes

### DIFF
--- a/share/revng/test/configuration/revng/import-from-c.yml
+++ b/share/revng/test/configuration/revng/import-from-c.yml
@@ -60,6 +60,10 @@ commands:
   #
   # otherwise, the error is checked against `${INPUT}/expected-error.txt` with
   # its license header stripped.
+  #
+  # Any other outcome fails the test: a crash (exit code other than 0 or 1),
+  # a failure in a test that has no `expected-error.txt`, or a failure whose
+  # stderr carries no `RuntimeError:` payload.
   - type: revng.import-from-c
     from:
       - type: source
@@ -70,22 +74,43 @@ commands:
       C_CODE=$$(sed 's;^;  ;' "${INPUT}/edit.c");
       CONFIGURATION="LocationToEdit: $${LOCATION_TO_EDIT}\nCCode: |\n$${C_CODE}";
 
-      if revng2 pipeline run-analysis import-from-c
-           -c "$$(echo -e "$$CONFIGURATION")"
-           "${INPUT}/input-model.yml"
-           -o "${OUTPUT}/model.yml"
-           2> "${OUTPUT}/error.txt"; then
+      EXIT_CODE=0;
+      revng2 pipeline run-analysis import-from-c
+        -c "$$(echo -e "$$CONFIGURATION")"
+        "${INPUT}/input-model.yml"
+        -o "${OUTPUT}/model.yml"
+        2> "${OUTPUT}/error.txt" || EXIT_CODE=$$?;
+
+      if [[ "$$EXIT_CODE" -eq 0 ]]; then
 
         revng model compare "${INPUT}/check-against.yml" "${OUTPUT}/model.yml";
 
       else
 
-        if ! [[ "$$(tail -n +5 "${INPUT}/expected-error.txt")" ==
-           "$$(grep -Pzo '(?<=RuntimeError: )[^\x00]*' "${OUTPUT}/error.txt" | tr -d '\0')" ]]; then
-          echo "Expected:"
-          cat "${INPUT}/expected-error.txt"
-          echo "Got:"
-          echo "${OUTPUT}/error.txt"
+        if [[ "$$EXIT_CODE" -ne 1 ]]; then
+          echo "import-from-c terminated unexpectedly (exit code $${EXIT_CODE}), stderr:";
+          cat "${OUTPUT}/error.txt";
+          exit 1;
+        fi;
+
+        if ! [[ -e "${INPUT}/expected-error.txt" ]]; then
+          echo "import-from-c failed but no error was expected, stderr:";
+          cat "${OUTPUT}/error.txt";
+          exit 1;
+        fi;
+
+        ACTUAL_ERROR=$$(grep -Pzo '(?<=RuntimeError: )[^\x00]*' "${OUTPUT}/error.txt" | tr -d '\0' || true);
+        if [[ -z "$$ACTUAL_ERROR" ]]; then
+          echo "import-from-c failed without reporting a RuntimeError, stderr:";
+          cat "${OUTPUT}/error.txt";
+          exit 1;
+        fi;
+
+        if ! [[ "$$(tail -n +5 "${INPUT}/expected-error.txt")" == "$$ACTUAL_ERROR" ]]; then
+          echo "Expected:";
+          cat "${INPUT}/expected-error.txt";
+          echo "Got:";
+          cat "${OUTPUT}/error.txt";
           exit 1;
         fi;
       fi


### PR DESCRIPTION
`import-from-c` test members could pass even when the analysis crashed: the crash trace ended up in the log, but the test still exited 0.

The root cause is in the test command of `share/revng/test/configuration/revng/import-from-c.yml`. The test harness joins the command block into a single shell line, and the diagnostic block of the error-comparison branch was missing its statement terminators: the whole block collapsed into a single `echo` whose arguments included `cat`, the file paths — and `exit 1`. The mismatch branch therefore printed its diagnostics and fell through with exit 0: the error comparison could never fail the test.

Three weaker spots additionally conspired to hide crashes:

- The exit code of `revng2 pipeline run-analysis` was only consumed as a boolean, so a crash (134 = SIGABRT, 139 = SIGSEGV, ...) was indistinguishable from a graceful analysis failure (an uncaught Python `RuntimeError`, which always exits 1).
- Success-shaped members have no `expected-error.txt`, so on failure `tail` of the missing file yielded an empty string that compared equal to the empty `RuntimeError:` payload extracted from a crash trace.
- Nothing required a `RuntimeError:` marker to be present in stderr at all.

One commit per problem:

1. Terminate the diagnostic statements so `exit 1` executes.
2. `cat` the error file instead of echoing its path.
3. Capture the exit code: only exit code 1 may enter the expected-error path; anything else dumps stderr and fails.
4. Fail when the analysis fails but the test expects success.
5. Fail with a dedicated diagnostic when stderr carries no `RuntimeError:` payload.
6. Document the new failure modes.
