### PR TITLE
EmitFieldAccesses: PA::`verify` soft-fail

### DIFF
--- a/lib/CliftTransforms/PointerArithmetic.cpp
+++ b/lib/CliftTransforms/PointerArithmetic.cpp
@@ -36,10 +36,18 @@ bool PointerArithmetic::isAddress() const {
 
 bool PointerArithmetic::verify() const {
 
+  // A negative `BaseOffset` would point before the pointed-to object, so it
+  // cannot correspond to a field or array element access
+  if (Offset.BaseOffset.isNegative()) {
+    return false;
+  }
+
   const auto &LinearCombination = Offset.LinearCombination;
 
   // Check that strides are strictly positive. Negative or null strides do not
-  // make sense
+  // make sense.
+  // TODO: currently negative `Stride`s fail the verify, we may need to support
+  //       them in the future.
   for (const auto &Term : LinearCombination) {
     if (Term.Stride.isNegative() or Term.Stride.isZero()) {
       return false;
@@ -231,6 +239,15 @@ PointerArithmeticBuilder::computePointerArithmetic(ExpressionOpInterface
     return std::nullopt;
   }
 
+  // If the traversal failed, or produced a `PointerArithmetic` that is not
+  // valid, we cannot rewrite the expression, so we leave it as raw pointer
+  // arithmetic instead of asserting.
+  // TODO: currently negative `Stride`s fail the verify, we may need to support
+  //       them in the future.
+  if (not Result or not Result->verify()) {
+    return std::nullopt;
+  }
+
   // We skip every replacement where the `PointerToReplace` is equal to the
   // `BasePointer`. Replacing such expression would create a circular reference:
   // the new `clift.subscript` uses the `BasePointer` as operand, and
@@ -245,9 +262,6 @@ PointerArithmeticBuilder::computePointerArithmetic(ExpressionOpInterface
                  and Offset.LinearCombination.empty());
     return std::nullopt;
   }
-
-  // Verify invariants for the obtained `PointerArithmetic`
-  revng_assert(not Result or Result->verify());
 
   // Log the resulting `PointerArithmetic`, together with the initial
   // `PointerToReplace` it was produced from

--- a/lib/CliftTransforms/PointerArithmetic.h
+++ b/lib/CliftTransforms/PointerArithmetic.h
@@ -66,7 +66,8 @@ struct PointerArithmetic {
   /// Check if this is an address (has base pointer) arithmetic
   bool isAddress() const;
 
-  /// Verify the invariants for the strides contained in the PointerArithmetic
+  /// Verify the `PointerArithmetic` is valid: a non-negative `BaseOffset` and
+  /// strictly-positive, unique, descending strides
   bool verify() const;
 
   /// Dump method

--- a/tests/filecheck/CMakeLists.txt
+++ b/tests/filecheck/CMakeLists.txt
@@ -107,6 +107,7 @@ set(FILECHECK_TESTS
     clift/emit-field-accesses/array-ptradd-linear-combination.mlir
     clift/emit-field-accesses/array-struct-stride-mul.mlir
     clift/emit-field-accesses/array-struct-stride-shl.mlir
+    clift/emit-field-accesses/negative-stride-and-offset-no-rewrite.mlir
     clift/emit-field-accesses/struct-array-field-no-traverse.mlir
     clift/emit-field-accesses/struct-array-field-target.mlir
     clift/emit-field-accesses/struct-base-access-leftover.mlir

--- a/tests/filecheck/clift/emit-field-accesses/negative-stride-and-offset-no-rewrite.mlir
+++ b/tests/filecheck/clift/emit-field-accesses/negative-stride-and-offset-no-rewrite.mlir
@@ -1,0 +1,80 @@
+//
+// This file is distributed under the MIT License. See LICENSE.md for details.
+//
+
+// RUN: %root/bin/revng clift-opt %s -emit-field-accesses -canonicalize 2>&1 | FileCheck %s
+
+// A pointer walking backward through an object produces a negative stride
+// (`idx * -56`) or a negative base offset (`-7`). Neither maps to a field or
+// array element access, so `PointerArithmetic::verify()` rejects the result and
+// emit-field-accesses leaves the raw pointer arithmetic untouched (no
+// `clift.subscript`/`clift.access`).
+
+!void = !clift.void
+!generic64_t = !clift.int<generic 8>
+!uint8_t = !clift.int<unsigned 1>
+!uint8_t$ptr = !clift.ptr<8 to !uint8_t>
+
+!f = !clift.func<
+  "1000" as "f" : !void()
+>
+
+!s = !clift.struct<
+  "1" : size(64) {
+    "" : offset(0) !generic64_t
+  }
+>
+!s$ptr = !clift.ptr<8 to !s>
+
+module attributes {clift.module} {
+
+  // Negative `Stride`: left as raw pointer arithmetic
+
+  clift.func @f<!f>() {
+    %0 = clift.local : !s
+    %1 = clift.local : !generic64_t
+    clift.expr {
+      %2 = clift.imm -56 : !generic64_t
+      %3 = clift.mul %1, %2 : !generic64_t
+      %4 = clift.addressof %0 : !s$ptr
+      %5 = clift.bitcast %4 : !s$ptr -> !uint8_t$ptr
+      %6 = clift.ptr_add %5, %3 : (!uint8_t$ptr, !generic64_t)
+      clift.yield %6 : !uint8_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @f<!f>
+  // CHECK: [[STRUCT:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[INDEX:%[0-9]+]] = clift.local : !generic64_t
+  // CHECK: [[STRIDE:%[0-9]+]] = clift.imm -56
+  // CHECK: [[OFFSET:%[0-9]+]] = clift.mul [[INDEX]], [[STRIDE]]
+  // CHECK: [[ADDRESSOF:%[0-9]+]] = clift.addressof [[STRUCT]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[CAST:%[0-9]+]] = clift.bitcast [[ADDRESSOF]] : !clift.ptr<8 to !_1_> -> !clift.ptr<8 to !uint8_t>
+  // CHECK: [[PTRADD:%[0-9]+]] = clift.ptr_add [[CAST]], [[OFFSET]]
+  // CHECK: clift.yield [[PTRADD]] : !clift.ptr<8 to !uint8_t>
+  // CHECK-NOT: clift.subscript
+  // CHECK-NOT: clift.access
+
+  // Negative `BaseOffset`: left as raw pointer arithmetic
+
+  clift.func @g<!f>() {
+    %0 = clift.local : !s
+    clift.expr {
+      %1 = clift.imm -7 : !generic64_t
+      %2 = clift.addressof %0 : !s$ptr
+      %3 = clift.bitcast %2 : !s$ptr -> !uint8_t$ptr
+      %4 = clift.ptr_add %3, %1 : (!uint8_t$ptr, !generic64_t)
+      clift.yield %4 : !uint8_t$ptr
+    }
+  }
+
+  // CHECK-LABEL: clift.func @g<!f>
+  // CHECK: [[STRUCT2:%[0-9]+]] = clift.local : !_1_
+  // CHECK: [[BASEOFFSET:%[0-9]+]] = clift.imm -7
+  // CHECK: [[ADDRESSOF2:%[0-9]+]] = clift.addressof [[STRUCT2]] : !clift.ptr<8 to !_1_>
+  // CHECK: [[CAST2:%[0-9]+]] = clift.bitcast [[ADDRESSOF2]] : !clift.ptr<8 to !_1_> -> !clift.ptr<8 to !uint8_t>
+  // CHECK: [[PTRADD2:%[0-9]+]] = clift.ptr_add [[CAST2]], [[BASEOFFSET]]
+  // CHECK: clift.yield [[PTRADD2]] : !clift.ptr<8 to !uint8_t>
+  // CHECK-NOT: clift.subscript
+  // CHECK-NOT: clift.access
+}


### PR DESCRIPTION
`computePointerArithmetic` asserted on a `PointerArithmetic` that did not verify, aborting on a negative `Stride` or a negative `BaseOffset`.

Return `nullopt` to keep the raw pointer arithmetic instead and transform the failure into a soft-fail.

`verify()` now also rejects negative `BaseOffset`s.