### PR TITLE
Floating Point Frontend: Extend Registers

### DIFF
--- a/include/revng/ABI/FunctionType/Layout.h
+++ b/include/revng/ABI/FunctionType/Layout.h
@@ -261,9 +261,33 @@ inline uint64_t finalStackOffset(const model::UpcastableType &Prototype) {
   return finalStackOffset(Prototype->toPrototype());
 }
 
+/// A register holding (part of) an argument or return value, together with the
+/// number of bytes the model says it actually carries.
+struct UsedRegister {
+  /// The register itself.
+  model::Register::Values Location;
+
+  /// The number of bytes the model assigns to this register. For a
+  /// `RawFunctionDefinition` this is the size of the `Type` of the
+  /// corresponding `NamedTypedRegister`, which can be smaller than the register
+  /// width when only its low part carries data (e.g. a scalar living in a
+  /// vector register). It dictates the width of the value `enforce-abi`
+  /// materializes, so the C backend is never handed an oversized integer.
+  uint64_t Size;
+
+  UsedRegister(model::Register::Values Location, uint64_t Size) :
+    Location(Location), Size(Size) {}
+
+  /// Convenience conversion sizing a register by its full width. Used by the
+  /// CABI path, which describes argument/return values by their position
+  /// rather than by a per-register model `Type`.
+  UsedRegister(model::Register::Values Location) :
+    Location(Location), Size(model::Register::getSize(Location)) {}
+};
+
 struct UsedRegisters {
-  llvm::SmallVector<model::Register::Values> Arguments;
-  llvm::SmallVector<model::Register::Values> ReturnValues;
+  llvm::SmallVector<UsedRegister> Arguments;
+  llvm::SmallVector<UsedRegister> ReturnValues;
 };
 UsedRegisters usedRegisters(const model::CABIFunctionDefinition &Prototype);
 
@@ -271,9 +295,11 @@ inline UsedRegisters
 usedRegisters(const model::RawFunctionDefinition &Prototype) {
   UsedRegisters Result;
   for (const model::NamedTypedRegister &Register : Prototype.Arguments())
-    Result.Arguments.emplace_back(Register.Location());
+    Result.Arguments.emplace_back(Register.Location(),
+                                  *Register.Type()->size());
   for (const model::NamedTypedRegister &Register : Prototype.ReturnValues())
-    Result.ReturnValues.emplace_back(Register.Location());
+    Result.ReturnValues.emplace_back(Register.Location(),
+                                     *Register.Type()->size());
   return Result;
 }
 

--- a/include/revng/Model/Architecture.h
+++ b/include/revng/Model/Architecture.h
@@ -243,9 +243,14 @@ inline bool hasELFRelocationAddend(Values V) {
   }
 }
 
