### PR TITLE
Fix `bash ignore=` in `test_docs`

### DIFF
--- a/python/revng/internal/cli/_commands/test_docs/__init__.py
+++ b/python/revng/internal/cli/_commands/test_docs/__init__.py
@@ -175,14 +175,27 @@ class BashDoctest(Doctest):
                 if heredoc_terminator is None:
                     next_line_is_command = line.endswith("\\")
             else:
-                if not ignore_regexp or not re.match(".*(" + ignore_regexp + ").*", line):
+                if not ignore_regexp:
                     self.expected_output += line + "\n"
+                else:
+                    self.expected_output += re.sub(ignore_regexp, "IGNORED", line) + "\n"
 
         if silent:
             self.script += " ) >& /dev/null\n"
 
         if ignore_regexp:
-            self.script += f" ) |& grep -vE '{ignore_regexp}'\n"
+            # TODO: in the future we could replace only certain parts of the regexp using named
+            #       groups: `struct_(?P<ignore>[0-9]+)` would turn `a struct_1234 b` into
+            #       `a struct_IGNORED b` instead of `a IGNORED b`, as this does.
+            filter_script = """
+import re
+import sys
+pattern = re.compile(sys.argv[1])
+sys.stdout.writelines(pattern.sub("IGNORED", line) for line in sys.stdin)
+"""
+            self.script += (
+                f" ) |& python3 -c {shlex.quote(filter_script)} {shlex.quote(ignore_regexp)}\n"
+            )
 
 
 class TypeScriptDoctest(Doctest):

--- a/share/doc/revng/developer-manual/qemu-helpers.md
+++ b/share/doc/revng/developer-manual/qemu-helpers.md
@@ -366,7 +366,7 @@ This metadata records which CSVs a helper reads and which it writes, *even when 
 
 For instance, in the *declarations-only* module, `helper_write_eflags` has no body, yet its declaration carries the metadata:
 
-```bash
+```bash ignore="![0-9]+"
 $ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep "^declare.*@helper_write_eflags"
 declare !revng.csua !299 !revng.csvaccess.offsets.load !303 !revng.csvaccess.offsets.store !305 !revng.tags !13 void @helper_write_eflags(ptr noundef, i64 noundef, i32 noundef) #0
@@ -375,7 +375,7 @@ declare !revng.csua !299 !revng.csvaccess.offsets.load !303 !revng.csvaccess.off
 The `!303` and `!305` are references to metadata nodes defined at the end of the module.
 Resolving them reveals the actual CSV lists:
 
-```bash
+```{bash notest}
 $ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep -E "^!(303|304|305|306) ="
 !303 = !{i32 0, !304}

--- a/share/doc/revng/developer-manual/qemu-helpers.md
+++ b/share/doc/revng/developer-manual/qemu-helpers.md
@@ -135,8 +135,8 @@ $ ROOT="$(dirname "$(dirname "$(which revng)")")"
 $ pretty() { sed "s/ #[0-9]*//; s/ ![^ ]*//g; s/;.*//"; }
 $ revng opt -strip-debug -sroa -instcombine -dce -S \
     "$ROOT/share/libtcg/libtcg-helpers-x86_64.bc" \
-    -o libtcg-helpers-x86_64-optimized.S
-$ cat libtcg-helpers-x86_64-optimized.S \
+    -o libtcg-helpers-x86_64-optimized.ll
+$ cat libtcg-helpers-x86_64-optimized.ll \
     | sed -n "/^define void @helper_clts/,/^}/p" \
     | pretty
 define void @helper_clts(ptr noundef %0) section "revng_inline" {
@@ -160,7 +160,7 @@ The function takes a `%struct.CPUArchState` pointer `%0` (the `env` argument) an
 Now let's look at `helper_divb_AL`:
 
 ```bash
-$ cat libtcg-helpers-x86_64-optimized.S \
+$ cat libtcg-helpers-x86_64-optimized.ll \
     | sed -n "/^define void @helper_divb_AL/,/^}/p" \
     | pretty \
     | head -16
@@ -218,8 +218,8 @@ Let's look at `helper_clts` after the `fix-helpers` transformation:
 ```bash
 $ revng opt -strip-debug -instcombine -dce -S \
     "$ROOT/share/revng/libtcg-helpers-full-x86_64.bc" \
-    -o libtcg-helpers-full-x86_64-optimized.S
-$ cat libtcg-helpers-full-x86_64-optimized.S \
+    -o libtcg-helpers-full-x86_64-optimized.ll
+$ cat libtcg-helpers-full-x86_64-optimized.ll \
     | sed -n "/^define void @helper_clts/,/^}/p" \
     | pretty
 define void @helper_clts(ptr noundef %0) section "revng_inline" {
@@ -241,7 +241,7 @@ Well-known registers get human-readable names instead.
 For instance, `helper_divb_AL` after annotation:
 
 ```bash
-$ cat libtcg-helpers-full-x86_64-optimized.S \
+$ cat libtcg-helpers-full-x86_64-optimized.ll \
     | sed -n "/^define void @helper_divb_AL/,/^}/p" \
     | pretty \
     | head -10
@@ -281,7 +281,7 @@ But in the full module, `fix-helpers` cannot replace them with a single CSV — 
 Instead, it emits a `switch` on the pointer value (which is the byte offset of the register within `CPUState`) to dispatch to the correct CSV:
 
 ```bash
-$ cat libtcg-helpers-full-x86_64-optimized.S \
+$ cat libtcg-helpers-full-x86_64-optimized.ll \
     | sed -n "/^define void @helper_addsd/,/^}/p" \
     | pretty \
     | sed -n '1,12p'
@@ -312,8 +312,8 @@ For example, `helper_clts` (which is `REVNG_INLINE`) still has its full definiti
 ```bash
 $ revng opt -strip-debug -S \
     "$ROOT/share/revng/libtcg-helpers-to-inline-x86_64.bc" \
-    -o libtcg-helpers-to-inline-x86_64-optimized.S
-$ cat libtcg-helpers-to-inline-x86_64-optimized.S \
+    -o libtcg-helpers-to-inline-x86_64-optimized.ll
+$ cat libtcg-helpers-to-inline-x86_64-optimized.ll \
     | grep "^define.*@helper_clts" \
     | pretty
 define void @helper_clts(ptr noundef %0) section "revng_inline" {
@@ -323,7 +323,7 @@ We can see the counts: the *to-inline* module has a small number of definitions 
 
 ```bash
 $ echo "Definitions:"
-$ cat libtcg-helpers-to-inline-x86_64-optimized.S \
+$ cat libtcg-helpers-to-inline-x86_64-optimized.ll \
     | grep -c "^define"
 Definitions:
 363
@@ -337,8 +337,8 @@ Every function, including `REVNG_INLINE` ones, is a bare declaration.
 ```bash
 $ revng opt -strip-debug -S \
     "$ROOT/share/revng/libtcg-helpers-declarations-only-x86_64.bc" \
-    -o libtcg-helpers-declarations-only-x86_64-optimized.S
-$ cat libtcg-helpers-declarations-only-x86_64-optimized.S \
+    -o libtcg-helpers-declarations-only-x86_64-optimized.ll
+$ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep "^declare.*@helper_clts" \
     | pretty
 declare void @helper_clts(ptr noundef) section "revng_inline"
@@ -348,12 +348,12 @@ The module has 0 definitions and 1089 declarations:
 
 ```bash
 $ echo "Definitions:"
-$ cat libtcg-helpers-declarations-only-x86_64-optimized.S \
+$ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | { grep -c "^define" || true; }
 Definitions:
 0
 $ echo "Declarations:"
-$ cat libtcg-helpers-declarations-only-x86_64-optimized.S \
+$ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep "^declare" | grep -c "helper_"
 Declarations:
 1089
@@ -367,7 +367,7 @@ This metadata records which CSVs a helper reads and which it writes, *even when 
 For instance, in the *declarations-only* module, `helper_write_eflags` has no body, yet its declaration carries the metadata:
 
 ```bash
-$ cat libtcg-helpers-declarations-only-x86_64-optimized.S \
+$ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep "^declare.*@helper_write_eflags"
 declare !revng.csua !299 !revng.csvaccess.offsets.load !303 !revng.csvaccess.offsets.store !305 !revng.tags !13 void @helper_write_eflags(ptr noundef, i64 noundef, i32 noundef) #0
 ```
@@ -376,7 +376,7 @@ The `!303` and `!305` are references to metadata nodes defined at the end of the
 Resolving them reveals the actual CSV lists:
 
 ```bash
-$ cat libtcg-helpers-declarations-only-x86_64-optimized.S \
+$ cat libtcg-helpers-declarations-only-x86_64-optimized.ll \
     | grep -E "^!(303|304|305|306) ="
 !303 = !{i32 0, !304}
 !304 = !{!"_state_0x2848"}

--- a/share/doc/revng/developer-manual/qemu-helpers.md
+++ b/share/doc/revng/developer-manual/qemu-helpers.md
@@ -511,7 +511,7 @@ $ revng2 project artifact enforce-abi -o enforced.bc
 
 Let's look at the isolated function.
 
-```bash ignore="%[0-9]|[0-9]:"
+```bash ignore="%[0-9]+|[0-9]+:"
 $ revng opt -strip-debug -S enforced.bc \
     | sed -n "/^define.*@local_0x400000_Code_x86_64/,/^}/p" \
     | pretty \
@@ -561,7 +561,7 @@ Running `-simplifycfg` eliminates the `unreachable` blocks, turning the error co
 These `llvm.assume` calls are later removed by the `remove-llvmassume-calls` pass (which runs as part of the `segregate-stack-accesses` step).
 Adding `-dce` cleans up the remaining dead instructions:
 
-```bash ignore="%[0-9]|[0-9]:"
+```bash ignore="%[0-9]+|[0-9]+:"
 $ revng opt -strip-debug -simplifycfg -remove-llvmassume-calls -dce -S enforced.bc \
     | sed -n "/^define.*@local_0x400000_Code_x86_64/,/^}/p" \
     | pretty \

--- a/share/doc/revng/user-manual/tutorial/comments-and-local-variables.md
+++ b/share/doc/revng/user-manual/tutorial/comments-and-local-variables.md
@@ -91,7 +91,7 @@ We hand this back to `edit-c-body`, together with the address of `resolve`, whic
 The configuration is a small YAML file with the function address and the edited C, which we assemble (indenting the code two spaces under the `CCode:` block) and pass to `-c`.
 We copy the model aside first, so a `diff` afterwards shows exactly what the analysis wrote:
 
-```{bash ignore="^(---|\+\+\+|@@)|TypeDefinitions/[0-9]|Code_x86_64"}
+```{bash ignore=".*(---|\+\+\+|@@).*|.*TypeDefinitions/[0-9]+.*|0x[0-9a-f]+:Code_x86_64"}
 $ RESOLVE=$(yq -r '.Functions[] | select(.Name == "resolve") | .Entry' revng.yml)
 $ cat > edit.yml << EOF
 Function: $RESOLVE

--- a/share/doc/revng/user-manual/tutorial/editing-types-in-c.md
+++ b/share/doc/revng/user-manual/tutorial/editing-types-in-c.md
@@ -40,7 +40,7 @@ $ revng2 project init account
 
 Here is the decompiled `summary`:
 
-```{bash ignore="struct_[0-9]"}
+```{bash ignore="struct_[0-9]+"}
 $ revng2 project artifact emit-c summary | revng ptml
 _ABI(SystemV_x86_64)
 generic64_t summary(struct_58 *argument_0) {
@@ -60,7 +60,7 @@ $ TYPE_ID=$(revng2 project artifact emit-c summary | revng ptml | grep -oE 'stru
 
 The [`emit-single-type-definition`](../../references/artifacts.md#emit-single-type-definition-artifact) artifact prints a single type as a C header:
 
-```{bash ignore="struct_[0-9]"}
+```{bash ignore="struct_[0-9]+"}
 $ revng2 project artifact emit-single-type-definition /type-definition/${TYPE_ID}-StructDefinition
 struct _PACKED _SIZE(40) struct_58 {
   generic32_t offset_0 _STARTS_AT(0);
@@ -72,7 +72,7 @@ struct _PACKED _SIZE(40) struct_58 {
 This is deliberately *not* the same C you get from the regular decompiled header, the [`emit-type-and-global-header` artifact](../../references/artifacts.md#emit-type-and-global-header-artifact).
 That one is meant to be recompilable by an ordinary C compiler, so it spells the padding out as explicit fields:
 
-```{bash ignore="struct_[0-9]"}
+```{bash ignore="struct_[0-9]+"}
 $ revng2 project artifact emit-type-and-global-header | revng ptml | grep -A6 "struct_${TYPE_ID} {"
 struct _PACKED _SIZE(40) struct_58 {
   generic32_t offset_0;

--- a/share/doc/revng/user-manual/tutorial/running-initial-auto-analysis.md
+++ b/share/doc/revng/user-manual/tutorial/running-initial-auto-analysis.md
@@ -19,7 +19,7 @@ $ gcc example.c -o example -O2
 
 We run the [`parse-binary` analysis](../../references/analyses.md#parse-binary-analysis) using [`revng2 project analyze`](../../references/cli/revng2-project-analyze.md) to automatically collect all the loading information available in the ELF headers:
 
-```{bash ignore="VirtualSize|FileSize"}
+```{bash ignore="^.*(VirtualSize|FileSize):.*[0-9]+$"}
 $ mkdir project-dir
 $ revng2 -C project-dir project init example --no-initial-auto-analysis
 $ revng2 -C project-dir project analyze parse-binary -o /dev/null


### PR DESCRIPTION
I used `~` as `sed` command delimiter for regexp replacement, because with the `§` symbol you originally suggested `sed` complains for it not being single-character. 