-inline llvm::StringRef getReadRegisterAssembly(Values V) {
+inline llvm::StringRef getReadRegisterAssembly(Values V,
+                                               uint64_t RegisterSize) {
   switch (V) {
   case model::Architecture::x86_64:
+    // `movq` can only move a quadword (8 bytes); wider registers such as the
+    // `zmm` registers have no `movq` form, so we emit no assembly for them.
+    if (RegisterSize > 8)
+      return "";
     return "movq %REGISTER, $0";
 
   case model::Architecture::systemz:
@@ -261,9 +266,14 @@ inline llvm::StringRef getReadRegisterAssembly(Values V) {
   }
 }
 
-inline llvm::StringRef getWriteRegisterAssembly(Values V) {
+inline llvm::StringRef getWriteRegisterAssembly(Values V,
+                                                uint64_t RegisterSize) {
   switch (V) {
   case model::Architecture::x86_64:
+    // `movq` can only move a quadword (8 bytes); wider registers such as the
+    // `zmm` registers have no `movq` form, so we emit no assembly for them.
+    if (RegisterSize > 8)
+      return "";
     return "movq $0, %REGISTER";
 
   case model::Architecture::systemz:

--- a/include/revng/Model/Register.h
+++ b/include/revng/Model/Register.h
@@ -59,14 +59,14 @@ getReferenceArchitecture(Values V) {
   case r13_x86_64:
   case r14_x86_64:
   case r15_x86_64:
-  case xmm0_x86_64:
-  case xmm1_x86_64:
-  case xmm2_x86_64:
-  case xmm3_x86_64:
-  case xmm4_x86_64:
-  case xmm5_x86_64:
-  case xmm6_x86_64:
-  case xmm7_x86_64:
+  case zmm0_x86_64:
+  case zmm1_x86_64:
+  case zmm2_x86_64:
+  case zmm3_x86_64:
+  case zmm4_x86_64:
+  case zmm5_x86_64:
+  case zmm6_x86_64:
+  case zmm7_x86_64:
   case fs_x86_64:
     return model::Architecture::x86_64;
   case r0_arm:
@@ -654,14 +654,14 @@ constexpr inline model::PrimitiveKind::Values primitiveKind(Values V) {
   case xmm5_x86:
   case xmm6_x86:
   case xmm7_x86:
-  case xmm0_x86_64:
-  case xmm1_x86_64:
-  case xmm2_x86_64:
-  case xmm3_x86_64:
-  case xmm4_x86_64:
-  case xmm5_x86_64:
-  case xmm6_x86_64:
-  case xmm7_x86_64:
+  case zmm0_x86_64:
+  case zmm1_x86_64:
+  case zmm2_x86_64:
+  case zmm3_x86_64:
+  case zmm4_x86_64:
+  case zmm5_x86_64:
+  case zmm6_x86_64:
+  case zmm7_x86_64:
   case q0_arm:
   case q1_arm:
   case q2_arm:

--- a/include/revng/Model/Register.h
+++ b/include/revng/Model/Register.h
@@ -4,6 +4,9 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include <string>
+#include <vector>
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
 
@@ -474,6 +477,46 @@ std::string getCSVName(Values V);
 
 Values fromCSVName(llvm::StringRef Name,
                    model::Architecture::Values Architecture);
+
+/// One of the CSVs (the LLVM globals representing slices of CPU state)
+/// composing a register, identified by its name plus its placement within
+/// the register.
+///
+/// `StartOffset` is the byte offset of this CSV within the register and
+/// `Size` its size in bytes. A register composed of a single CSV has
+/// `StartOffset == 0` and `Size == getSize(Register)`. Registers spanning
+/// multiple CSVs (e.g. a 512-bit `zmm`) are described by several `CSV`
+/// entries covering consecutive portions.
+struct CSV {
+  std::string Name;
+  uint64_t StartOffset;
+  uint64_t Size;
+};
+
+/// \return the ordered list of CSVs composing register \p V.
+///
+/// Every register currently maps to exactly one CSV, so the returned vector
+/// always holds a single element. This will change once registers spanning
+/// multiple CSVs are represented.
+std::vector<CSV> getCSVs(Values V);
+
+/// The portion of a register a given CSV covers: the register it belongs to,
+/// the byte offset of the CSV within it and the CSV size in bytes.
+struct RegisterPortion {
+  Values Register;
+  uint64_t StartOffset;
+  uint64_t Size;
+};
+
+/// \return the register a CSV belongs to and the portion of it the CSV
+///         covers.
+///
+/// The `Register` field is `Invalid` when \p Name is not a known register
+/// CSV. Each CSV currently covers a whole register, so `StartOffset` is
+/// always 0 and `Size` equals the register size.
+RegisterPortion
+registerPortionFromCSVName(llvm::StringRef Name,
+                           model::Architecture::Values Architecture);
 
 constexpr inline model::PrimitiveKind::Values primitiveKind(Values V) {
   switch (V) {

--- a/include/revng/Model/Register.h
+++ b/include/revng/Model/Register.h
@@ -292,6 +292,15 @@ inline uint64_t getSize(Values V) {
   switch (V) {
   case st0_x86:
     return 10;
+  case zmm0_x86_64:
+  case zmm1_x86_64:
+  case zmm2_x86_64:
+  case zmm3_x86_64:
+  case zmm4_x86_64:
+  case zmm5_x86_64:
+  case zmm6_x86_64:
+  case zmm7_x86_64:
+    return 64;
   case f0_mips:
   case f1_mips:
   case f2_mips:
@@ -329,7 +338,8 @@ inline uint64_t getSize(Values V) {
     break;
   }
 
-  // TODO: this does not account for vector registers, but it should eventually.
+  // TODO: this does not account for non-x86-64 vector registers, but it should
+  //       eventually.
   switch (Architecture) {
   case model::Architecture::x86:
   case model::Architecture::arm:
@@ -475,6 +485,12 @@ inline std::optional<unsigned> getMContextIndex(Values V) {
 
 std::string getCSVName(Values V);
 
+/// \return the register a CSV belongs to, or `Invalid` if unknown; for a
+///         single lane of a multi-CSV register (an x86-64 `zmm`), the whole
+///         owning register.
+///
+/// Thin wrapper over `registerPortionFromCSVName`, kept for callers that only
+/// need the register and not the portion.
 Values fromCSVName(llvm::StringRef Name,
                    model::Architecture::Values Architecture);
 
@@ -495,9 +511,9 @@ struct CSV {
 
 /// \return the ordered list of CSVs composing register \p V.
 ///
-/// Every register currently maps to exactly one CSV, so the returned vector
-/// always holds a single element. This will change once registers spanning
-/// multiple CSVs are represented.
+/// Most registers map to a single CSV. A register spanning multiple CSVs (an
+/// x86-64 `zmm`, laid out as eight 64-bit lanes) returns one entry per lane,
+/// in ascending offset order.
 std::vector<CSV> getCSVs(Values V);
 
 /// \return the name of the single CSV composing register \p V.
@@ -519,8 +535,9 @@ struct RegisterPortion {
 ///         covers.
 ///
 /// The `Register` field is `Invalid` when \p Name is not a known register
-/// CSV. Each CSV currently covers a whole register, so `StartOffset` is
-/// always 0 and `Size` equals the register size.
+/// CSV. For a single-CSV register `StartOffset` is 0 and `Size` is the whole
+/// register; for a lane of a multi-CSV register (an x86-64 `zmm`) they locate
+/// the lane within the register.
 RegisterPortion
 registerPortionFromCSVName(llvm::StringRef Name,
                            model::Architecture::Values Architecture);

--- a/include/revng/Model/Register.h
+++ b/include/revng/Model/Register.h
@@ -500,6 +500,13 @@ struct CSV {
 /// multiple CSVs are represented.
 std::vector<CSV> getCSVs(Values V);
 
+/// \return the name of the single CSV composing register \p V.
+///
+/// Aborts if \p V is composed of more than one CSV. Use only for registers
+/// known to map to exactly one CSV (e.g. the stack pointer or the program
+/// counter).
+std::string singleCSVName(Values V);
+
 /// The portion of a register a given CSV covers: the register it belongs to,
 /// the byte offset of the CSV within it and the CSV size in bytes.
 struct RegisterPortion {

--- a/include/revng/Model/model-schema.yml
+++ b/include/revng/Model/model-schema.yml
@@ -2,7 +2,7 @@
 # This file is distributed under the MIT License. See LICENSE.md for details.
 #
 
-version: 9
+version: 10
 root_type: Binary
 
 definitions:
@@ -1333,14 +1333,14 @@ definitions:
       - name: r13_x86_64
       - name: r14_x86_64
       - name: r15_x86_64
-      - name: xmm0_x86_64
-      - name: xmm1_x86_64
-      - name: xmm2_x86_64
-      - name: xmm3_x86_64
-      - name: xmm4_x86_64
-      - name: xmm5_x86_64
-      - name: xmm6_x86_64
-      - name: xmm7_x86_64
+      - name: zmm0_x86_64
+      - name: zmm1_x86_64
+      - name: zmm2_x86_64
+      - name: zmm3_x86_64
+      - name: zmm4_x86_64
+      - name: zmm5_x86_64
+      - name: zmm6_x86_64
+      - name: zmm7_x86_64
       - name: fs_x86_64
       # ARM registers
       - name: r0_arm

--- a/include/revng/RegisterUsageAnalyses/Function.h
+++ b/include/revng/RegisterUsageAnalyses/Function.h
@@ -4,33 +4,18 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include <limits>
 #include <string>
 
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/GlobalVariable.h"
 
 #include "revng/ADT/GenericGraph.h"
-#include "revng/Model/Register.h"
-
-template<>
-struct llvm::DenseMapInfo<model::Register::Values> {
-  static model::Register::Values getEmptyKey() {
-    return model::Register::Count;
-  }
-
-  static model::Register::Values getTombstoneKey() {
-    return static_cast<model::Register::Values>(model::Register::Count + 1);
-  }
-
-  static unsigned getHashValue(const model::Register::Values &S) { return S; }
-
-  static bool isEqual(const model::Register::Values &LHS,
-                      const model::Register::Values &RHS) {
-    return LHS == RHS;
-  }
-};
+#include "revng/Support/Generator.h"
 
 namespace rua {
 
@@ -64,7 +49,9 @@ inline llvm::StringRef getName(Values V) {
 class Operation {
 public:
   OperationType::Values Type = OperationType::Invalid;
-  uint8_t Target = model::Register::Invalid;
+  // Index of the CSV this operation targets, assigned by Function::csvIndex.
+  // Default-constructed operations are never analyzed (Type == Invalid).
+  uint8_t Target = 0;
 };
 
 static_assert(sizeof(Operation) == 2);
@@ -109,47 +96,52 @@ using BlockNode = BidirectionalNode<Block>;
 
 class Function : public GenericGraph<BlockNode> {
 private:
-  llvm::DenseMap<uint8_t, model::Register::Values> IndexToRegister;
-  llvm::DenseMap<model::Register::Values, uint8_t> RegisterToIndex;
+  llvm::DenseMap<uint8_t, llvm::GlobalVariable *> IndexToCSV;
+  llvm::DenseMap<llvm::GlobalVariable *, uint8_t> CSVToIndex;
 
 public:
   Function() = default;
 
 public:
-  uint8_t registerIndex(model::Register::Values Register) {
-    auto It = RegisterToIndex.find(Register);
-    if (It != RegisterToIndex.end())
+  uint8_t csvIndex(llvm::GlobalVariable *CSV) {
+    auto It = CSVToIndex.find(CSV);
+    if (It != CSVToIndex.end())
       return It->second;
 
-    auto RegistersCount = RegisterToIndex.size();
-    RegisterToIndex[Register] = RegistersCount;
-    IndexToRegister[RegistersCount] = Register;
+    auto CSVCount = CSVToIndex.size();
 
-    revng_assert(RegisterToIndex.size() == IndexToRegister.size());
-    revng_assert(RegisterToIndex.size() == 1 + RegistersCount);
+    // The index is stored in Operation::Target (a uint8_t), so a function
+    // cannot index more CSVs than that type can hold.
+    revng_assert(CSVCount <= std::numeric_limits<uint8_t>::max());
 
-    return RegistersCount;
+    CSVToIndex[CSV] = CSVCount;
+    IndexToCSV[CSVCount] = CSV;
+
+    revng_assert(CSVToIndex.size() == IndexToCSV.size());
+    revng_assert(CSVToIndex.size() == 1 + CSVCount);
+
+    return CSVCount;
   }
 
-  model::Register::Values registerByIndex(uint8_t Index) const {
-    auto It = IndexToRegister.find(Index);
-    revng_assert(It != IndexToRegister.end());
+  llvm::GlobalVariable *csvByIndex(uint8_t Index) const {
+    auto It = IndexToCSV.find(Index);
+    revng_assert(It != IndexToCSV.end());
     return It->second;
   }
 
-  uint8_t registersCount() const { return IndexToRegister.size(); }
+  uint8_t csvCount() const { return IndexToCSV.size(); }
 
-  cppcoro::generator<model::Register::Values>
-  registersInSet(const llvm::BitVector &Set) {
+  cppcoro::generator<llvm::GlobalVariable *>
+  csvsInSet(const llvm::BitVector &Set) {
     for (unsigned Index : Set.set_bits()) {
-      co_yield registerByIndex(Index);
+      co_yield csvByIndex(Index);
     }
   }
 
   std::string toString(const Operation &Operation) const {
-    auto Register = registerByIndex(Operation.Target);
+    auto *CSV = csvByIndex(Operation.Target);
     return (OperationType::getName(Operation.Type).str() + "("
-            + model::Register::getName(Register).str() + ")");
+            + CSV->getName().str() + ")");
   }
 
 public:

--- a/include/revng/RegisterUsageAnalyses/ReachingDefinitions.h
+++ b/include/revng/RegisterUsageAnalyses/ReachingDefinitions.h
@@ -73,20 +73,20 @@ private:
 public:
   ReachingDefinitions(const Function &F) {
     // Populate WriteToIndex
-    llvm::SmallVector<int> RegisterWriteIndex(F.registersCount(), 0);
+    llvm::SmallVector<int> CSVWriteIndex(F.csvCount(), 0);
     for (const Block *Block : F.nodes()) {
       for (const Operation &Operation : Block->Operations) {
         if (Operation.Type == OperationType::Write) {
-          WriteToIndex[&Operation] = RegisterWriteIndex[Operation.Target];
-          RegisterWriteIndex[Operation.Target] += 1;
+          WriteToIndex[&Operation] = CSVWriteIndex[Operation.Target];
+          CSVWriteIndex[Operation.Target] += 1;
         }
       }
     }
 
-    Default.resize(RegisterWriteIndex.size());
-    for (unsigned I = 0; I < RegisterWriteIndex.size(); ++I) {
-      Default[I].Reaching.resize(RegisterWriteIndex[I]);
-      Default[I].Read.resize(RegisterWriteIndex[I]);
+    Default.resize(CSVWriteIndex.size());
+    for (unsigned I = 0; I < CSVWriteIndex.size(); ++I) {
+      Default[I].Reaching.resize(CSVWriteIndex[I]);
+      Default[I].Read.resize(CSVWriteIndex[I]);
     }
   }
 

--- a/include/revng/Support/OpaqueRegisterUser.h
+++ b/include/revng/Support/OpaqueRegisterUser.h
@@ -66,14 +66,6 @@ public:
     return writeImpl(Builder, CSV, "write_", Writers);
   }
 
-  llvm::StoreInst *write(revng::IRBuilder &Builder,
-                         model::Register::Values Value) {
-    if (auto *CSV = M->getGlobalVariable(model::Register::getCSVName(Value)))
-      return write(Builder, CSV);
-    else
-      return nullptr;
-  }
-
   llvm::Instruction *read(revng::IRBuilder &Builder,
                           llvm::GlobalVariable *CSV) {
     auto *CSVTy = CSV->getValueType();
@@ -90,14 +82,6 @@ public:
     Created.push_back(Load);
 
     return OpaqueCall;
-  }
-
-  llvm::Instruction *read(revng::IRBuilder &Builder,
-                          model::Register::Values Value) {
-    if (auto *CSV = M->getGlobalVariable(model::Register::getCSVName(Value)))
-      return read(Builder, CSV);
-    else
-      return nullptr;
   }
 
   void purgeCreated() {

--- a/include/revng/Support/OpaqueRegisterUser.h
+++ b/include/revng/Support/OpaqueRegisterUser.h
@@ -54,12 +54,17 @@ public:
     return writeImpl(Builder, CSV, "clobber_", Clobberers);
   }
 
-  llvm::StoreInst *clobber(revng::IRBuilder &Builder,
-                           model::Register::Values Value) {
-    if (auto *CSV = M->getGlobalVariable(model::Register::getCSVName(Value)))
-      return clobber(Builder, CSV);
-    else
-      return nullptr;
+  // Clobbering a register clobbers every CSV composing it. Returns the
+  // clobbering stores, one per CSV, since a register can be composed of more
+  // than one CSV.
+  llvm::SmallVector<llvm::StoreInst *> clobber(revng::IRBuilder &Builder,
+                                               model::Register::Values Value) {
+    llvm::SmallVector<llvm::StoreInst *> Stores;
+    for (const model::Register::CSV &RegisterCSV :
+         model::Register::getCSVs(Value))
+      if (auto *CSV = M->getGlobalVariable(RegisterCSV.Name))
+        Stores.push_back(clobber(Builder, CSV));
+    return Stores;
   }
 
   llvm::StoreInst *write(revng::IRBuilder &Builder, llvm::GlobalVariable *CSV) {

--- a/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
+++ b/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
@@ -39,10 +39,10 @@ GeneratedCodeBasicInfo::GeneratedCodeBasicInfo(const model::Binary &Binary,
   using namespace model::Architecture;
   auto Architecture = Binary.Architecture();
   PC = M.getGlobalVariable(getPCCSVName(Architecture), true);
-  SP = M.getGlobalVariable(getCSVName(getStackPointer(Architecture)), true);
+  SP = M.getGlobalVariable(singleCSVName(getStackPointer(Architecture)), true);
   auto ReturnAddressRegister = getReturnAddressRegister(Architecture);
   if (ReturnAddressRegister != model::Register::Invalid)
-    RA = M.getGlobalVariable(getCSVName(ReturnAddressRegister), true);
+    RA = M.getGlobalVariable(singleCSVName(ReturnAddressRegister), true);
 
   for (model::Register::Values Register : registers(Architecture)) {
     GlobalVariable *CSV = M.getGlobalVariable(getCSVName(Register), true);

--- a/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
+++ b/lib/BasicAnalyses/GeneratedCodeBasicInfo.cpp
@@ -45,9 +45,11 @@ GeneratedCodeBasicInfo::GeneratedCodeBasicInfo(const model::Binary &Binary,
     RA = M.getGlobalVariable(singleCSVName(ReturnAddressRegister), true);
 
   for (model::Register::Values Register : registers(Architecture)) {
-    GlobalVariable *CSV = M.getGlobalVariable(getCSVName(Register), true);
-    ABIRegisters.push_back(CSV);
-    ABIRegistersSet.insert(CSV);
+    for (const model::Register::CSV &RegisterCSV : getCSVs(Register)) {
+      GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name, true);
+      ABIRegisters.push_back(CSV);
+      ABIRegistersSet.insert(CSV);
+    }
   }
 
   Type *PCType = PC->getValueType();

--- a/lib/EarlyFunctionAnalysis/AnalyzeRegisterUsage.cpp
+++ b/lib/EarlyFunctionAnalysis/AnalyzeRegisterUsage.cpp
@@ -63,14 +63,6 @@ struct FunctionToAnalyze {
   Node *SinkNode = nullptr;
 };
 
-static model::Register::Values
-getRegister(Value *Pointer, model::Architecture::Values Architecture) {
-  if (auto *CSV = dyn_cast<GlobalVariable>(Pointer)) {
-    return model::Register::fromCSVName(CSV->getName(), Architecture);
-  }
-  return model::Register::Invalid;
-}
-
 static rua::Function::Node *findUnrechableNode(rua::Function::Node *Start) {
   df_iterator_default_set<rua::Function::Node *> Visited;
   for (auto &_ : llvm::inverse_depth_first_ext(Start, Visited))
@@ -137,10 +129,17 @@ fromLLVMFunction(llvm::Function &F,
                             &Architecture,
                             StackPointer](rua::OperationType::Values Type,
                                           Value *Pointer) {
-      auto Register = getRegister(Pointer, Architecture);
-      if (Register != model::Register::Invalid and Register != StackPointer) {
-        Operations.emplace_back(Type, Function.registerIndex(Register));
-      }
+      auto *CSV = dyn_cast<GlobalVariable>(Pointer);
+      if (CSV == nullptr)
+        return;
+
+      // Only track CSVs that compose a register, excluding the stack pointer.
+      // We key the analysis on the CSV itself rather than on the register, so
+      // that each CSV composing a register is tracked independently.
+      auto Register = model::Register::fromCSVName(CSV->getName(),
+                                                   Architecture);
+      if (Register != model::Register::Invalid and Register != StackPointer)
+        Operations.emplace_back(Type, Function.csvIndex(CSV));
     };
 
     // Translate the basic block
@@ -247,16 +246,6 @@ RUAResults analyzeRegisterUsage(Function *F,
     Log << DoLog;
   }
 
-  auto GetRegisterName = model::Register::getRegisterName;
-
-  auto *M = F->getParent();
-  auto GetCSV = [&M](model::Register::Values Register) {
-    auto *Result = M->getGlobalVariable(model::Register::getCSVName(Register),
-                                        true);
-    revng_assert(Result != nullptr);
-    return Result;
-  };
-
   {
     // Run the liveness analysis
     revng_log(Log, "Running Liveness");
@@ -286,11 +275,11 @@ RUAResults analyzeRegisterUsage(Function *F,
     revng_log(Log, "Registers alive at the entry of the function:");
     rua::BlockNode *EntryNode = Function.Function.getEntryNode();
     const BitVector &EntryResult = AnalysisResult[EntryNode].OutValue;
-    for (auto Register : Function.Function.registersInSet(EntryResult)) {
-      // This register is alive at the entry of the function
+    for (auto *CSV : Function.Function.csvsInSet(EntryResult)) {
+      // This CSV is alive at the entry of the function
 
-      revng_log(Log, "  " << GetRegisterName(Register));
-      FinalResults.ArgumentsRegisters.insert(GetCSV(Register));
+      revng_log(Log, "  " << CSV->getName());
+      FinalResults.ArgumentsRegisters.insert(CSV);
     }
 
     for (const auto &[PC, CallSite] : Function.CallSites) {
@@ -303,11 +292,11 @@ RUAResults analyzeRegisterUsage(Function *F,
                   << CallSite.Callee.toString() << " at " << PC.toString()
                   << " (block " << PostNode->label() << ")");
       const BitVector &CallSiteResult = AnalysisResult.at(PostNode).InValue;
-      for (auto Register : Function.Function.registersInSet(CallSiteResult)) {
-        // This register is alive after the call site
+      for (auto *CSV : Function.Function.csvsInSet(CallSiteResult)) {
+        // This CSV is alive after the call site
 
-        revng_log(Log, "  " << GetRegisterName(Register));
-        ResultsCallSite.ReturnValuesRegisters.insert(GetCSV(Register));
+        revng_log(Log, "  " << CSV->getName());
+        ResultsCallSite.ReturnValuesRegisters.insert(CSV);
       }
     }
   }
@@ -353,12 +342,12 @@ RUAResults analyzeRegisterUsage(Function *F,
               "the function without ever being read:");
     rua::BlockNode *ExitNode = Function.ReturnNode;
     const BitVector &ExitResult = Compute(ExitNode, false);
-    for (auto Register : Function.Function.registersInSet(ExitResult)) {
-      // This register has at least one write that reaches the exit node of the
+    for (auto *CSV : Function.Function.csvsInSet(ExitResult)) {
+      // This CSV has at least one write that reaches the exit node of the
       // function without ever being read
-      revng_log(Log, "  " << GetRegisterName(Register));
+      revng_log(Log, "  " << CSV->getName());
 
-      FinalResults.ReturnValuesRegisters.insert(GetCSV(Register));
+      FinalResults.ReturnValuesRegisters.insert(CSV);
     }
 
     for (const auto &[PC, CallSite] : Function.CallSites) {
@@ -371,13 +360,13 @@ RUAResults analyzeRegisterUsage(Function *F,
 
       auto *PreNode = CallSite.Block;
       const BitVector &CallSiteResult = Compute(PreNode, true);
-      for (auto Register : Function.Function.registersInSet(CallSiteResult)) {
-        // This register has at least one write that reaches the call site
+      for (auto *CSV : Function.Function.csvsInSet(CallSiteResult)) {
+        // This CSV has at least one write that reaches the call site
         // without ever being read
 
-        revng_log(Log, "  " << GetRegisterName(Register));
+        revng_log(Log, "  " << CSV->getName());
 
-        ResultsCallSite.ArgumentsRegisters.insert(GetCSV(Register));
+        ResultsCallSite.ArgumentsRegisters.insert(CSV);
       }
     }
   }

--- a/lib/EarlyFunctionAnalysis/DetectABI.cpp
+++ b/lib/EarlyFunctionAnalysis/DetectABI.cpp
@@ -250,8 +250,6 @@ private:
   model::UpcastableType
   buildPrototypeForIndirectCall(const FunctionSummary &CallerSummary,
                                 const efa::BasicBlock &CallerBlock);
-
-  bool getRegisterState(model::Register::Values, const CSVSet &);
 };
 
 void DetectABI::computeApproximateCallGraph() {
@@ -939,17 +937,6 @@ static void combineCrossCallSites(auto &CallSite, auto &Callee) {
   for (auto *CSV : CallSite.ArgumentsRegisters) {
     Callee.ArgumentsRegisters.insert(CSV);
   }
-}
-
-bool DetectABI::getRegisterState(model::Register::Values RegisterValue,
-                                 const CSVSet &ABIRegisterMap) {
-
-  auto Name = model::Register::getCSVName(RegisterValue);
-  if (llvm::GlobalVariable *CSV = M.getGlobalVariable(Name, true)) {
-    return ABIRegisterMap.contains(CSV);
-  }
-
-  return false;
 }
 
 CSVSet DetectABI::findWrittenRegisters(llvm::Function *F) {

--- a/lib/EarlyFunctionAnalysis/DetectABI.cpp
+++ b/lib/EarlyFunctionAnalysis/DetectABI.cpp
@@ -640,8 +640,13 @@ void DetectABI::applyABIDeductions() {
     abi::Definition::RegisterSet RValues;
     model::Architecture::Values Architecture = Binary->Architecture();
     for (const auto &Register : model::Architecture::registers(Architecture)) {
-      auto Name = model::Register::getCSVName(Register);
-      if (llvm::GlobalVariable *CSV = M.getGlobalVariable(Name, true)) {
+      for (const model::Register::CSV &RegisterCSV :
+           model::Register::getCSVs(Register)) {
+        llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name, true);
+        if (CSV == nullptr)
+          continue;
+
+        // A register is an argument or a return value if any of its CSVs is.
         if (Summary.ABIResults.ArgumentsRegisters.contains(CSV))
           Arguments.emplace(Register);
 
@@ -668,8 +673,12 @@ void DetectABI::applyABIDeductions() {
     efa::CSVSet ResultingArguments;
     efa::CSVSet ResultingReturnValues;
     for (const auto &Register : model::Architecture::registers(Architecture)) {
-      auto Name = model::Register::getCSVName(Register);
-      if (llvm::GlobalVariable *CSV = M.getGlobalVariable(Name, true)) {
+      for (const model::Register::CSV &RegisterCSV :
+           model::Register::getCSVs(Register)) {
+        llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name, true);
+        if (CSV == nullptr)
+          continue;
+
         if (Arguments.contains(Register))
           ResultingArguments.insert(CSV);
         if (RValues.contains(Register))

--- a/lib/EarlyFunctionAnalysis/DetectABI.cpp
+++ b/lib/EarlyFunctionAnalysis/DetectABI.cpp
@@ -999,15 +999,22 @@ DetectABI::computePreservedRegisters(const CSVSet &ClobberedRegisters) const {
   TrackingSortedVector<model::Register::Values> Result;
   CSVSet PreservedRegisters = computePreservedCSVs(ClobberedRegisters);
 
-  auto PreservedRegistersInserter = Result.batch_insert();
+  // A register is preserved only if all the CSVs composing it are preserved,
+  // so count how many of each register's CSVs survive.
+  std::map<model::Register::Values, uint64_t> PreservedLaneCount;
   for (auto *CSV : PreservedRegisters) {
     auto RegisterID = model::Register::fromCSVName(CSV->getName(),
                                                    Binary->Architecture());
     if (RegisterID == Register::Invalid)
       continue;
 
-    PreservedRegistersInserter.insert(RegisterID);
+    PreservedLaneCount[RegisterID] += 1;
   }
+
+  auto PreservedRegistersInserter = Result.batch_insert();
+  for (auto [RegisterID, Count] : PreservedLaneCount)
+    if (Count == model::Register::getCSVs(RegisterID).size())
+      PreservedRegistersInserter.insert(RegisterID);
 
   return Result;
 }

--- a/lib/EarlyFunctionAnalysis/DetectABI.cpp
+++ b/lib/EarlyFunctionAnalysis/DetectABI.cpp
@@ -709,10 +709,25 @@ void DetectABI::applyABIDeductions() {
 }
 
 void DetectABI::recordRegisters(const efa::CSVSet &CSVs, auto Inserter) {
+  // Group the live CSVs by the register they compose and type each
+  // argument/return value by its live lanes rather than the full register
+  // width: a register live only in its low 64 bits is typed `generic64_t`
+  // even when the register itself is wider.
+  auto Architecture = Binary->Architecture();
+  std::map<model::Register::Values, uint64_t> LiveSizeByRegister;
   for (auto *CSV : CSVs) {
-    auto Reg = model::Register::fromCSVName(CSV->getName(),
-                                            Binary->Architecture());
-    Inserter.emplace(Reg).Type() = model::PrimitiveType::makeGeneric(Reg);
+    auto Portion = model::Register::registerPortionFromCSVName(CSV->getName(),
+                                                               Architecture);
+    if (Portion.Register == model::Register::Invalid)
+      continue;
+
+    uint64_t &LiveSize = LiveSizeByRegister[Portion.Register];
+    LiveSize = std::max(LiveSize, Portion.StartOffset + Portion.Size);
+  }
+
+  for (auto [RegisterID, LiveSize] : LiveSizeByRegister) {
+    auto Type = model::PrimitiveType::makeGeneric(LiveSize);
+    Inserter.emplace(RegisterID).Type() = std::move(Type);
   }
 }
 

--- a/lib/EarlyFunctionAnalysis/FunctionSummaryOracle.cpp
+++ b/lib/EarlyFunctionAnalysis/FunctionSummaryOracle.cpp
@@ -20,15 +20,13 @@ PrototypeImporter::prototype(const AttributesSet &Attributes,
     return Summary;
 
   // Drop known to be preserved registers from `Summary.ClobberedRegisters`.
-  auto TransformToCSV = std::views::transform([this](Register Register) {
-    return M.getGlobalVariable(model::Register::getCSVName(Register), true);
-  });
-  auto IgnoreNullptr = std::views::filter([](const auto *Pointer) -> bool {
-    return Pointer != nullptr;
-  });
-  for (auto *CSV : abi::FunctionType::calleeSavedRegisters(*Prototype)
-                     | TransformToCSV | IgnoreNullptr) {
-    Summary.ClobberedRegisters.erase(CSV);
+  for (Register CalleeSavedRegister :
+       abi::FunctionType::calleeSavedRegisters(*Prototype)) {
+    for (const model::Register::CSV &RegisterCSV :
+         model::Register::getCSVs(CalleeSavedRegister)) {
+      if (auto *CSV = M.getGlobalVariable(RegisterCSV.Name, true))
+        Summary.ClobberedRegisters.erase(CSV);
+    }
   }
 
   // Stop importing prototype here, if `ClobberedRegisters` is the only
@@ -50,15 +48,21 @@ PrototypeImporter::prototype(const AttributesSet &Attributes,
   auto &&[ArgumentRegisters,
           ReturnValueRegisters] = abi::FunctionType::usedRegisters(*Prototype);
   for (Register ArgumentRegister : ArgumentRegisters) {
-    auto Name = model::Register::getCSVName(ArgumentRegister);
-    if (llvm::GlobalVariable *CSV = M.getGlobalVariable(Name, true))
-      Summary.ABIResults.ArgumentsRegisters.insert(CSV);
+    for (const model::Register::CSV &RegisterCSV :
+         model::Register::getCSVs(ArgumentRegister)) {
+      if (llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name,
+                                                          true))
+        Summary.ABIResults.ArgumentsRegisters.insert(CSV);
+    }
   }
 
   for (Register ReturnValueRegister : ReturnValueRegisters) {
-    auto Name = model::Register::getCSVName(ReturnValueRegister);
-    if (llvm::GlobalVariable *CSV = M.getGlobalVariable(Name, true))
-      Summary.ABIResults.ReturnValuesRegisters.insert(CSV);
+    for (const model::Register::CSV &RegisterCSV :
+         model::Register::getCSVs(ReturnValueRegister)) {
+      if (llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name,
+                                                          true))
+        Summary.ABIResults.ReturnValuesRegisters.insert(CSV);
+    }
   }
 
   // This point is only ever reached on the "full" import (like the one

--- a/lib/EarlyFunctionAnalysis/FunctionSummaryOracle.cpp
+++ b/lib/EarlyFunctionAnalysis/FunctionSummaryOracle.cpp
@@ -47,18 +47,18 @@ PrototypeImporter::prototype(const AttributesSet &Attributes,
 
   auto &&[ArgumentRegisters,
           ReturnValueRegisters] = abi::FunctionType::usedRegisters(*Prototype);
-  for (Register ArgumentRegister : ArgumentRegisters) {
+  for (const auto &Argument : ArgumentRegisters) {
     for (const model::Register::CSV &RegisterCSV :
-         model::Register::getCSVs(ArgumentRegister)) {
+         model::Register::getCSVs(Argument.Location)) {
       if (llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name,
                                                           true))
         Summary.ABIResults.ArgumentsRegisters.insert(CSV);
     }
   }
 
-  for (Register ReturnValueRegister : ReturnValueRegisters) {
+  for (const auto &ReturnValue : ReturnValueRegisters) {
     for (const model::Register::CSV &RegisterCSV :
-         model::Register::getCSVs(ReturnValueRegister)) {
+         model::Register::getCSVs(ReturnValue.Location)) {
       if (llvm::GlobalVariable *CSV = M.getGlobalVariable(RegisterCSV.Name,
                                                           true))
         Summary.ABIResults.ReturnValuesRegisters.insert(CSV);

--- a/lib/FunctionIsolation/EnforceABI.cpp
+++ b/lib/FunctionIsolation/EnforceABI.cpp
@@ -215,8 +215,19 @@ using UsedRegisters = abi::FunctionType::UsedRegisters;
 static std::pair<Type *, SmallVector<Type *>>
 getLLVMReturnTypeAndArguments(llvm::Module *M, const UsedRegisters &Registers) {
   LLVMContext &Context = M->getContext();
-  auto ArgumentsTypes = toLLVMTypes(Context, Registers.Arguments);
-  auto ReturnTypes = toLLVMTypes(Context, Registers.ReturnValues);
+  auto IntoLLVMType = [&Context](const auto &UsedReg) -> llvm::Type * {
+    // Size the argument/return value by the model `Type` carried in the
+    // register, not by the (possibly much wider) register itself.
+    return IntegerType::getIntNTy(Context, 8 * UsedReg.Size);
+  };
+
+  SmallVector<Type *> ArgumentsTypes;
+  SmallVector<Type *> ReturnTypes;
+  std::ranges::copy(Registers.Arguments | std::views::transform(IntoLLVMType),
+                    std::back_inserter(ArgumentsTypes));
+  std::ranges::copy(Registers.ReturnValues
+                      | std::views::transform(IntoLLVMType),
+                    std::back_inserter(ReturnTypes));
 
   // Create the return type
   Type *ReturnType = Type::getVoidTy(Context);
@@ -263,8 +274,10 @@ Function *EnforceABI::recreateFunction(Function &OldFunction,
   auto *Result = changeFunctionType(OldFunction, NewReturnType, NewArguments);
   revng_assert(Result->arg_size() == Registers.Arguments.size());
 
-  for (size_t Index = 0; model::Register::Values Register : Registers.Arguments)
-    Result->getArg(Index++)->setName(model::Register::getName(Register));
+  for (size_t Index = 0; const auto &Argument : Registers.Arguments) {
+    auto Name = model::Register::getName(Argument.Location);
+    Result->getArg(Index++)->setName(Name);
+  }
 
   return Result;
 }
@@ -299,23 +312,28 @@ getCSVOrUndef(Module *M, model::Register::Values Register) {
   }
 }
 
-// Assemble the value of `Register` from the CSV(s) composing it into a single
-// integer of `8 * getSize(Register)` bits. A register backed by a single CSV
-// is just loaded; a register spanning multiple CSVs (e.g. a 512-bit vector
-// register represented as eight 64-bit CSVs) has each CSV loaded,
-// zero-extended and shifted to its position within the register, then OR-ed
-// together.
+// Assemble the low `SizeInBytes` bytes of `Register` from the CSV(s) composing
+// it into a single integer of `8 * SizeInBytes` bits. `SizeInBytes` comes from
+// the model `Type` of the register and may be smaller than the register width,
+// in which case only the CSV(s) covering that prefix are read. A register
+// backed by a single CSV that spans exactly that size is just loaded; otherwise
+// each relevant CSV is loaded, zero-extended and shifted to its position within
+// the register, then OR-ed together.
 static Value *assembleRegister(revng::IRBuilder &Builder,
                                Module *M,
-                               model::Register::Values Register) {
+                               model::Register::Values Register,
+                               uint64_t SizeInBytes) {
   auto CSVs = model::Register::getCSVs(Register);
-  if (CSVs.size() == 1)
+  if (CSVs.size() == 1 and SizeInBytes == model::Register::getSize(Register))
     return loadCSVOrUndef(Builder, M, Register);
 
-  auto *WideType = IntegerType::get(M->getContext(),
-                                    8 * model::Register::getSize(Register));
+  auto *WideType = IntegerType::get(M->getContext(), 8 * SizeInBytes);
   Value *Result = ConstantInt::get(WideType, 0);
   for (const model::Register::CSV &Lane : CSVs) {
+    // Skip the lanes that lie entirely above the model-described prefix.
+    if (Lane.StartOffset >= SizeInBytes)
+      continue;
+
     Value *LaneValue = nullptr;
     if (GlobalVariable *CSV = M->getGlobalVariable(Lane.Name, true))
       LaneValue = Builder.createLoad(CSV);
@@ -323,7 +341,7 @@ static Value *assembleRegister(revng::IRBuilder &Builder,
       LaneValue = UndefValue::get(IntegerType::get(M->getContext(),
                                                    Lane.Size * 8));
 
-    Value *Extended = Builder.CreateZExt(LaneValue, WideType);
+    Value *Extended = Builder.CreateZExtOrTrunc(LaneValue, WideType);
     if (Lane.StartOffset != 0)
       Extended = Builder.CreateShl(Extended, Lane.StartOffset * 8);
     Result = Builder.CreateOr(Result, Extended);
@@ -332,21 +350,28 @@ static Value *assembleRegister(revng::IRBuilder &Builder,
   return Result;
 }
 
-// Disassemble `WideValue` (an integer of `8 * getSize(Register)` bits) into the
-// CSV(s) composing `Register`; the inverse of `assembleRegister`. A single-CSV
-// register is stored directly; for a multi-CSV register each lane is extracted
+// Disassemble `WideValue` (an integer of `8 * SizeInBytes` bits, where
+// `SizeInBytes` is the model size of the register) into the CSV(s) composing
+// `Register`; the inverse of `assembleRegister`. Only the CSV(s) covering the
+// low `SizeInBytes` bytes are written. A single-CSV register that spans exactly
+// that size is stored directly; otherwise each relevant lane is extracted
 // (shift + truncate) and stored into its CSV.
 static void disassembleRegister(revng::IRBuilder &Builder,
                                 Module *M,
                                 model::Register::Values Register,
                                 Value *WideValue) {
+  uint64_t SizeInBytes = WideValue->getType()->getIntegerBitWidth() / 8;
   auto CSVs = model::Register::getCSVs(Register);
-  if (CSVs.size() == 1) {
+  if (CSVs.size() == 1 and SizeInBytes == model::Register::getSize(Register)) {
     Builder.CreateStore(WideValue, getCSVOrUndef(M, Register).second);
     return;
   }
 
   for (const model::Register::CSV &Lane : CSVs) {
+    // Skip the lanes that lie entirely above the model-described prefix.
+    if (Lane.StartOffset >= SizeInBytes)
+      continue;
+
     GlobalVariable *CSV = M->getGlobalVariable(Lane.Name, true);
     if (CSV == nullptr)
       continue;
@@ -354,7 +379,8 @@ static void disassembleRegister(revng::IRBuilder &Builder,
     Value *Slice = WideValue;
     if (Lane.StartOffset != 0)
       Slice = Builder.CreateLShr(Slice, Lane.StartOffset * 8);
-    Builder.CreateStore(Builder.CreateTrunc(Slice, CSV->getValueType()), CSV);
+    Builder.CreateStore(Builder.CreateZExtOrTrunc(Slice, CSV->getValueType()),
+                        CSV);
   }
 }
 
@@ -367,9 +393,9 @@ void EnforceABI::createPrologue(Function *NewFunction,
   // across lanes for registers backed by more than one CSV.
   BasicBlock &Entry = NewFunction->getEntryBlock();
   revng::IRBuilder StoreBuilder(Entry.getTerminator());
-  for (const auto &[TheArgument, Register] :
+  for (const auto &[TheArgument, Argument] :
        zip(NewFunction->args(), ArgumentRegisters))
-    disassembleRegister(StoreBuilder, &M, Register, &TheArgument);
+    disassembleRegister(StoreBuilder, &M, Argument.Location, &TheArgument);
 
   // Build the return value by assembling each return register from its CSV(s).
   if (not ReturnValueRegisters.empty()) {
@@ -377,8 +403,11 @@ void EnforceABI::createPrologue(Function *NewFunction,
       if (auto *Return = dyn_cast<ReturnInst>(BB.getTerminator())) {
         revng::IRBuilder Builder(Return);
         std::vector<Value *> ReturnValues;
-        for (model::Register::Values Register : ReturnValueRegisters)
-          ReturnValues.push_back(assembleRegister(Builder, &M, Register));
+        for (const auto &ReturnValue : ReturnValueRegisters)
+          ReturnValues.push_back(assembleRegister(Builder,
+                                                  &M,
+                                                  ReturnValue.Location,
+                                                  ReturnValue.Size));
 
         if (ReturnValues.size() == 1)
           Builder.CreateRet(ReturnValues[0]);
@@ -510,8 +539,11 @@ CallInst *EnforceABI::generateCall(revng::IRBuilder &Builder,
   //
   // Collect arguments
   //
-  for (model::Register::Values Register : Registers.Arguments)
-    Arguments.push_back(assembleRegister(Builder, &M, Register));
+  for (const auto &Argument : Registers.Arguments)
+    Arguments.push_back(assembleRegister(Builder,
+                                         &M,
+                                         Argument.Location,
+                                         Argument.Size));
 
   //
   // Produce the call
@@ -529,11 +561,11 @@ CallInst *EnforceABI::generateCall(revng::IRBuilder &Builder,
   // returns a struct, one field per register.
   bool MultipleReturnValues = Registers.ReturnValues.size() != 1;
   unsigned Index = 0;
-  for (model::Register::Values Register : Registers.ReturnValues) {
+  for (const auto &ReturnValue : Registers.ReturnValues) {
     Value *Component = MultipleReturnValues ?
                          Builder.CreateExtractValue(Result, { Index }) :
                          Result;
-    disassembleRegister(Builder, &M, Register, Component);
+    disassembleRegister(Builder, &M, ReturnValue.Location, Component);
     ++Index;
   }
 

--- a/lib/FunctionIsolation/EnforceABI.cpp
+++ b/lib/FunctionIsolation/EnforceABI.cpp
@@ -270,7 +270,7 @@ Function *EnforceABI::recreateFunction(Function &OldFunction,
 }
 
 static GlobalVariable *tryGetCSV(Module *M, model::Register::Values Register) {
-  auto Name = model::Register::getCSVName(Register);
+  auto Name = model::Register::singleCSVName(Register);
   return M->getGlobalVariable(Name, true);
 }
 
@@ -299,33 +299,86 @@ getCSVOrUndef(Module *M, model::Register::Values Register) {
   }
 }
 
+// Assemble the value of `Register` from the CSV(s) composing it into a single
+// integer of `8 * getSize(Register)` bits. A register backed by a single CSV
+// is just loaded; a register spanning multiple CSVs (e.g. a 512-bit vector
+// register represented as eight 64-bit CSVs) has each CSV loaded,
+// zero-extended and shifted to its position within the register, then OR-ed
+// together.
+static Value *assembleRegister(revng::IRBuilder &Builder,
+                               Module *M,
+                               model::Register::Values Register) {
+  auto CSVs = model::Register::getCSVs(Register);
+  if (CSVs.size() == 1)
+    return loadCSVOrUndef(Builder, M, Register);
+
+  auto *WideType = IntegerType::get(M->getContext(),
+                                    8 * model::Register::getSize(Register));
+  Value *Result = ConstantInt::get(WideType, 0);
+  for (const model::Register::CSV &Lane : CSVs) {
+    Value *LaneValue = nullptr;
+    if (GlobalVariable *CSV = M->getGlobalVariable(Lane.Name, true))
+      LaneValue = Builder.createLoad(CSV);
+    else
+      LaneValue = UndefValue::get(IntegerType::get(M->getContext(),
+                                                   Lane.Size * 8));
+
+    Value *Extended = Builder.CreateZExt(LaneValue, WideType);
+    if (Lane.StartOffset != 0)
+      Extended = Builder.CreateShl(Extended, Lane.StartOffset * 8);
+    Result = Builder.CreateOr(Result, Extended);
+  }
+
+  return Result;
+}
+
+// Disassemble `WideValue` (an integer of `8 * getSize(Register)` bits) into the
+// CSV(s) composing `Register`; the inverse of `assembleRegister`. A single-CSV
+// register is stored directly; for a multi-CSV register each lane is extracted
+// (shift + truncate) and stored into its CSV.
+static void disassembleRegister(revng::IRBuilder &Builder,
+                                Module *M,
+                                model::Register::Values Register,
+                                Value *WideValue) {
+  auto CSVs = model::Register::getCSVs(Register);
+  if (CSVs.size() == 1) {
+    Builder.CreateStore(WideValue, getCSVOrUndef(M, Register).second);
+    return;
+  }
+
+  for (const model::Register::CSV &Lane : CSVs) {
+    GlobalVariable *CSV = M->getGlobalVariable(Lane.Name, true);
+    if (CSV == nullptr)
+      continue;
+
+    Value *Slice = WideValue;
+    if (Lane.StartOffset != 0)
+      Slice = Builder.CreateLShr(Slice, Lane.StartOffset * 8);
+    Builder.CreateStore(Builder.CreateTrunc(Slice, CSV->getValueType()), CSV);
+  }
+}
+
 void EnforceABI::createPrologue(Function *NewFunction,
                                 const abi::FunctionType::UsedRegisters
                                   &UsedRegisters) {
-  SmallVector<Constant *, 8> ArgumentCSVs;
-  SmallVector<std::pair<Type *, Constant *>, 8> ReturnCSVs;
-
-  // We sort arguments by their CSV name
   auto &&[ArgumentRegisters, ReturnValueRegisters] = UsedRegisters;
-  for (model::Register::Values Register : ArgumentRegisters)
-    ArgumentCSVs.push_back(getCSVOrUndef(&M, Register).second);
-  for (model::Register::Values Register : ReturnValueRegisters)
-    ReturnCSVs.push_back(getCSVOrUndef(&M, Register));
 
-  // Store arguments to CSVs
+  // Store each argument into the CSV(s) composing its register, splitting it
+  // across lanes for registers backed by more than one CSV.
   BasicBlock &Entry = NewFunction->getEntryBlock();
   revng::IRBuilder StoreBuilder(Entry.getTerminator());
-  for (const auto &[TheArgument, CSV] : zip(NewFunction->args(), ArgumentCSVs))
-    StoreBuilder.CreateStore(&TheArgument, CSV);
+  for (const auto &[TheArgument, Register] :
+       zip(NewFunction->args(), ArgumentRegisters))
+    disassembleRegister(StoreBuilder, &M, Register, &TheArgument);
 
-  // Build the return value
-  if (ReturnCSVs.size() != 0) {
+  // Build the return value by assembling each return register from its CSV(s).
+  if (not ReturnValueRegisters.empty()) {
     for (BasicBlock &BB : *NewFunction) {
       if (auto *Return = dyn_cast<ReturnInst>(BB.getTerminator())) {
         revng::IRBuilder Builder(Return);
         std::vector<Value *> ReturnValues;
-        for (auto &&[Type, ReturnCSV] : ReturnCSVs)
-          ReturnValues.push_back(Builder.CreateLoad(Type, ReturnCSV));
+        for (model::Register::Values Register : ReturnValueRegisters)
+          ReturnValues.push_back(assembleRegister(Builder, &M, Register));
 
         if (ReturnValues.size() == 1)
           Builder.CreateRet(ReturnValues[0]);
@@ -433,7 +486,6 @@ CallInst *EnforceABI::generateCall(revng::IRBuilder &Builder,
   revng_assert(Callee.getCallee() != nullptr);
 
   llvm::SmallVector<Value *, 8> Arguments;
-  llvm::SmallVector<Constant *, 8> ReturnCSVs;
 
   auto *Prototype = getPrototype(Binary, Entry, CallSiteBlock.ID(), CallSite);
   revng_assert(Prototype != nullptr);
@@ -456,13 +508,10 @@ CallInst *EnforceABI::generateCall(revng::IRBuilder &Builder,
   }
 
   //
-  // Collect arguments and returns
+  // Collect arguments
   //
   for (model::Register::Values Register : Registers.Arguments)
-    Arguments.push_back(loadCSVOrUndef(Builder, &M, Register));
-
-  for (model::Register::Values Register : Registers.ReturnValues)
-    ReturnCSVs.push_back(getCSVOrUndef(&M, Register).second);
+    Arguments.push_back(assembleRegister(Builder, &M, Register));
 
   //
   // Produce the call
@@ -474,14 +523,18 @@ CallInst *EnforceABI::generateCall(revng::IRBuilder &Builder,
                     Binary.getTypeDefinitionReference(Prototype->key())
                       .toString());
 
-  if (ReturnCSVs.size() != 1) {
-    unsigned I = 0;
-    for (Constant *ReturnCSV : ReturnCSVs) {
-      Builder.CreateStore(Builder.CreateExtractValue(Result, { I }), ReturnCSV);
-      I++;
-    }
-  } else {
-    Builder.CreateStore(Result, ReturnCSVs[0]);
+  // Scatter the result into the CSV(s) of each return register, splitting it
+  // across lanes for registers backed by more than one CSV. With a single
+  // return register the call returns its value directly; with several it
+  // returns a struct, one field per register.
+  bool MultipleReturnValues = Registers.ReturnValues.size() != 1;
+  unsigned Index = 0;
+  for (model::Register::Values Register : Registers.ReturnValues) {
+    Value *Component = MultipleReturnValues ?
+                         Builder.CreateExtractValue(Result, { Index }) :
+                         Result;
+    disassembleRegister(Builder, &M, Register, Component);
+    ++Index;
   }
 
   return Result;

--- a/lib/FunctionIsolation/IsolateFunctions.cpp
+++ b/lib/FunctionIsolation/IsolateFunctions.cpp
@@ -716,7 +716,9 @@ public:
     // Also preserve every register CSV, later passes might want to use them
     std::set<std::string> RegisterNames;
     for (auto Register : model::Architecture::registers(Architecture))
-      RegisterNames.insert(model::Register::getCSVName(Register));
+      for (const model::Register::CSV &RegisterCSV :
+           model::Register::getCSVs(Register))
+        RegisterNames.insert(RegisterCSV.Name);
 
     auto IsRegister = [&PCH, &RegisterNames](llvm::GlobalVariable &GV) {
       return PCH->affectsPC(&GV) or RegisterNames.contains(GV.getName().str());

--- a/lib/Lift/CodeGenerator.cpp
+++ b/lib/Lift/CodeGenerator.cpp
@@ -221,8 +221,6 @@ void CodeGenerator::translate(LibTcg &LibTcg,
   //
   // Create well-known CSVs
   //
-  auto SP = model::Architecture::getStackPointer(Model->Architecture());
-  std::string SPName = model::Register::getCSVName(SP);
   GlobalVariable *SPReg = Variables.getByEnvOffset(ArchInfo.sp).first;
 
   using PCHOwner = std::unique_ptr<ProgramCounterHandler>;

--- a/lib/Lift/ExternalJumpsHandler.cpp
+++ b/lib/Lift/ExternalJumpsHandler.cpp
@@ -84,7 +84,17 @@ BasicBlock *ExternalJumpsHandler::createReturnFromExternal() {
 
       } else {
 
-        auto AsmString = getReadRegisterAssembly(Model.Architecture()).str();
+        uint64_t RegisterSize = model::Register::getSize(Register);
+        auto AsmString = getReadRegisterAssembly(Model.Architecture(),
+                                                 RegisterSize)
+                           .str();
+
+        // No assembly to emit for this register (e.g. the wide `zmm`
+        // registers, which have no `movq` form), as for the architectures
+        // handled in `createExternalJumpsHandler`.
+        if (AsmString.size() == 0)
+          continue;
+
         replace(AsmString, "REGISTER", getRegisterName(Register).str());
         std::stringstream ConstraintStringStream;
         ConstraintStringStream << "*m,~{},~{dirflag},~{fpsr},~{flags}";
@@ -149,8 +159,17 @@ BasicBlock *ExternalJumpsHandler::createSerializeAndJumpOut() {
     if (CSV == nullptr)
       continue;
 
-    std::string AsmString = getWriteRegisterAssembly(Model.Architecture())
+    uint64_t RegisterSize = model::Register::getSize(Register);
+    std::string AsmString = getWriteRegisterAssembly(Model.Architecture(),
+                                                     RegisterSize)
                               .str();
+
+    // No assembly to emit for this register (e.g. the wide `zmm` registers,
+    // which have no `movq` form), as for the architectures handled in
+    // `createExternalJumpsHandler`.
+    if (AsmString.size() == 0)
+      continue;
+
     StringRef RegisterName = getRegisterName(Register);
     replace(AsmString, "REGISTER", RegisterName);
     std::stringstream ConstraintStringStream;

--- a/lib/Lift/RootAnalyzer.cpp
+++ b/lib/Lift/RootAnalyzer.cpp
@@ -407,8 +407,19 @@ Function *RootAnalyzer::createTemporaryRoot(Function *TheFunction,
     for (const model::Segment &Segment : Model->Segments()) {
       if (Segment.contains(getBasicBlockAddress(BB))) {
         for (const auto &CanonicalValue : Segment.CanonicalRegisterValues()) {
-          auto Name = model::Register::getCSVName(CanonicalValue.Register());
-          if (auto *CSV = M->getGlobalVariable(Name)) {
+          auto CSVs = model::Register::getCSVs(CanonicalValue.Register());
+
+          // A canonical value is a single constant: ignore registers composed
+          // of more than one CSV, we cannot store one value across all of them.
+          if (CSVs.size() != 1) {
+            revng_log(Log,
+                      "Ignoring canonical value for register "
+                        << model::Register::getName(CanonicalValue.Register())
+                        << ": it is composed of " << CSVs.size() << " CSVs");
+            continue;
+          }
+
+          if (auto *CSV = M->getGlobalVariable(CSVs.front().Name)) {
             auto *Type = getCSVType(CSV);
             Builder.CreateStore(ConstantInt::get(Type, CanonicalValue.Value()),
                                 CSV);

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -580,21 +580,21 @@ std::string model::Register::getCSVName(Values V) {
   switch (V) {
   case st0_x86:
     return "_" UnknownCSVPrefix "0x2960";
-  case xmm0_x86_64:
+  case zmm0_x86_64:
     return "_" UnknownCSVPrefix "0x2b10";
-  case xmm1_x86_64:
+  case zmm1_x86_64:
     return "_" UnknownCSVPrefix "0x2b50";
-  case xmm2_x86_64:
+  case zmm2_x86_64:
     return "_" UnknownCSVPrefix "0x2b90";
-  case xmm3_x86_64:
+  case zmm3_x86_64:
     return "_" UnknownCSVPrefix "0x2bd0";
-  case xmm4_x86_64:
+  case zmm4_x86_64:
     return "_" UnknownCSVPrefix "0x2c10";
-  case xmm5_x86_64:
+  case zmm5_x86_64:
     return "_" UnknownCSVPrefix "0x2c50";
-  case xmm6_x86_64:
+  case zmm6_x86_64:
     return "_" UnknownCSVPrefix "0x2c90";
-  case xmm7_x86_64:
+  case zmm7_x86_64:
     return "_" UnknownCSVPrefix "0x2cd0";
   default:
     return "_" + model::Register::getRegisterName(V).str();
@@ -616,21 +616,21 @@ model::Register::fromCSVName(llvm::StringRef Name,
   } else if (Architecture == model::Architecture::x86_64) {
     // TODO: handle xmm0_x86
     if (Name == UnknownCSVPrefix "0x2b10") {
-      return xmm0_x86_64;
+      return zmm0_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2b50") {
-      return xmm1_x86_64;
+      return zmm1_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2b90") {
-      return xmm2_x86_64;
+      return zmm2_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2bd0") {
-      return xmm3_x86_64;
+      return zmm3_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2c10") {
-      return xmm4_x86_64;
+      return zmm4_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2c50") {
-      return xmm5_x86_64;
+      return zmm5_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2c90") {
-      return xmm6_x86_64;
+      return zmm6_x86_64;
     } else if (Name == UnknownCSVPrefix "0x2cd0") {
-      return xmm7_x86_64;
+      return zmm7_x86_64;
     }
   }
 

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -666,3 +666,23 @@ std::pair<model::Segment *, uint64_t>
 model::Binary::getSegmentFor(const MetaAddress &Address) {
   return getSegmentForImpl(*this, Address);
 }
+
+std::vector<model::Register::CSV> model::Register::getCSVs(Values V) {
+  // Every register currently maps to exactly one CSV, covering the whole
+  // register. Registers spanning multiple CSVs (e.g. a 512-bit `zmm`) will
+  // return more than one entry.
+  return { { getCSVName(V), 0, model::Register::getSize(V) } };
+}
+
+model::Register::RegisterPortion
+model::Register::registerPortionFromCSVName(llvm::StringRef Name,
+                                            model::Architecture::Values
+                                              Architecture) {
+  // Each CSV currently covers a whole register, so the portion always starts
+  // at offset 0 and spans the full register.
+  model::Register::Values Register = fromCSVName(Name, Architecture);
+  uint64_t Size = Register == model::Register::Invalid ?
+                    0 :
+                    model::Register::getSize(Register);
+  return { Register, 0, Size };
+}

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -674,6 +674,13 @@ std::vector<model::Register::CSV> model::Register::getCSVs(Values V) {
   return { { getCSVName(V), 0, model::Register::getSize(V) } };
 }
 
+std::string model::Register::singleCSVName(Values V) {
+  std::vector<CSV> CSVs = getCSVs(V);
+  revng_assert(CSVs.size() == 1,
+               "singleCSVName called on a register composed of multiple CSVs");
+  return CSVs.front().Name;
+}
+
 model::Register::RegisterPortion
 model::Register::registerPortionFromCSVName(llvm::StringRef Name,
                                             model::Architecture::Values

--- a/lib/Model/Binary.cpp
+++ b/lib/Model/Binary.cpp
@@ -2,9 +2,12 @@
 // This file is distributed under the MIT License. See LICENSE.md for details.
 //
 
+#include <array>
+#include <optional>
 #include <queue>
 #include <type_traits>
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Regex.h"
@@ -574,67 +577,136 @@ llvm::StringRef model::Architecture::getPCCSVName(Values V) {
 
 #define UnknownCSVPrefix "state_"
 
-std::string model::Register::getCSVName(Values V) {
-  // TODO: handle xmm0_x86
+namespace {
 
-  switch (V) {
-  case st0_x86:
-    return "_" UnknownCSVPrefix "0x2960";
-  case zmm0_x86_64:
-    return "_" UnknownCSVPrefix "0x2b10";
-  case zmm1_x86_64:
-    return "_" UnknownCSVPrefix "0x2b50";
-  case zmm2_x86_64:
-    return "_" UnknownCSVPrefix "0x2b90";
-  case zmm3_x86_64:
-    return "_" UnknownCSVPrefix "0x2bd0";
-  case zmm4_x86_64:
-    return "_" UnknownCSVPrefix "0x2c10";
-  case zmm5_x86_64:
-    return "_" UnknownCSVPrefix "0x2c50";
-  case zmm6_x86_64:
-    return "_" UnknownCSVPrefix "0x2c90";
-  case zmm7_x86_64:
-    return "_" UnknownCSVPrefix "0x2cd0";
-  default:
-    return "_" + model::Register::getRegisterName(V).str();
+// An x86-64 zmm register occupies a contiguous 64-byte slot in the CPU state,
+// laid out as eight 8-byte lanes. The lifter materializes one i64 CSV per lane,
+// named `_state_0x<cpu-state-offset>`. This table is the single source of truth
+// for the base CPU-state offset of each register.
+constexpr uint64_t ZMMLaneSize = 8;
+constexpr uint64_t ZMMLaneCount = 8;
+
+struct ZMMRegisterCSV {
+  model::Register::Values Register;
+  uint64_t BaseOffset;
+};
+
+constexpr std::array<ZMMRegisterCSV, 8> ZMMRegisters{ {
+  { model::Register::zmm0_x86_64, 0x2b10 },
+  { model::Register::zmm1_x86_64, 0x2b50 },
+  { model::Register::zmm2_x86_64, 0x2b90 },
+  { model::Register::zmm3_x86_64, 0x2bd0 },
+  { model::Register::zmm4_x86_64, 0x2c10 },
+  { model::Register::zmm5_x86_64, 0x2c50 },
+  { model::Register::zmm6_x86_64, 0x2c90 },
+  { model::Register::zmm7_x86_64, 0x2cd0 },
+} };
+
+std::optional<uint64_t> zmmBaseOffset(model::Register::Values V) {
+  for (const ZMMRegisterCSV &Entry : ZMMRegisters)
+    if (Entry.Register == V)
+      return Entry.BaseOffset;
+  return std::nullopt;
+}
+
+std::string stateCSVName(uint64_t Offset) {
+  return "_" UnknownCSVPrefix "0x"
+         + llvm::utohexstr(Offset, /* LowerCase */ true);
+}
+
+// If `Name` is the CSV of an x86-64 zmm lane, return the register it belongs to
+// and the byte portion of it the CSV covers.
+std::optional<model::Register::RegisterPortion>
+zmmPortionFromCSVName(llvm::StringRef Name) {
+  if (not Name.consume_front("_" UnknownCSVPrefix "0x"))
+    return std::nullopt;
+
+  uint64_t Offset = 0;
+  if (Name.getAsInteger(/* Radix */ 16, Offset))
+    return std::nullopt;
+
+  for (const ZMMRegisterCSV &Entry : ZMMRegisters) {
+    if (Entry.BaseOffset <= Offset
+        and Offset < Entry.BaseOffset + ZMMLaneCount * ZMMLaneSize) {
+      return model::Register::RegisterPortion{ Entry.Register,
+                                               Offset - Entry.BaseOffset,
+                                               ZMMLaneSize };
+    }
   }
+
+  return std::nullopt;
+}
+
+// Resolve a CSV name that does not denote an x86-64 zmm lane.
+model::Register::Values
+nonVectorRegisterFromCSVName(llvm::StringRef Name,
+                             model::Architecture::Values Architecture) {
+  if (not Name.consume_front("_"))
+    return model::Register::Invalid;
+
+  if (Architecture == model::Architecture::x86
+      and Name == UnknownCSVPrefix "0x2960")
+    return model::Register::st0_x86;
+
+  return model::Register::fromRegisterName(Name, Architecture);
+}
+
+} // namespace
+
+std::string model::Register::getCSVName(Values V) {
+  if (std::optional<uint64_t> Base = zmmBaseOffset(V))
+    return stateCSVName(*Base);
+
+  if (V == st0_x86)
+    return stateCSVName(0x2960);
+
+  return "_" + model::Register::getRegisterName(V).str();
 }
 
 model::Register::Values
 model::Register::fromCSVName(llvm::StringRef Name,
                              model::Architecture::Values Architecture) {
-  if (not Name.starts_with("_"))
-    return model::Register::Invalid;
+  return registerPortionFromCSVName(Name, Architecture).Register;
+}
 
-  Name = Name.substr(1);
-
-  if (Architecture == model::Architecture::x86) {
-    if (Name == UnknownCSVPrefix "0x2960") {
-      return st0_x86;
-    }
-  } else if (Architecture == model::Architecture::x86_64) {
-    // TODO: handle xmm0_x86
-    if (Name == UnknownCSVPrefix "0x2b10") {
-      return zmm0_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2b50") {
-      return zmm1_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2b90") {
-      return zmm2_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2bd0") {
-      return zmm3_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2c10") {
-      return zmm4_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2c50") {
-      return zmm5_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2c90") {
-      return zmm6_x86_64;
-    } else if (Name == UnknownCSVPrefix "0x2cd0") {
-      return zmm7_x86_64;
-    }
+std::vector<model::Register::CSV> model::Register::getCSVs(Values V) {
+  // A zmm register spans several CSVs, one per 8-byte lane; every other
+  // register maps to a single CSV covering the whole register.
+  if (std::optional<uint64_t> Base = zmmBaseOffset(V)) {
+    std::vector<CSV> Result;
+    Result.reserve(ZMMLaneCount);
+    for (uint64_t Lane = 0; Lane < ZMMLaneCount; ++Lane)
+      Result.push_back({ stateCSVName(*Base + Lane * ZMMLaneSize),
+                         Lane * ZMMLaneSize,
+                         ZMMLaneSize });
+    return Result;
   }
 
-  return model::Register::fromRegisterName(Name, Architecture);
+  return { { getCSVName(V), 0, model::Register::getSize(V) } };
+}
+
+std::string model::Register::singleCSVName(Values V) {
+  std::vector<CSV> CSVs = getCSVs(V);
+  revng_assert(CSVs.size() == 1,
+               "singleCSVName called on a register composed of multiple CSVs");
+  return CSVs.front().Name;
+}
+
+model::Register::RegisterPortion
+model::Register::registerPortionFromCSVName(llvm::StringRef Name,
+                                            model::Architecture::Values
+                                              Architecture) {
+  if (Architecture == model::Architecture::x86_64)
+    if (std::optional<RegisterPortion> Portion = zmmPortionFromCSVName(Name))
+      return *Portion;
+
+  // Non-zmm CSVs map to a single register covering its whole size.
+  model::Register::Values Register = nonVectorRegisterFromCSVName(Name,
+                                                                  Architecture);
+  uint64_t Size = Register == model::Register::Invalid ?
+                    0 :
+                    model::Register::getSize(Register);
+  return { Register, 0, Size };
 }
 
 #undef UnknownCSVPrefix
@@ -665,31 +737,4 @@ model::Binary::getSegmentFor(const MetaAddress &Address) const {
 std::pair<model::Segment *, uint64_t>
 model::Binary::getSegmentFor(const MetaAddress &Address) {
   return getSegmentForImpl(*this, Address);
-}
-
-std::vector<model::Register::CSV> model::Register::getCSVs(Values V) {
-  // Every register currently maps to exactly one CSV, covering the whole
-  // register. Registers spanning multiple CSVs (e.g. a 512-bit `zmm`) will
-  // return more than one entry.
-  return { { getCSVName(V), 0, model::Register::getSize(V) } };
-}
-
-std::string model::Register::singleCSVName(Values V) {
-  std::vector<CSV> CSVs = getCSVs(V);
-  revng_assert(CSVs.size() == 1,
-               "singleCSVName called on a register composed of multiple CSVs");
-  return CSVs.front().Name;
-}
-
-model::Register::RegisterPortion
-model::Register::registerPortionFromCSVName(llvm::StringRef Name,
-                                            model::Architecture::Values
-                                              Architecture) {
-  // Each CSV currently covers a whole register, so the portion always starts
-  // at offset 0 and spans the full register.
-  model::Register::Values Register = fromCSVName(Name, Architecture);
-  uint64_t Size = Register == model::Register::Invalid ?
-                    0 :
-                    model::Register::getSize(Register);
-  return { Register, 0, Size };
 }

--- a/lib/Model/Verification.cpp
+++ b/lib/Model/Verification.cpp
@@ -299,7 +299,7 @@ bool DynamicFunction::verify(VerifyHelper &VH) const {
 
 static constexpr bool isValidPrimitiveSize(PrimitiveKind::Values Kind,
                                            uint8_t Size) {
-  constexpr std::array ValidGenericPrimitives{ 1, 2, 4, 8, 16 };
+  constexpr std::array ValidGenericPrimitives{ 1, 2, 4, 8, 16, 32, 64 };
   constexpr std::array ValidFloatPrimitives{ 2, 4, 8, 10, 12, 16 };
   // NOTE: We are supporting floats that are 10 bytes long, since we found such
   //       cases in some PDB files by using VS on Windows platforms. The source

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -222,7 +222,8 @@ set(PYTHON_MODEL_MIGRATIONS_FILES
     revng/model/migrations/versions/v6.py
     revng/model/migrations/versions/v7.py
     revng/model/migrations/versions/v8.py
-    revng/model/migrations/versions/v9.py)
+    revng/model/migrations/versions/v9.py
+    revng/model/migrations/versions/v10.py)
 python_module(TARGET_NAME python-model-migrations WHEEL revng MODULE_FILES
               ${PYTHON_MODEL_MIGRATIONS_FILES})
 

--- a/python/revng/model/migrations/versions/v10.py
+++ b/python/revng/model/migrations/versions/v10.py
@@ -1,0 +1,47 @@
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+
+import re
+
+from revng.model.migrations import MigrationBase
+
+# The x86-64 vector registers are renamed `xmmN_x86_64` -> `zmmN_x86_64` to
+# reflect that the model now represents the full 512-bit register. The 32-bit
+# `xmmN_x86` registers are a distinct enum and must be left untouched.
+_X86_64_VECTOR_REGISTER = re.compile(r"^xmm([0-7])_x86_64$")
+
+
+def _rename_register(register):
+    if isinstance(register, str):
+        match = _X86_64_VECTOR_REGISTER.match(register)
+        if match is not None:
+            return f"zmm{match.group(1)}_x86_64"
+    return register
+
+
+class Migration(MigrationBase):
+    def migrate(self, binary):
+        # Register names appear in RawFunctionDefinition arguments, return
+        # values and preserved registers, and in the canonical register values
+        # of segments.
+        for type_definition in binary.get("TypeDefinitions", []):
+            if type_definition.get("Kind") != "RawFunctionDefinition":
+                continue
+
+            for register in type_definition.get("Arguments", []):
+                if "Location" in register:
+                    register["Location"] = _rename_register(register["Location"])
+
+            for register in type_definition.get("ReturnValues", []):
+                if "Location" in register:
+                    register["Location"] = _rename_register(register["Location"])
+
+            preserved = type_definition.get("PreservedRegisters", [])
+            for index, register in enumerate(preserved):
+                preserved[index] = _rename_register(register)
+
+        for segment in binary.get("Segments", []):
+            for canonical_value in segment.get("CanonicalRegisterValues", []):
+                if "Register" in canonical_value:
+                    canonical_value["Register"] = _rename_register(canonical_value["Register"])

--- a/share/doc/revng/developer-manual/qemu-helpers.md
+++ b/share/doc/revng/developer-manual/qemu-helpers.md
@@ -510,36 +510,36 @@ $ revng opt -strip-debug -S enforced.bc \
     | pretty \
     | sed -n "1p; /and i64.*u0xffff$/,/helper_divb_AL.exit:/p"
 define i64 @local_0x400000_Code_x86_64(i64 %rdi_x86_64, i64 %rsi_x86_64) {
-  %27 = and i64 %26, u0xffff
-  %28 = trunc i64 %27 to i32
-  %29 = and i64 %25, 255
-  %30 = trunc i64 %29 to i32
-  %31 = icmp eq i32 %30, 0
-  br i1 %31, label %32, label %33
+  %83 = and i64 %82, u0xffff
+  %84 = trunc i64 %83 to i32
+  %85 = and i64 %81, 255
+  %86 = trunc i64 %85 to i32
+  %87 = icmp eq i32 %86, 0
+  br i1 %87, label %88, label %89
 
-32:
+88:
   unreachable
 
-33:
-  %34 = udiv i32 %28, %30
-  %35 = icmp ugt i32 %34, 255
-  br i1 %35, label %36, label %37
+89:
+  %90 = udiv i32 %84, %86
+  %91 = icmp ugt i32 %90, 255
+  br i1 %91, label %92, label %93
 
-36:
+92:
   unreachable
 
-37:
-  %38 = and i32 %34, 255
-  %39 = urem i32 %28, %30
-  %40 = and i32 %39, 255
-  %41 = load i64, ptr %_rax, align 8
-  %42 = and i64 %41, u0xffffffffffff0000
-  %43 = shl i32 %40, 8
-  %44 = zext i32 %43 to i64
-  %45 = or i64 %42, %44
-  %46 = zext i32 %38 to i64
-  %47 = or i64 %45, %46
-  store i64 %47, ptr %_rax, align 8
+93:
+  %94 = and i32 %90, 255
+  %95 = urem i32 %84, %86
+  %96 = and i32 %95, 255
+  %97 = load i64, ptr %_rax, align 8
+  %98 = and i64 %97, u0xffffffffffff0000
+  %99 = shl i32 %96, 8
+  %100 = zext i32 %99 to i64
+  %101 = or i64 %98, %100
+  %102 = zext i32 %94 to i64
+  %103 = or i64 %101, %102
+  store i64 %103, ptr %_rax, align 8
   br label %helper_divb_AL.exit
 
 helper_divb_AL.exit:
@@ -560,22 +560,22 @@ $ revng opt -strip-debug -simplifycfg -remove-llvmassume-calls -dce -S enforced.
     | pretty \
     | sed -n "1p; /and i64.*u0xffff$/,/store i64.*%_rax/p"
 define i64 @local_0x400000_Code_x86_64(i64 %rdi_x86_64, i64 %rsi_x86_64) {
-  %27 = and i64 %26, u0xffff
-  %28 = trunc i64 %27 to i32
-  %29 = and i64 %25, 255
-  %30 = trunc i64 %29 to i32
-  %31 = udiv i32 %28, %30
-  %32 = and i32 %31, 255
-  %33 = urem i32 %28, %30
-  %34 = and i32 %33, 255
-  %35 = load i64, ptr %_rax, align 8
-  %36 = and i64 %35, u0xffffffffffff0000
-  %37 = shl i32 %34, 8
-  %38 = zext i32 %37 to i64
-  %39 = or i64 %36, %38
-  %40 = zext i32 %32 to i64
-  %41 = or i64 %39, %40
-  store i64 %41, ptr %_rax, align 8
+  %83 = and i64 %82, u0xffff
+  %84 = trunc i64 %83 to i32
+  %85 = and i64 %81, 255
+  %86 = trunc i64 %85 to i32
+  %87 = udiv i32 %84, %86
+  %88 = and i32 %87, 255
+  %89 = urem i32 %84, %86
+  %90 = and i32 %89, 255
+  %91 = load i64, ptr %_rax, align 8
+  %92 = and i64 %91, u0xffffffffffff0000
+  %93 = shl i32 %90, 8
+  %94 = zext i32 %93 to i64
+  %95 = or i64 %92, %94
+  %96 = zext i32 %88 to i64
+  %97 = or i64 %95, %96
+  store i64 %97, ptr %_rax, align 8
 ```
 
 The exceptional calls and dead code are completely gone.

--- a/share/doc/revng/user-manual/tutorial/model-from-scratch.md
+++ b/share/doc/revng/user-manual/tutorial/model-from-scratch.md
@@ -3,7 +3,7 @@ An empty model is a valid model:
 ```bash
 $ revng model opt /dev/null -verify
 ---
-Version:         9
+Version:         10
 ...
 ```
 

--- a/share/revng/abi/Microsoft_x86_64.yml
+++ b/share/revng/abi/Microsoft_x86_64.yml
@@ -32,12 +32,12 @@ GeneralPurposeArgumentRegisters:
 GeneralPurposeReturnValueRegisters:
   - rax_x86_64
 VectorArgumentRegisters:
-  - xmm0_x86_64
-  - xmm1_x86_64
-  - xmm2_x86_64
-  - xmm3_x86_64
+  - zmm0_x86_64
+  - zmm1_x86_64
+  - zmm2_x86_64
+  - zmm3_x86_64
 VectorReturnValueRegisters:
-  - xmm0_x86_64
+  - zmm0_x86_64
 CalleeSavedRegisters:
   - r12_x86_64
   - r13_x86_64
@@ -47,8 +47,8 @@ CalleeSavedRegisters:
   - rsi_x86_64
   - rbx_x86_64
   - rbp_x86_64
-  - xmm6_x86_64
-  - xmm7_x86_64
+  - zmm6_x86_64
+  - zmm7_x86_64
 
 ReturnValueLocationRegister: rcx_x86_64
 ReturnValueLocationIsReturned: true

--- a/share/revng/abi/Microsoft_x86_64_vectorcall.yml
+++ b/share/revng/abi/Microsoft_x86_64_vectorcall.yml
@@ -32,14 +32,14 @@ GeneralPurposeArgumentRegisters:
 GeneralPurposeReturnValueRegisters:
   - rax_x86_64
 VectorArgumentRegisters:
-  - xmm0_x86_64
-  - xmm1_x86_64
-  - xmm2_x86_64
-  - xmm3_x86_64
-  - xmm4_x86_64
-  - xmm5_x86_64
+  - zmm0_x86_64
+  - zmm1_x86_64
+  - zmm2_x86_64
+  - zmm3_x86_64
+  - zmm4_x86_64
+  - zmm5_x86_64
 VectorReturnValueRegisters:
-  - xmm0_x86_64
+  - zmm0_x86_64
 CalleeSavedRegisters:
   - r12_x86_64
   - r13_x86_64
@@ -49,8 +49,8 @@ CalleeSavedRegisters:
   - rsi_x86_64
   - rbx_x86_64
   - rbp_x86_64
-  - xmm6_x86_64
-  - xmm7_x86_64
+  - zmm6_x86_64
+  - zmm7_x86_64
 
 ReturnValueLocationRegister: rcx_x86_64
 ReturnValueLocationIsReturned: true

--- a/share/revng/abi/SystemV_x86_64.yml
+++ b/share/revng/abi/SystemV_x86_64.yml
@@ -35,17 +35,17 @@ GeneralPurposeReturnValueRegisters:
   - rax_x86_64
   - rdx_x86_64
 VectorArgumentRegisters:
-  - xmm0_x86_64
-  - xmm1_x86_64
-  - xmm2_x86_64
-  - xmm3_x86_64
-  - xmm4_x86_64
-  - xmm5_x86_64
-  - xmm6_x86_64
-  - xmm7_x86_64
+  - zmm0_x86_64
+  - zmm1_x86_64
+  - zmm2_x86_64
+  - zmm3_x86_64
+  - zmm4_x86_64
+  - zmm5_x86_64
+  - zmm6_x86_64
+  - zmm7_x86_64
 VectorReturnValueRegisters:
-  - xmm0_x86_64
-  - xmm1_x86_64
+  - zmm0_x86_64
+  - zmm1_x86_64
 CalleeSavedRegisters:
   - rbx_x86_64
   - rbp_x86_64

--- a/share/revng/include/primitive-types.h
+++ b/share/revng/include/primitive-types.h
@@ -144,6 +144,38 @@ static_assert(sizeof(uint128_t) == 16, "");
 #endif
 
 //
+// Wide integer types (256- and 512-bit)
+//
+// C has no native integer type wider than 128 bits (__int128). These wide
+// integer types are therefore defined using C23's _BitInt, mirroring the way
+// the wide float types below fall back to a native type when one is available.
+// They back the decompilation of values held in wide vector registers (an
+// x86-64 zmm modelled as a full register is a 512-bit integer), where
+// extracting or assembling its lanes requires wide-integer shifts. A toolchain
+// without _BitInt cannot express such operations, so these types are only
+// defined when it provides one.
+//
+#if defined(__BITINT_MAXWIDTH__) && __BITINT_MAXWIDTH__ >= 512
+typedef unsigned _BitInt(256) pointer_or_number256_t;
+typedef unsigned _BitInt(512) pointer_or_number512_t;
+typedef unsigned _BitInt(256) number256_t;
+typedef unsigned _BitInt(512) number512_t;
+typedef _BitInt(256) int256_t;
+typedef _BitInt(512) int512_t;
+typedef unsigned _BitInt(256) uint256_t;
+typedef unsigned _BitInt(512) uint512_t;
+
+static_assert(sizeof(pointer_or_number256_t) == 32, "");
+static_assert(sizeof(pointer_or_number512_t) == 64, "");
+static_assert(sizeof(number256_t) == 32, "");
+static_assert(sizeof(number512_t) == 64, "");
+static_assert(sizeof(int256_t) == 32, "");
+static_assert(sizeof(int512_t) == 64, "");
+static_assert(sizeof(uint256_t) == 32, "");
+static_assert(sizeof(uint512_t) == 64, "");
+#endif
+
+//
 // Float
 //
 

--- a/share/revng/include/primitive-types.h
+++ b/share/revng/include/primitive-types.h
@@ -57,6 +57,16 @@ typedef struct {
 typedef unsigned __int128 generic128_t;
 #endif
 
+// `generic256_t`/`generic512_t` back values held in wide vector registers (an
+// x86-64 `zmm` modelled as a full register is 512 bits). Assembling a register
+// from its lanes, or extracting one, requires wide-integer shifts, so — like
+// the `uint256_t`/`uint512_t` wide integers below, and consistently with
+// `generic128_t` (`unsigned __int128`) — these are arithmetic `_BitInt`s when
+// the toolchain provides one, falling back to a byte struct otherwise.
+#if defined(__BITINT_MAXWIDTH__) && __BITINT_MAXWIDTH__ >= 512
+typedef unsigned _BitInt(256) generic256_t;
+typedef unsigned _BitInt(512) generic512_t;
+#else
 typedef struct {
   char data[32];
 } generic256_t;
@@ -64,6 +74,7 @@ typedef struct {
 typedef struct {
   char data[64];
 } generic512_t;
+#endif
 
 static_assert(sizeof(generic8_t) == 1, "");
 static_assert(sizeof(generic16_t) == 2, "");

--- a/share/revng/include/primitive-types.h
+++ b/share/revng/include/primitive-types.h
@@ -57,6 +57,14 @@ typedef struct {
 typedef unsigned __int128 generic128_t;
 #endif
 
+typedef struct {
+  char data[32];
+} generic256_t;
+
+typedef struct {
+  char data[64];
+} generic512_t;
+
 static_assert(sizeof(generic8_t) == 1, "");
 static_assert(sizeof(generic16_t) == 2, "");
 static_assert(sizeof(generic32_t) == 4, "");
@@ -66,6 +74,8 @@ static_assert(sizeof(generic96_t) == 12, "");
 #ifdef __SIZEOF_INT128__
 static_assert(sizeof(generic128_t) == 16, "");
 #endif
+static_assert(sizeof(generic256_t) == 32, "");
+static_assert(sizeof(generic512_t) == 64, "");
 
 //
 // PointerOrNumber

--- a/share/revng/test/configuration/revng/model-migration.yml
+++ b/share/revng/test/configuration/revng/model-migration.yml
@@ -21,6 +21,7 @@ sources:
       - v5/
       - v6/
       - v9/
+      - v10/
 
 commands:
   - type: revng.model-migration

--- a/share/revng/test/tests/model-migration/v10/checks.csv
+++ b/share/revng/test/tests/model-migration/v10/checks.csv
@@ -1,0 +1,10 @@
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+
+.TypeDefinitions[0].Kind,"RawFunctionDefinition"
+.TypeDefinitions[0].Arguments[0].Location,"zmm0_x86_64"
+.TypeDefinitions[0].ReturnValues[0].Location,"zmm1_x86_64"
+.TypeDefinitions[0].PreservedRegisters[0],"zmm2_x86_64"
+.TypeDefinitions[0].PreservedRegisters[1],"zmm7_x86_64"
+.Segments[0].CanonicalRegisterValues[0].Register,"zmm3_x86_64"

--- a/share/revng/test/tests/model-migration/v10/model.yml
+++ b/share/revng/test/tests/model-migration/v10/model.yml
@@ -1,0 +1,31 @@
+#
+# This file is distributed under the MIT License. See LICENSE.md for details.
+#
+
+Version: 9
+
+TypeDefinitions:
+  - ID: 0
+    Kind: RawFunctionDefinition
+    Architecture: x86_64
+    Arguments:
+      - Location: xmm0_x86_64
+    ReturnValues:
+      - Location: xmm1_x86_64
+    PreservedRegisters:
+      - xmm2_x86_64
+      - xmm7_x86_64
+
+Segments:
+  - StartAddress: "0x1000:Generic64"
+    VirtualSize: 4096
+    StartOffset: 0
+    FileSize: 4096
+    IsReadable: true
+    IsWriteable: false
+    IsExecutable: true
+    CanonicalRegisterValues:
+      - Register: xmm3_x86_64
+        Value: 0
+
+Architecture: x86_64

--- a/tests/unit/RegisterUsageAnalyses.cpp
+++ b/tests/unit/RegisterUsageAnalyses.cpp
@@ -6,11 +6,40 @@
 bool init_unit_test();
 #include "boost/test/unit_test.hpp"
 
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+
 #include "revng/RegisterUsageAnalyses/Liveness.h"
 #include "revng/RegisterUsageAnalyses/ReachingDefinitions.h"
 
 using namespace rua;
 using namespace llvm;
+
+// Two distinct dummy CSVs, used purely as opaque tokens to populate the rua
+// index space (indices 0 and 1); the tests below address them by raw index.
+// They are owned by the static module and never dereferenced by the analyses.
+static llvm::GlobalVariable *testCSV(unsigned Index) {
+  static llvm::LLVMContext Context;
+  static llvm::Module Module("rua-unit-test", Context);
+  static llvm::GlobalVariable *CSVs[2] = {
+    new llvm::GlobalVariable(Module,
+                             llvm::Type::getInt64Ty(Context),
+                             false,
+                             llvm::GlobalValue::ExternalLinkage,
+                             nullptr,
+                             "csv0"),
+    new llvm::GlobalVariable(Module,
+                             llvm::Type::getInt64Ty(Context),
+                             false,
+                             llvm::GlobalValue::ExternalLinkage,
+                             nullptr,
+                             "csv1"),
+  };
+  revng_assert(Index < 2);
+  return CSVs[Index];
+}
 
 struct TestAnalysisResult {
   TestAnalysisResult() = delete;
@@ -28,8 +57,8 @@ struct TestAnalysisResult {
 static TestAnalysisResult
 createSingleNode(rua::Block::OperationsVector &&Operations) {
   rua::Function F;
-  F.registerIndex(model::Register::rax_x86_64);
-  F.registerIndex(model::Register::rdi_x86_64);
+  F.csvIndex(testCSV(0));
+  F.csvIndex(testCSV(1));
   auto *Entry = F.addNode();
   F.setEntryNode(Entry);
   Entry->Operations = Operations;
@@ -41,8 +70,8 @@ static TestAnalysisResult createDiamond(rua::Block::OperationsVector &&Header,
                                         rua::Block::OperationsVector &&Right,
                                         rua::Block::OperationsVector &&Footer) {
   rua::Function F;
-  F.registerIndex(model::Register::rax_x86_64);
-  F.registerIndex(model::Register::rdi_x86_64);
+  F.csvIndex(testCSV(0));
+  F.csvIndex(testCSV(1));
 
   auto *HeaderBlock = F.addNode();
   F.setEntryNode(HeaderBlock);
@@ -70,8 +99,8 @@ static TestAnalysisResult createLoop(rua::Block::OperationsVector &&Header,
                                      rua::Block::OperationsVector &&LoopBody,
                                      rua::Block::OperationsVector &&Footer) {
   rua::Function F;
-  F.registerIndex(model::Register::rax_x86_64);
-  F.registerIndex(model::Register::rdi_x86_64);
+  F.csvIndex(testCSV(0));
+  F.csvIndex(testCSV(1));
 
   auto *HeaderBlock = F.addNode();
   F.setEntryNode(HeaderBlock);
@@ -102,8 +131,8 @@ createNoReturn(rua::Block::OperationsVector &&Header,
                rua::Block::OperationsVector &&NoReturn,
                rua::Block::OperationsVector &&Exit) {
   rua::Function F;
-  F.registerIndex(model::Register::rax_x86_64);
-  F.registerIndex(model::Register::rdi_x86_64);
+  F.csvIndex(testCSV(0));
+  F.csvIndex(testCSV(1));
 
   auto *HeaderBlock = F.addNode();
   F.setEntryNode(HeaderBlock);


### PR DESCRIPTION
This PR introduces the required changes for the REP69 `Extend registers represented in the model` task.